### PR TITLE
test: add/update unit-tests to use pytest throughout

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -9,7 +9,7 @@ import re
 from dataclasses import asdict, dataclass
 from typing import List, Optional, Set
 
-from charms.kafka.v0.kafka_snap import SNAP_CONFIG_PATH, KafkaSnap
+from snap import KafkaSnap
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +40,6 @@ class KafkaAuth:
             f"--authorizer-properties zookeeper.connect={self.zookeeper}",
             "--list",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={SNAP_CONFIG_PATH}server.properties"]
         acls = KafkaSnap.run_bin_command(bin_keyword="acls", bin_args=command, opts=self.opts)
 
         return acls
@@ -155,8 +153,6 @@ class KafkaAuth:
             f"--entity-name={username}",
             f"--add-config=SCRAM-SHA-512=[password={password}]",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={SNAP_CONFIG_PATH}server.properties"]
         KafkaSnap.run_bin_command(bin_keyword="configs", bin_args=command, opts=self.opts)
 
     def delete_user(self, username: str) -> None:
@@ -175,8 +171,6 @@ class KafkaAuth:
             f"--entity-name={username}",
             "--delete-config=SCRAM-SHA-512",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={SNAP_CONFIG_PATH}server.properties"]
         KafkaSnap.run_bin_command(bin_keyword="configs", bin_args=command, opts=self.opts)
 
     def add_acl(
@@ -204,8 +198,6 @@ class KafkaAuth:
             f"--allow-principal=User:{username}",
             f"--operation={operation}",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={SNAP_CONFIG_PATH}server.properties"]
 
         if resource_type == "TOPIC":
             command += [f"--topic={resource_name}"]
@@ -239,8 +231,6 @@ class KafkaAuth:
             f"--operation={operation}",
             "--force",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={SNAP_CONFIG_PATH}server.properties"]
 
         if resource_type == "TOPIC":
             command += [f"--topic={resource_name}"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -93,14 +93,9 @@ class KafkaCharm(CharmBase):
             event.defer()
             return
 
-        current_sync_password = self.get_secret(scope="app", key="sync_password")
+        current_sync_password = self.get_secret(scope="app", key="sync-password")
         self.set_secret(
-            scope="app", key="sync_password", value=(current_sync_password or generate_password())
-        )
-
-        current_sync_password = self.peer_relation.data[self.app].get("sync_password", None)
-        self.peer_relation.data[self.app].update(
-            {"sync_password": current_sync_password or generate_password()}
+            scope="app", key="sync-password", value=(current_sync_password or generate_password())
         )
 
     def _on_zookeeper_joined(self, event: RelationJoinedEvent) -> None:
@@ -292,9 +287,6 @@ class KafkaCharm(CharmBase):
             String of key value.
             None if non-existent key
         """
-        if not self.app_peer_data or not self.unit_peer_data:
-            return None
-
         if scope == "unit":
             return self.unit_peer_data.get(key, None)
         elif scope == "app":

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,6 @@ import subprocess
 from collections.abc import MutableMapping
 from typing import Optional
 
-from charms.kafka.v0.kafka_snap import KafkaSnap
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from ops.charm import (
     ActionEvent,
@@ -27,6 +26,7 @@ from auth import KafkaAuth
 from config import KafkaConfig
 from literals import CHARM_KEY, CHARM_USERS, PEER, REL_NAME, ZK
 from provider import KafkaProvider
+from snap import KafkaSnap
 from tls import KafkaTLS
 from utils import broker_active, generate_password, safe_get_file
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,8 +6,7 @@
 
 import logging
 import subprocess
-from collections.abc import MutableMapping
-from typing import Optional
+from typing import MutableMapping, Optional
 
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from ops.charm import (

--- a/src/charm.py
+++ b/src/charm.py
@@ -291,7 +291,7 @@ class KafkaCharm(CharmBase):
 
         Returns:
             String of key value.
-            None if non-existant key
+            None if non-existent key
         """
         if not self.app_peer_data or not self.unit_peer_data:
             return None

--- a/src/config.py
+++ b/src/config.py
@@ -38,7 +38,7 @@ class KafkaConfig:
     @property
     def sync_password(self) -> Optional[str]:
         """Returns charm-set sync_password for server-server auth between brokers."""
-        return self.charm.get_secret(scope="app", key="sync_password")
+        return self.charm.get_secret(scope="app", key="sync-password")
 
     @property
     def zookeeper_config(self) -> Dict[str, str]:

--- a/src/config.py
+++ b/src/config.py
@@ -7,10 +7,10 @@
 import logging
 from typing import Dict, List, Optional
 
-from charms.kafka.v0.kafka_snap import SNAP_CONFIG_PATH
 from ops.model import Unit
 
 from literals import PEER, REL_NAME, ZK
+from snap import SNAP_CONFIG_PATH
 from utils import safe_write_to_file
 
 logger = logging.getLogger(__name__)

--- a/src/provider.py
+++ b/src/provider.py
@@ -55,9 +55,12 @@ class KafkaProvider(Object):
         Returns:
             Dict with keys `topic` and `extra_user_roles`
         """
+        if not event.app:
+            return {}
+
         return {
             "extra_user_roles": event.relation.data[event.app].get("extra-user-roles", ""),
-            "topic": event.relation.data[event.app].get("topic"),
+            "topic": event.relation.data[event.app].get("topic", ""),
         }
 
     def provider_relation_config(self, event: RelationEvent) -> Dict[str, str]:
@@ -69,6 +72,9 @@ class KafkaProvider(Object):
         Returns:
             Dict of `username`, `password` and `endpoints` data for the related app
         """
+        if not event.app:
+            return {}
+
         relation = event.relation
 
         username = f"relation-{relation.id}"

--- a/src/snap.py
+++ b/src/snap.py
@@ -2,34 +2,8 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""KafkaSnap class and methods
+"""KafkaSnap class and methods."""
 
-`KafkaSnap` provides a collection of common functions for managing the Kafka Snap and
-running bin commands common to both the Kafka and ZooKeeper charms.
-
-The [Kafka Snap](https://snapcraft.io/kafka) tracks the upstream binaries released by
-The Apache Software Foundation that comes with [Apache Kafka](https://github.com/apache/kafka).
-Currently the snap channel is hard-coded to `rock/edge`.
-
-Exposed methods includes snap installation, starting/restarting the snap service, and running
-bin commands exposed in the snap services
-
-Example usage for `KafkaSnap`:
-
-```python
-
-class KafkaCharm(CharmBase):
-    def __init__(self, *args):
-        super().__init__(*args)
-        self.snap =  KafkaSnap()
-
-        self.framework.observe(getattr(self.on, "start"), self._on_start)
-
-    def _on_start(self, event):
-        self.snap.install()
-        self.snap.start_snap_service(snap_service="kafka")
-```
-"""
 import logging
 import subprocess
 from typing import List
@@ -38,16 +12,6 @@ from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import snap
 
 logger = logging.getLogger(__name__)
-
-# The unique Charmhub library identifier, never change it
-LIBID = "db3c8438a0fc435895a2f6a1cccf03a2"
-
-# Increment this major API version when introducing breaking changes
-LIBAPI = 0
-
-# Increment this PATCH version before using `charmcraft publish-lib` or reset
-# to 0 if you are raising the major API version
-LIBPATCH = 5
 
 
 SNAP_CONFIG_PATH = "/var/snap/kafka/common/"
@@ -149,8 +113,11 @@ class KafkaSnap:
             `subprocess.CalledProcessError`: if the error returned a non-zero exit code
         """
         args_string = " ".join(bin_args)
+        args_string_appended = (
+            f"{args_string} --zk-tls-config-file={SNAP_CONFIG_PATH}server.properties"
+        )
         opts_string = " ".join(opts)
-        command = f"KAFKA_OPTS={opts_string} kafka.{bin_keyword} {args_string}"
+        command = f"KAFKA_OPTS={opts_string} kafka.{bin_keyword} {args_string_appended}"
 
         try:
             output = subprocess.check_output(

--- a/src/tls.py
+++ b/src/tls.py
@@ -10,7 +10,6 @@ import socket
 import subprocess
 from typing import List, Optional
 
-from charms.kafka.v0.kafka_snap import SNAP_CONFIG_PATH
 from charms.tls_certificates_interface.v1.tls_certificates import (
     TLSCertificatesRequiresV1,
     generate_csr,
@@ -21,6 +20,7 @@ from ops.framework import Object
 from ops.model import Relation
 
 from literals import TLS_RELATION
+from snap import SNAP_CONFIG_PATH
 from utils import generate_password, parse_tls_file, safe_write_to_file
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -45,6 +45,7 @@ def test_acl():
 
 
 def test_parse_acls():
+    """Checks that returned ACL message is parsed correctly into Acl object."""
     acls = """
     Current ACLs for resource `ResourcePattern(resourceType=GROUP, name=relation-81-*, patternType=LITERAL)`:
         (principal=User:relation-81, host=*, operation=READ, permissionType=ALLOW)
@@ -63,6 +64,7 @@ def test_parse_acls():
 
 
 def test_generate_producer_acls():
+    """Checks correct resourceType for producer ACLs."""
     generated_acls = KafkaAuth._generate_producer_acls(topic="theonering", username="frodo")
     assert len(generated_acls) == 3
 
@@ -77,6 +79,7 @@ def test_generate_producer_acls():
 
 
 def test_generate_consumer_acls():
+    """Checks correct resourceType for consumer ACLs."""
     generated_acls = KafkaAuth._generate_consumer_acls(topic="theonering", username="frodo")
     assert len(generated_acls) == 3
 
@@ -94,6 +97,7 @@ def test_generate_consumer_acls():
 
 
 def test_get_acls_tls_adds_zk_tls_flag(harness):
+    """Checks zk-tls-config-file flag is called for acls bin command."""
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     zk_rel_id = harness.add_relation(ZK, ZK)
     harness.add_relation_unit(zk_rel_id, "zookeeper/0")
@@ -124,6 +128,7 @@ def test_get_acls_tls_adds_zk_tls_flag(harness):
 
 
 def test_add_user_adds_zk_tls_flag(harness):
+    """Checks zk-tls-config-file flag is called for configs bin command."""
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     zk_rel_id = harness.add_relation(ZK, ZK)
     harness.add_relation_unit(zk_rel_id, "zookeeper/0")
@@ -154,6 +159,7 @@ def test_add_user_adds_zk_tls_flag(harness):
 
 
 def test_delete_user_adds_zk_tls_flag(harness):
+    """Checks zk-tls-config-file flag is called for configs bin command."""
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     zk_rel_id = harness.add_relation(ZK, ZK)
     harness.add_relation_unit(zk_rel_id, "zookeeper/0")

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -5,12 +5,13 @@
 import logging
 from pathlib import Path
 from unittest.mock import patch
-import pytest
-from ops.testing import Harness
-import yaml
-from charm import KafkaCharm
-from auth import Acl, KafkaAuth
 
+import pytest
+import yaml
+from ops.testing import Harness
+
+from auth import Acl, KafkaAuth
+from charm import KafkaCharm
 from literals import CHARM_KEY, PEER
 
 logger = logging.getLogger(__name__)
@@ -19,15 +20,23 @@ CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
 METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
+
 @pytest.fixture
 def harness():
     harness = Harness(KafkaCharm, meta=METADATA)
     harness.add_relation("restart", CHARM_KEY)
     harness.add_relation(PEER, CHARM_KEY)
-    harness._update_config({"offsets-retention-minutes": 10080, "log-retention-hours": 168, "auto-create-topics": False})
+    harness._update_config(
+        {
+            "offsets-retention-minutes": 10080,
+            "log-retention-hours": 168,
+            "auto-create-topics": False,
+        }
+    )
 
     harness.begin()
     return harness
+
 
 def test_acl():
     assert sorted(list(Acl.__annotations__.keys())) == sorted(
@@ -67,6 +76,7 @@ def test_generate_producer_acls():
     assert sorted(operations) == sorted(set(["CREATE", "WRITE", "DESCRIBE"]))
     assert resource_types == {"TOPIC"}
 
+
 def test_generate_consumer_acls():
     generated_acls = KafkaAuth._generate_consumer_acls(topic="theonering", username="frodo")
     assert len(generated_acls) == 3
@@ -83,8 +93,9 @@ def test_generate_consumer_acls():
     assert sorted(operations) == sorted(set(["READ", "DESCRIBE"]))
     assert sorted(resource_types) == sorted(set(["TOPIC", "GROUP"]))
 
+
 def test_tls_adds_zk_tls_flag(harness):
     with patch("charms.kafka.v0.kafka_snap.KafkaSnap.run_bin_command") as patched_bin:
         auth = KafkaAuth(harness, opts=["mordor"], zookeeper="server.1:gandalf.the.grey")
-        
+
         print()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -142,11 +142,11 @@ def test_add_user_adds_zk_tls_flag(harness):
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
     auth = KafkaAuth(harness.charm, opts=["mordor"], zookeeper="server.1:gandalf.the.grey")
 
-    with patch("subprocess.check_output") as patched:
+    with patch("subprocess.check_output") as patched_check_output:
         auth.add_user("samwise", "gamgee")
 
         found = False
-        for arg in patched.call_args.args:
+        for arg in patched_check_output.call_args.args:
             if "--zk-tls-config-file" in arg:
                 found = True
 
@@ -172,11 +172,11 @@ def test_delete_user_adds_zk_tls_flag(harness):
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
     auth = KafkaAuth(harness.charm, opts=["mordor"], zookeeper="server.1:gandalf.the.grey")
 
-    with patch("subprocess.check_output") as patched:
+    with patch("subprocess.check_output") as patched_check_output:
         auth.delete_user("samwise")
 
         found = False
-        for arg in patched.call_args.args:
+        for arg in patched_check_output.call_args.args:
             if "--zk-tls-config-file" in arg:
                 found = True
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -69,7 +69,7 @@ def test_leader_elected_sets_passwords(harness):
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
     harness.set_leader(True)
 
-    assert harness.charm.app_peer_data.get("sync_password", None)
+    assert harness.charm.app_peer_data.get("sync-password", None)
 
 
 def test_zookeeper_joined_sets_chroot(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,14 +2,20 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 from pathlib import Path
+from unittest.mock import PropertyMock, patch
 
 import pytest
 import yaml
+from ops.model import BlockedStatus, WaitingStatus
 from ops.testing import Harness
+from tenacity.wait import wait_none
 
 from charm import KafkaCharm
-from literals import CHARM_KEY
+from literals import CHARM_KEY, PEER, ZK
+
+logger = logging.getLogger(__name__)
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
@@ -29,3 +35,256 @@ def harness():
     )
     harness.begin()
     return harness
+
+
+def test_install_sets_opts(harness):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.install"), patch(
+        "config.KafkaConfig.set_kafka_opts"
+    ) as patched_opts:
+        harness.charm.on.install.emit()
+
+        patched_opts.assert_called_once()
+
+
+def test_install_waits_until_zookeeper_relation(harness):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.install"), patch(
+        "config.KafkaConfig.set_kafka_opts"
+    ):
+        harness.charm.on.install.emit()
+        assert isinstance(harness.charm.unit.status, WaitingStatus)
+
+
+def test_install_blocks_snap_install_failure(harness):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.install", return_value=False), patch(
+        "config.KafkaConfig.set_kafka_opts"
+    ):
+        harness.charm.on.install.emit()
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+
+
+def test_leader_elected_sets_passwords(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.set_leader(True)
+
+    assert harness.charm.app_peer_data.get("sync_password", None)
+
+
+def test_zookeeper_joined_sets_chroot(harness):
+    harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+    zk_rel_id = harness.add_relation(ZK, ZK)
+    harness.add_relation_unit(zk_rel_id, f"zookeeper/0")
+
+    assert CHARM_KEY in harness.charm.model.relations[ZK][0].data[harness.charm.app].get(
+        "chroot", ""
+    )
+
+
+def test_zookeeper_broken_stops_service(harness):
+    harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZK, ZK)
+
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.stop_snap_service") as patched:
+        harness.remove_relation(zk_rel_id)
+
+        patched.assert_called_once()
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+
+
+def test_start_defers_without_zookeeper(harness):
+    with patch("ops.framework.EventBase.defer") as patched:
+        harness.charm.on.start.emit()
+
+        patched.assert_called_once()
+
+
+def test_start_sets_necessary_config(harness):
+    harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZK, ZK)
+    harness.add_relation_unit(zk_rel_id, f"zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZK,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "disabled",
+        },
+    )
+
+    with patch("config.KafkaConfig.set_jaas_config") as patched_jaas, patch(
+        "config.KafkaConfig.set_server_properties"
+    ) as patched_properties:
+        harness.charm.on.start.emit()
+        patched_jaas.assert_called_once()
+        patched_properties.assert_called_once()
+
+
+def test_start_sets_auth_and_broker_creds_on_leader(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZK, ZK)
+    harness.add_relation_unit(zk_rel_id, f"zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZK,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "disabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
+
+    with patch("auth.KafkaAuth.add_user") as patched, patch(
+        "config.KafkaConfig.set_jaas_config"
+    ), patch("config.KafkaConfig.set_server_properties"), patch(
+        "charm.broker_active"
+    ) as patched_active:
+        patched_active.retry.wait = wait_none
+        harness.charm.on.start.emit()
+        patched.assert_not_called()
+
+        harness.set_leader(True)
+        harness.charm.on.start.emit()
+        patched.assert_called_once()
+
+
+def test_start_does_not_start_if_not_ready(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZK, ZK)
+    harness.add_relation_unit(zk_rel_id, f"zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZK,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "disabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
+
+    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
+        "config.KafkaConfig.set_server_properties"
+    ), patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock) as patched_start, patch(
+        "charms.kafka.v0.kafka_snap.KafkaSnap.start_snap_service"
+    ) as patched_service:
+        patched_start.return_value = False
+        harness.charm.on.start.emit()
+
+        patched_service.assert_not_called()
+
+
+def test_start_does_not_start_if_not_same_tls_as_zk(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZK, ZK)
+    harness.add_relation_unit(zk_rel_id, f"zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZK,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "enabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
+
+    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
+        "config.KafkaConfig.set_server_properties"
+    ), patch("charms.kafka.v0.kafka_snap.KafkaSnap.start_snap_service") as patched_service:
+        harness.charm.on.start.emit()
+
+        patched_service.assert_not_called()
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+
+
+def test_start_does_not_start_if_leader_has_not_set_creds(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZK, ZK)
+    harness.add_relation_unit(zk_rel_id, f"zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZK,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "enabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
+
+    with patch("config.KafkaConfig.set_jaas_config"), patch(
+        "config.KafkaConfig.set_server_properties"
+    ), patch("charms.kafka.v0.kafka_snap.KafkaSnap.start_snap_service") as patched_service:
+        harness.charm.on.start.emit()
+
+        patched_service.assert_not_called()
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+
+
+def test_start_blocks_if_service_failed_silently(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZK, ZK)
+    harness.add_relation_unit(zk_rel_id, f"zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZK,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "disabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
+    harness.set_leader(True)
+
+    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
+        "config.KafkaConfig.set_server_properties"
+    ), patch("charms.kafka.v0.kafka_snap.KafkaSnap.start_snap_service") as patched_service, patch(
+        "charm.broker_active", return_value=False
+    ) as patched_active:
+        patched_active.retry.wait = wait_none
+        harness.charm.on.start.emit()
+
+        patched_service.assert_called_once()
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+
+
+def test_config_changed_updates_properties(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with patch(
+        "config.KafkaConfig.server_properties", new_callable=PropertyMock
+    ) as patched_properties, patch(
+        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock
+    ) as patched_ready, patch(
+        "charm.safe_get_file", return_value=["gandalf=grey"]
+    ), patch(
+        "config.KafkaConfig.set_server_properties"
+    ) as set_props:
+        patched_properties.return_value = ["gandalf=white"]
+        patched_ready.return_value = True
+
+        harness.charm.on.config_changed.emit()
+        set_props.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+import pytest
+from ops.testing import Harness
+import yaml
+from charm import KafkaCharm
+
+from literals import CHARM_KEY
+
+
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
+
+@pytest.fixture
+def harness():
+    harness = Harness(KafkaCharm, meta=METADATA)
+    harness.add_relation("restart", CHARM_KEY)
+    harness._update_config({"offsets-retention-minutes": 10080, "log-retention-hours": 168, "auto-create-topics": False})
+    harness.begin()
+    return harness

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,22 +3,29 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
+
 import pytest
-from ops.testing import Harness
 import yaml
+from ops.testing import Harness
+
 from charm import KafkaCharm
-
 from literals import CHARM_KEY
-
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
 METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
+
 @pytest.fixture
 def harness():
     harness = Harness(KafkaCharm, meta=METADATA)
     harness.add_relation("restart", CHARM_KEY)
-    harness._update_config({"offsets-retention-minutes": 10080, "log-retention-hours": 168, "auto-create-topics": False})
+    harness._update_config(
+        {
+            "offsets-retention-minutes": 10080,
+            "log-retention-hours": 168,
+            "auto-create-topics": False,
+        }
+    )
     harness.begin()
     return harness

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,23 +3,30 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
+
 import pytest
-from ops.testing import Harness
 import yaml
+from ops.testing import Harness
+
 from charm import KafkaCharm
-
-from literals import CHARM_KEY, ZK, PEER
-
+from literals import CHARM_KEY, PEER, ZK
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
 METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
+
 @pytest.fixture
 def harness():
     harness = Harness(KafkaCharm, meta=METADATA)
     harness.add_relation("restart", CHARM_KEY)
-    harness._update_config({"offsets-retention-minutes": 10080, "log-retention-hours": 168, "auto-create-topics": False})
+    harness._update_config(
+        {
+            "offsets-retention-minutes": 10080,
+            "log-retention-hours": 168,
+            "auto-create-topics": False,
+        }
+    )
     harness.begin()
     return harness
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -32,6 +32,7 @@ def harness():
 
 
 def test_zookeeper_config_succeeds_fails_config(harness):
+    """Checks that no ZK config is returned if missing field."""
     zk_relation_id = harness.add_relation(ZK, CHARM_KEY)
     harness.update_relation_data(
         zk_relation_id,
@@ -49,6 +50,7 @@ def test_zookeeper_config_succeeds_fails_config(harness):
 
 
 def test_zookeeper_config_succeeds_valid_config(harness):
+    """Checks that ZK config is returned if all fields."""
     zk_relation_id = harness.add_relation(ZK, CHARM_KEY)
     harness.update_relation_data(
         zk_relation_id,
@@ -70,11 +72,13 @@ def test_zookeeper_config_succeeds_valid_config(harness):
 
 
 def test_extra_args(harness):
+    """Checks necessary args in extra-args for KAFKA_OPTS."""
     args = "".join(harness.charm.kafka_config.extra_args)
     assert "-Djava.security.auth.login.config" in args
 
 
 def test_bootstrap_server(harness):
+    """Checks the bootstrap-server property setting."""
     peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_relation_id, "kafka/1")
     harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
@@ -86,6 +90,7 @@ def test_bootstrap_server(harness):
 
 
 def test_default_replication_properties_less_than_three(harness):
+    """Checks replication property defaults updates with units < 3."""
     assert "num.partitions=1" in harness.charm.kafka_config.default_replication_properties
     assert (
         "default.replication.factor=1" in harness.charm.kafka_config.default_replication_properties
@@ -94,6 +99,7 @@ def test_default_replication_properties_less_than_three(harness):
 
 
 def test_default_replication_properties_more_than_three(harness):
+    """Checks replication property defaults updates with units > 3."""
     peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_relation_id, "kafka/1")
     harness.add_relation_unit(peer_relation_id, "kafka/2")
@@ -109,6 +115,7 @@ def test_default_replication_properties_more_than_three(harness):
 
 
 def test_auth_properties(harness):
+    """Checks necessary auth properties are present."""
     zk_relation_id = harness.add_relation(ZK, CHARM_KEY)
     peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
     harness.update_relation_data(
@@ -135,6 +142,7 @@ def test_auth_properties(harness):
 
 
 def test_super_users(harness):
+    """Checks super-users property is updated for new admin clients."""
     assert len(harness.charm.kafka_config.super_users.split(";")) == 1
 
     client_relation_id = harness.add_relation("kafka-client", "app")

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -42,22 +42,22 @@ def test_client_relation_created_defers_if_not_ready(harness):
 
     with patch(
         "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False
-    ), patch("auth.KafkaAuth.add_user") as patched:
+    ), patch("auth.KafkaAuth.add_user") as patched_add_user:
         harness.set_leader(True)
         harness.add_relation(REL_NAME, "app")
 
-        patched.assert_not_called()
+        patched_add_user.assert_not_called()
 
 
 def test_client_relation_created_adds_user(harness):
     harness.add_relation(PEER, CHARM_KEY)
     with patch(
         "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch("auth.KafkaAuth.add_user") as patched:
+    ), patch("auth.KafkaAuth.add_user") as patched_add_user:
         harness.set_leader(True)
         client_rel_id = harness.add_relation(REL_NAME, "app")
 
-        patched.assert_called_once()
+        patched_add_user.assert_called_once()
 
         assert harness.charm.peer_relation.data[harness.charm.app].get(f"relation-{client_rel_id}")
 
@@ -68,7 +68,7 @@ def test_client_relation_broken_removes_user(harness):
         "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
     ), patch("auth.KafkaAuth.add_user"), patch(
         "auth.KafkaAuth.delete_user"
-    ) as patched_delete, patch(
+    ) as patched_delete_user, patch(
         "auth.KafkaAuth.remove_all_user_acls"
     ) as patched_remove_acls, patch(
         "snap.KafkaSnap.run_bin_command"
@@ -86,7 +86,7 @@ def test_client_relation_broken_removes_user(harness):
             f"relation-{client_rel_id}"
         )
         patched_remove_acls.assert_called_once()
-        patched_delete.assert_called_once()
+        patched_delete_user.assert_called_once()
 
 
 def test_client_relation_joined_sets_necessary_relation_data(harness):

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
+import pytest
+import yaml
+from ops.testing import Harness
+
+from charm import KafkaCharm
+from literals import CHARM_KEY, PEER, REL_NAME
+
+logger = logging.getLogger(__name__)
+
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
+
+
+@pytest.fixture
+def harness():
+    harness = Harness(KafkaCharm, meta=METADATA)
+    harness.add_relation("restart", CHARM_KEY)
+    harness._update_config(
+        {
+            "offsets-retention-minutes": 10080,
+            "log-retention-hours": 168,
+            "auto-create-topics": False,
+        }
+    )
+
+    harness.begin()
+    return harness
+
+
+def test_client_relation_created_defers_if_not_ready(harness):
+    with harness.hooks_disabled():
+        harness.add_relation(PEER, CHARM_KEY)
+
+    with patch(
+        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False
+    ), patch("auth.KafkaAuth.add_user") as patched:
+        harness.set_leader(True)
+        harness.add_relation(REL_NAME, "app")
+
+        patched.assert_not_called()
+
+
+def test_client_relation_created_adds_user(harness):
+    harness.add_relation(PEER, CHARM_KEY)
+    with patch(
+        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
+    ), patch("auth.KafkaAuth.add_user") as patched:
+        harness.set_leader(True)
+        client_rel_id = harness.add_relation(REL_NAME, "app")
+
+        patched.assert_called_once()
+
+        assert harness.charm.peer_relation.data[harness.charm.app].get(f"relation-{client_rel_id}")
+
+
+def test_client_relation_broken_removes_user(harness):
+    harness.add_relation(PEER, CHARM_KEY)
+    with patch(
+        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
+    ), patch("auth.KafkaAuth.add_user"), patch(
+        "auth.KafkaAuth.delete_user"
+    ) as patched_delete, patch(
+        "auth.KafkaAuth.remove_all_user_acls"
+    ) as patched_remove_acls, patch(
+        "snap.KafkaSnap.run_bin_command"
+    ):
+        harness.set_leader(True)
+        client_rel_id = harness.add_relation(REL_NAME, "app")
+
+        # validating username got added
+        assert harness.charm.peer_relation.data[harness.charm.app].get(f"relation-{client_rel_id}")
+
+        harness.remove_relation(client_rel_id)
+
+        # validating username got removed
+        assert not harness.charm.peer_relation.data[harness.charm.app].get(
+            f"relation-{client_rel_id}"
+        )
+        patched_remove_acls.assert_called_once()
+        patched_delete.assert_called_once()
+
+
+def test_client_relation_joined_sets_necessary_relation_data(harness):
+    harness.add_relation(PEER, CHARM_KEY)
+    with patch(
+        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
+    ), patch("auth.KafkaAuth.add_user"), patch("snap.KafkaSnap.run_bin_command"), patch(
+        "config.KafkaConfig.zookeeper_connected", new_callable=PropertyMock, return_value=True
+    ), patch(
+        "config.KafkaConfig.zookeeper_config",
+        new_callable=PropertyMock,
+        return_value={"connect": "yes"},
+    ):
+        harness.set_leader(True)
+        client_rel_id = harness.add_relation(REL_NAME, "app")
+        client_relation = harness.charm.model.relations[REL_NAME][0]
+
+        harness.update_relation_data(client_relation.id, "app", {"extra-user-roles": "consumer"})
+        harness.add_relation_unit(client_rel_id, "app/0")
+
+        assert sorted(
+            [
+                "username",
+                "password",
+                "endpoints",
+                "uris",
+                "zookeeper-uris",
+                "consumer-group-prefix",
+                "tls",
+            ]
+        ) == sorted(client_relation.data[harness.charm.app].keys())
+
+        assert client_relation.data[harness.charm.app].get("tls", None) == "disabled"
+        assert client_relation.data[harness.charm.app].get("zookeeper-uris", None) == "yes"
+        assert (
+            client_relation.data[harness.charm.app].get("username", None)
+            == f"relation-{client_rel_id}"
+        )
+        assert (
+            client_relation.data[harness.charm.app].get("consumer-group-prefix", None)
+            == f"relation-{client_rel_id}-"
+        )

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -37,19 +37,24 @@ def harness():
 
 
 def test_client_relation_created_defers_if_not_ready(harness):
+    """Checks event is deferred if not ready on clientrelationcreated hook."""
     with harness.hooks_disabled():
         harness.add_relation(PEER, CHARM_KEY)
 
     with patch(
         "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False
-    ), patch("auth.KafkaAuth.add_user") as patched_add_user:
+    ), patch("auth.KafkaAuth.add_user") as patched_add_user, patch(
+        "ops.framework.EventBase.defer"
+    ) as patched_defer:
         harness.set_leader(True)
         harness.add_relation(REL_NAME, "app")
 
         patched_add_user.assert_not_called()
+        patched_defer.assert_called()
 
 
 def test_client_relation_created_adds_user(harness):
+    """Checks if new users are added on clientrelationcreated hook."""
     harness.add_relation(PEER, CHARM_KEY)
     with patch(
         "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
@@ -63,6 +68,7 @@ def test_client_relation_created_adds_user(harness):
 
 
 def test_client_relation_broken_removes_user(harness):
+    """Checks if users are removed on clientrelationbroken hook."""
     harness.add_relation(PEER, CHARM_KEY)
     with patch(
         "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
@@ -90,6 +96,7 @@ def test_client_relation_broken_removes_user(harness):
 
 
 def test_client_relation_joined_sets_necessary_relation_data(harness):
+    """Checks if all needed provider relation data is set on clientrelationjoined hook."""
     harness.add_relation(PEER, CHARM_KEY)
     with patch(
         "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -6,7 +6,8 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
-from charms.kafka.v0.kafka_snap import KafkaSnap
+
+from snap import KafkaSnap
 
 
 def test_run_bin_command_raises():
@@ -18,4 +19,13 @@ def test_run_bin_command_args():
     with patch("subprocess.check_output") as patched:
         KafkaSnap.run_bin_command("configs", ["--list"], ["-Djava"])
 
-    assert ("KAFKA_OPTS=-Djava kafka.configs --list",) in list(patched.call_args)
+        found_tls = False
+        found_opts = False
+        for arg in patched.call_args.args:
+            if "--zk-tls-config-file" in arg:
+                found_tls = True
+            if "KAFKA_OPTS=" in arg:
+                found_opts = True
+
+        assert found_tls, "--zk-tls-config-file flag not found"
+        assert found_opts, "KAFKA_OPTS not found"

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -11,11 +11,13 @@ from snap import KafkaSnap
 
 
 def test_run_bin_command_raises():
+    """Checks failed snap command raises CalledProcessError."""
     with pytest.raises(subprocess.CalledProcessError):
         KafkaSnap.run_bin_command("stuff", ["to"], ["fail"])
 
 
 def test_run_bin_command_args():
+    """Checks KAFKA_OPTS env-var and zk-tls flag present in all snap commands."""
     with patch("subprocess.check_output") as patched:
         KafkaSnap.run_bin_command("configs", ["--list"], ["-Djava"])
 

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ description = Run unit tests
 deps =
     pytest
     coverage[toml]
+    cryptography
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
## Changes Made
#### `chore: deprecate kafka_snap lib, use snap.py`
- As ZK charm no-longer uses the `kafka_snap` lib, there is little value in it
- Moved code to `src/snap.py`
#### `test: add/update unit-tests to use pytest throughout`
- Added various unit-tests, especially to `provider` and `charm`, which did not have any before
- All unit-tests now use `pytest` framework
#### `chore: removed if tls flags from auth`
- It's OK to pass this flag, as does nothing if not TLS