### PR TITLE
fix: Update relation endpoints

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,7 @@ from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus
 
 from auth import KafkaAuth
 from config import KafkaConfig
-from literals import CHARM_KEY, CHARM_USERS, PEER, ZK
+from literals import CHARM_KEY, CHARM_USERS, PEER, REL_NAME, ZK
 from provider import KafkaProvider
 from tls import KafkaTLS
 from utils import broker_active, generate_password, safe_get_file
@@ -176,6 +176,9 @@ class KafkaCharm(CharmBase):
             self.kafka_config.set_server_properties()
 
             self.on[self.restart.name].acquire_lock.emit()
+
+        if self.model.get_relation(REL_NAME):
+            self.provider.update_connection_info()
 
     def _restart(self, event: EventBase) -> None:
         """Handler for `rolling_ops` restart events."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -177,6 +177,7 @@ class KafkaCharm(CharmBase):
 
             self.on[self.restart.name].acquire_lock.emit()
 
+        # If Kafka is related to client charms, update their information.
         if self.model.relations.get(REL_NAME, None) and self.unit.is_leader():
             self.provider.update_connection_info()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -177,7 +177,7 @@ class KafkaCharm(CharmBase):
 
             self.on[self.restart.name].acquire_lock.emit()
 
-        if self.model.get_relation(REL_NAME):
+        if self.model.relations.get(REL_NAME, None):
             self.provider.update_connection_info()
 
     def _restart(self, event: EventBase) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -177,7 +177,7 @@ class KafkaCharm(CharmBase):
 
             self.on[self.restart.name].acquire_lock.emit()
 
-        if self.model.relations.get(REL_NAME, None):
+        if self.model.relations.get(REL_NAME, None) and self.unit.is_leader():
             self.provider.update_connection_info()
 
     def _restart(self, event: EventBase) -> None:

--- a/src/config.py
+++ b/src/config.py
@@ -109,7 +109,8 @@ class KafkaConfig:
         hosts = [
             self.charm.model.get_relation(PEER).data[unit].get("private-address") for unit in units
         ]
-        return [f"{host}:9092" for host in hosts]
+        port = 9093 if self.charm.tls.enabled else 9092
+        return [f"{host}:{port}" for host in hosts]
 
     @property
     def default_replication_properties(self) -> List[str]:

--- a/src/provider.py
+++ b/src/provider.py
@@ -76,7 +76,7 @@ class KafkaProvider(Object):
         bootstrap_server = self.charm.kafka_config.bootstrap_server
         endpoints = [server.split(":")[0] for server in bootstrap_server]
         zookeeper_uris = self.charm.kafka_config.zookeeper_config.get("connect", "")
-        tls = str(self.charm.tls.enabled)
+        tls = "enabled" if self.charm.tls.enabled else "disabled"
 
         relation_config = {
             "username": username,

--- a/src/provider.py
+++ b/src/provider.py
@@ -195,7 +195,7 @@ class KafkaProvider(Object):
         bootstrap_server = self.charm.kafka_config.bootstrap_server
         endpoints = [server.split(":")[0] for server in bootstrap_server]
         zookeeper_uris = self.charm.kafka_config.zookeeper_config.get("connect", "")
-        tls = str(self.charm.tls.enabled)
+        tls = "enabled" if self.charm.tls.enabled else "disabled"
 
         relation_config = {
             "endpoints": ",".join(endpoints),

--- a/src/provider.py
+++ b/src/provider.py
@@ -76,6 +76,7 @@ class KafkaProvider(Object):
         bootstrap_server = self.charm.kafka_config.bootstrap_server
         endpoints = [server.split(":")[0] for server in bootstrap_server]
         zookeeper_uris = self.charm.kafka_config.zookeeper_config.get("connect", "")
+        tls = str(self.charm.tls.enabled)
 
         relation_config = {
             "username": username,
@@ -84,6 +85,7 @@ class KafkaProvider(Object):
             "uris": ",".join(bootstrap_server),
             "zookeeper-uris": zookeeper_uris,
             "consumer-group-prefix": "",
+            "tls": tls,
         }
 
         # only set this if `consumer` is set to avoid missing information
@@ -184,3 +186,24 @@ class KafkaProvider(Object):
             self.charm.model.get_relation(PEER).data[self.charm.app].update(
                 {provider_relation_config["username"]: ""}
             )
+
+    def update_connection_info(self):
+        """Updates all relations with current uri, endpoints and tls data.
+
+        If information didn't change, no events will trigger.
+        """
+        bootstrap_server = self.charm.kafka_config.bootstrap_server
+        endpoints = [server.split(":")[0] for server in bootstrap_server]
+        zookeeper_uris = self.charm.kafka_config.zookeeper_config.get("connect", "")
+        tls = str(self.charm.tls.enabled)
+
+        relation_config = {
+            "endpoints": ",".join(endpoints),
+            "uris": ",".join(bootstrap_server),
+            "zookeeper-uris": zookeeper_uris,
+            "tls": tls,
+        }
+
+        for relation in self.charm.model.relations[REL_NAME]:
+            if self.charm.app_peer_data.get(f"relation-{relation.id}", None):
+                relation.data[self.charm.app].update(relation_config)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -113,6 +113,22 @@ def get_kafka_zk_relation_data(unit_name: str, model_full_name: str) -> Dict[str
     return zk_relation_data
 
 
+def get_provider_data(unit_name: str, model_full_name: str) -> Dict[str, str]:
+    result = show_unit(unit_name=unit_name, model_full_name=model_full_name)
+    relations_info = result[unit_name]["relation-info"]
+
+    provider_relation_data = {}
+    for info in relations_info:
+        if info["endpoint"] == "kafka-client":
+            provider_relation_data["username"] = info["application-data"]["username"]
+            provider_relation_data["password"] = info["application-data"]["password"]
+            provider_relation_data["endpoints"] = info["application-data"]["endpoints"]
+            provider_relation_data["uris"] = info["application-data"]["uris"]
+            provider_relation_data["zookeeper-uris"] = info["application-data"]["zookeeper-uris"]
+            provider_relation_data["tls"] = info["application-data"]["tls"]
+    return provider_relation_data
+
+
 async def get_address(ops_test: OpsTest, app_name=APP_NAME, unit_num=0) -> str:
     """Get the address for a unit."""
     status = await ops_test.model.get_status()  # noqa: F821

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,6 +4,7 @@
 
 import pytest
 from ops.charm import CharmBase
+from ops.framework import Object
 from ops.testing import Harness
 
 from config import KafkaConfig
@@ -22,10 +23,21 @@ METADATA = """
 """
 
 
+class KafkaTLS(Object):
+    def __init__(self, charm):
+        super().__init__(charm, "tls")
+        self.charm = charm
+
+    @property
+    def enabled(self) -> bool:
+        return False
+
+
 class DummyKafkaCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self.kafka_config = KafkaConfig(self)
+        self.tls = KafkaTLS(self)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
# Issue

This PR addresses Jira ticket [DPE-661](https://warthogs.atlassian.net/browse/DPE-661).
Updates relation info on peer-related events.

## Solution

Adds a call on `config_changed` event that updates related application info, if they exist.

## Release Notes

- `src/charm.py`: _on_config_changed_ now updates provider info.
- `src/config.py`: _bootstrap_server_ will change the port depending on TLS status.
- `src/provider.py`: added a method to update information on related applications.

## Testing

Added a test on the provider-suite to check connection information.