### PR TITLE
Update kafka_snap.py to support installing a specific snap channel

### DIFF
--- a/lib/charms/kafka/v0/kafka_snap.py
+++ b/lib/charms/kafka/v0/kafka_snap.py
@@ -60,7 +60,7 @@ class KafkaSnap:
         self.snap_config_path = SNAP_CONFIG_PATH
         self.kafka = snap.SnapCache()["kafka"]
 
-    def install(self) -> bool:
+    def install(self, channel="rock/edge") -> bool:
         """Loads the Kafka snap from LP, returning a StatusBase for the Charm to set.
 
         Returns:
@@ -73,7 +73,7 @@ class KafkaSnap:
             kafka = cache["kafka"]
 
             if not kafka.present:
-                kafka.ensure(snap.SnapState.Latest, channel="rock/edge")
+                kafka.ensure(snap.SnapState.Latest, channel=channel)
 
             self.kafka = kafka
             return True


### PR DESCRIPTION
Update kafka_snap.py to support installing a specific snap channel.

Defaults to rock/edge. This will allow for releasing charms with specific snap channels.