### PR TITLE
Add password rotation action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+.vscode

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,3 +1,5 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
 # In Juju 3 this will be easier to copy
 get-server-properties:
   description: |
@@ -6,3 +8,15 @@ get-snap-apps:
   description: |
     Action to retrieve the available commands within the kafka snap
 
+set-password:
+  description: Change the system user's password, which is used by the charm.
+    It is for internal charm users and SHOULD NOT be used by applications.
+    This action must be called on the leader unit.
+  params:
+    username:
+      type: string
+      description: The username, the default value 'operator'.
+        Possible values - operator
+    password:
+      type: string
+      description: The password will be auto-generated if this option is not specified.

--- a/src/literals.py
+++ b/src/literals.py
@@ -8,3 +8,4 @@ CHARM_KEY = "kafka"
 PEER = "cluster"
 ZK = "zookeeper"
 REL_NAME = "kafka-client"
+CHARM_USERS = ["sync"]

--- a/src/utils.py
+++ b/src/utils.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 @retry(
     # retry to give ZK time to update its broker zNodes before failing
-    wait=wait_fixed(5),
-    stop=stop_after_attempt(6),
+    wait=wait_fixed(6),
+    stop=stop_after_attempt(10),
     retry_error_callback=(lambda state: state.outcome.result()),
     retry=retry_if_not_result(lambda result: True if result else False),
 )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -54,7 +54,7 @@ def check_user(model_full_name: str, username: str, zookeeper_uri: str) -> None:
     assert "SCRAM-SHA-512" in result
 
 
-def get_user(model_full_name: str, username: str, zookeeper_uri: str) -> None:
+def get_user(model_full_name: str, username: str, zookeeper_uri: str) -> str:
     result = check_output(
         f"JUJU_MODEL={model_full_name} juju ssh kafka/0 'kafka.configs --zookeeper {zookeeper_uri} --describe --entity-type users --entity-name {username}'",
         stderr=PIPE,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,7 +16,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     kafka_charm = await ops_test.build_charm(".")
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=1
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=3
         ),
         ops_test.model.deploy(kafka_charm, application_name="kafka", num_units=1),
     )

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from helpers import APP_NAME, ZK_NAME, get_user, get_zookeeper_connection, set_password
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest):
+    kafka_charm = await ops_test.build_charm(".")
+    await asyncio.gather(
+        ops_test.model.deploy(ZK_NAME, channel="edge", application_name=ZK_NAME, num_units=3),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1),
+    )
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME])
+    assert ops_test.model.applications[APP_NAME].status == "waiting"
+    assert ops_test.model.applications[ZK_NAME].status == "active"
+
+    await ops_test.model.add_relation(APP_NAME, ZK_NAME)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME])
+
+    assert ops_test.model.applications[APP_NAME].status == "active"
+    assert ops_test.model.applications[ZK_NAME].status == "active"
+
+
+async def test_password_rotation(ops_test: OpsTest):
+    """Check that password stored on ZK has changed after a password rotation."""
+    _, zookeeper_uri = get_zookeeper_connection(
+        unit_name=f"{APP_NAME}/0", model_full_name=ops_test.model_full_name
+    )
+
+    initial_sync_user = get_user(
+        username="sync",
+        zookeeper_uri=zookeeper_uri,
+        model_full_name=ops_test.model_full_name,
+    )
+
+    result = await set_password(ops_test, username="sync", num_unit=0)
+    assert "sync-password" in result.keys()
+
+    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME])
+
+    new_sync_user = get_user(
+        username="sync",
+        zookeeper_uri=zookeeper_uri,
+        model_full_name=ops_test.model_full_name,
+    )
+
+    assert initial_sync_user != new_sync_user

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -6,7 +6,13 @@ import asyncio
 import logging
 
 import pytest
-from helpers import APP_NAME, ZK_NAME, get_user, get_kafka_zk_relation_data, set_password
+from helpers import (
+    APP_NAME,
+    ZK_NAME,
+    get_kafka_zk_relation_data,
+    get_user,
+    set_password,
+)
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -39,7 +45,7 @@ async def test_password_rotation(ops_test: OpsTest):
     relation_data = get_kafka_zk_relation_data(
         unit_name=f"{APP_NAME}/0", model_full_name=ops_test.model_full_name
     )
-    uri = relation_data["uris"].split(',')[-1]
+    uri = relation_data["uris"].split(",")[-1]
 
     initial_sync_user = get_user(
         username="sync",

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -30,14 +30,14 @@ def usernames():
 
 @pytest.mark.abort_on_fail
 async def test_deploy_charms_relate_active(ops_test: OpsTest, usernames):
-    zk_charm = await ops_test.build_charm(".")
+    charm = await ops_test.build_charm(".")
     app_charm = await ops_test.build_charm("tests/integration/app-charm")
 
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=1
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=3
         ),
-        ops_test.model.deploy(zk_charm, application_name=APP_NAME, num_units=1),
+        ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1),
         ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_1, num_units=1),
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_NAME_1, ZK])

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -28,7 +28,7 @@ async def test_kafka_simple_scale_up(ops_test: OpsTest):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=1
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=3
         ),
         ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1),
     )


### PR DESCRIPTION
# Issue

This PR adds an action to change the password of an operator related user.

## Solution

The charm sends the user change to zookeeper and then stores the new password on the application databag.

## Release Notes

- Added actions to set passwords.
- `charm.py`:
   - Added password rotation action handler
- Added some extra helpers for integration tests.

## Testing

Added an integration test for password rotation.