### PR TITLE
chore: Password to use secret placeholders

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -85,9 +85,9 @@ class KafkaCharm(CharmBase):
 
     def _on_leader_elected(self, _) -> None:
         """Handler for `leader_elected` event, ensuring sync_passwords gets set."""
-        current_sync_password = self.peer_relation.data[self.app].get("sync_password", None)
-        self.peer_relation.data[self.app].update(
-            {"sync_password": current_sync_password or generate_password()}
+        current_sync_password = self.get_secret(scope="app", key="sync_password")
+        self.set_secret(
+            scope="app", key="sync_password", value=(current_sync_password or generate_password())
         )
 
     def _on_zookeeper_joined(self, event: RelationJoinedEvent) -> None:
@@ -228,7 +228,7 @@ class KafkaCharm(CharmBase):
             return
 
         # Store the password on application databag
-        self.peer_relation.data[self.app].update({f"{username}_password": new_password})
+        self.set_secret(scope="app", key=f"{username}_password", value=new_password)
         event.set_results({f"{username}-password": new_password})
 
     @property

--- a/src/config.py
+++ b/src/config.py
@@ -38,7 +38,7 @@ class KafkaConfig:
     @property
     def sync_password(self) -> Optional[str]:
         """Returns charm-set sync_password for server-server auth between brokers."""
-        return self.charm.model.get_relation(PEER).data[self.charm.app].get("sync_password", None)
+        return self.charm.get_secret(scope="app", key="sync_password")
 
     @property
     def zookeeper_config(self) -> Dict[str, str]:
@@ -64,7 +64,6 @@ class KafkaConfig:
             zookeeper_config.update(relation.data[relation.app])
             break
 
-        #
         if zookeeper_config:
             sorted_uris = sorted(
                 zookeeper_config["uris"].replace(zookeeper_config["chroot"], "").split(",")


### PR DESCRIPTION
Linked to Jira [DPE-660](https://warthogs.atlassian.net/browse/DPE-660).

Changes `sync_password` to be stored using the `set_secret`/`get_secret` placeholders.

Note: Information coming from Zookeeper relation is not stored using the same scheme.