### PR TITLE
chore: switch to tls flag over ssl

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -234,11 +234,11 @@ class KafkaCharm(CharmBase):
         Returns:
             True if ZK is related and `sync` user has been added. False otherwise.
         """
-        # SSL must be enabled for Kafka and ZK or disabled for both
+        # TLS must be enabled for Kafka and ZK or disabled for both
         if self.tls.enabled ^ (
-            self.kafka_config.zookeeper_config.get("ssl", "disabled") == "enabled"
+            self.kafka_config.zookeeper_config.get("tls", "disabled") == "enabled"
         ):
-            logger.error("SSL must be enabled for Zookeeper and Kafka, or disabled for both")
+            logger.error("TLS must be enabled for Zookeeper and Kafka, or disabled for both")
             self.unit.status = BlockedStatus("TLS needs to be active for Zookeeper and Kafka")
             return False
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -238,8 +238,9 @@ class KafkaCharm(CharmBase):
         if self.tls.enabled ^ (
             self.kafka_config.zookeeper_config.get("tls", "disabled") == "enabled"
         ):
-            logger.error("TLS must be enabled for Zookeeper and Kafka, or disabled for both")
-            self.unit.status = BlockedStatus("TLS needs to be active for Zookeeper and Kafka")
+            msg = "TLS must be enabled for Zookeeper and Kafka"
+            logger.error(msg)
+            self.unit.status = BlockedStatus(msg)
             return False
 
         if not self.kafka_config.zookeeper_connected or not self.peer_relation.data[self.app].get(

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,6 @@ import logging
 from typing import Dict, List, Optional
 
 from charms.kafka.v0.kafka_snap import SNAP_CONFIG_PATH
-from ops.charm import CharmBase
 from ops.model import Unit
 
 from literals import PEER, REL_NAME, ZK
@@ -28,7 +27,7 @@ allow.everyone.if.no.acl.found=false
 class KafkaConfig:
     """Manager for handling Kafka configuration."""
 
-    def __init__(self, charm: CharmBase):
+    def __init__(self, charm):
         self.charm = charm
         self.default_config_path = SNAP_CONFIG_PATH
         self.properties_filepath = f"{self.default_config_path}/server.properties"
@@ -47,12 +46,12 @@ class KafkaConfig:
 
         Returns:
             Dict of ZooKeeeper:
-            `username`, `password`, `endpoints`, `chroot`, `connect`, `uris` and `ssl`
+            `username`, `password`, `endpoints`, `chroot`, `connect`, `uris` and `tls`
         """
         zookeeper_config = {}
         # loop through all relations to ZK, attempt to find all needed config
         for relation in self.charm.model.relations[ZK]:
-            zk_keys = ["username", "password", "endpoints", "chroot", "uris", "ssl"]
+            zk_keys = ["username", "password", "endpoints", "chroot", "uris", "tls"]
             missing_config = any(
                 relation.data[relation.app].get(key, None) is None for key in zk_keys
             )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -50,6 +50,7 @@ def test_zookeeper_config_succeeds_fails_config(zk_relation_id, harness):
             "username": "moria",
             "endpoints": "1.1.1.1,2.2.2.2",
             "uris": "1.1.1.1:2181,2.2.2.2:2181/kafka",
+            "tls": "disabled",
         },
     )
     assert harness.charm.kafka_config.zookeeper_config == {}
@@ -66,6 +67,7 @@ def test_zookeeper_config_succeeds_valid_config(zk_relation_id, harness):
             "password": "mellon",
             "endpoints": "1.1.1.1,2.2.2.2",
             "uris": "1.1.1.1:2181/kafka,2.2.2.2:2181/kafka",
+            "tls": "disabled",
         },
     )
     assert "connect" in harness.charm.kafka_config.zookeeper_config
@@ -128,16 +130,13 @@ def test_auth_properties(zk_relation_id, harness):
             "password": "mellon",
             "endpoints": "1.1.1.1,2.2.2.2",
             "uris": "1.1.1.1:2181/kafka,2.2.2.2:2181/kafka",
+            "tls": "disabled",
         },
     )
 
     assert "broker.id=0" in harness.charm.kafka_config.auth_properties
     assert (
         f"zookeeper.connect={harness.charm.kafka_config.zookeeper_config['connect']}"
-        in harness.charm.kafka_config.auth_properties
-    )
-    assert (
-        'listener.name.sasl_plaintext.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="sync" password="mellon";'
         in harness.charm.kafka_config.auth_properties
     )
 


### PR DESCRIPTION
## Changes Made
#### `chore: switch to using tls flag instead of ssl`
- Update to align with other database charm relation interfaces, after ZooKeeper change