### PR TITLE
feat: add basic Juju storage support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,6 +4,8 @@
 type: charm
 parts:
   charm:
+    charm-binary-python-packages:
+      - setuptools
     build-packages:
       - libffi-dev
       - libssl-dev
@@ -12,7 +14,7 @@ parts:
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,6 +9,8 @@ description: |
   ""
 maintainers:
   - Marc Oppenheimer <marc.oppenheimer@canonical.com>
+series:
+  - jammy
 
 peers:
   cluster:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ provides:
     interface: kafka_client
 
 storage:
-  logs:
+  log-data:
     type: filesystem
     description: Directories where the log data is stored
     minimum-size: 50M

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,5 +32,6 @@ storage:
     type: filesystem
     description: Directories where the log data is stored
     minimum-size: 50M
-    location: /var/snap/kafka/common/log
-    multiple: 12+
+    location: /var/snap/kafka/common
+    multiple:
+      range: "12"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,3 +26,11 @@ requires:
 provides:
   kafka-client:
     interface: kafka_client
+
+storage:
+  log-dirs:
+    type: filesystem
+    description: Directories where the log data is stored
+    minimum-size: 50M
+    location: /var/snap/kafka/common/log
+    multiple: 12+

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ provides:
     interface: kafka_client
 
 storage:
-  log-dirs:
+  logs:
     type: filesystem
     description: Directories where the log data is stored
     minimum-size: 50M

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops >= 1.5.0
+ops >= 1.5.3
 kazoo >= 2.8.0
 tenacity >= 8.0.1
 pure-sasl >= 0.6.2

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,8 +5,8 @@
 """Charmed Machine Operator for Apache Kafka."""
 
 import logging
-import subprocess
 import os
+import subprocess
 from typing import MutableMapping, Optional
 
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
@@ -60,7 +60,9 @@ class KafkaCharm(CharmBase):
 
         self.framework.observe(getattr(self.on, "set_password_action"), self._set_password_action)
 
-        self.framework.observe(getattr(self.on, "logs_storage_attached"), self._on_storage_attached)
+        self.framework.observe(
+            getattr(self.on, "logs_storage_attached"), self._on_storage_attached
+        )
 
     def _on_storage_attached(self, event: StorageAttachedEvent) -> None:
         path = event.storage.location if event.storage else None
@@ -68,9 +70,8 @@ class KafkaCharm(CharmBase):
             logger.error("Unable to find storage in StorageAttachedEvent")
             return
 
-        logger.info(path)
-
         os.makedirs(os.path.dirname(str(path)), exist_ok=True)
+        logger.info(f"Created directory at path - {str(path)=}")
 
         self.unit_peer_data.update({"logs": "attached"})
 
@@ -143,6 +144,9 @@ class KafkaCharm(CharmBase):
         if not self.model.storages.get("logs", None):
             logger.error("Unable to find storage in StartEvent")
             return
+
+        logger.warning("Exiting")
+        return
 
         # required settings given zookeeper connection config has been created
         self.kafka_config.set_jaas_config()
@@ -293,8 +297,10 @@ class KafkaCharm(CharmBase):
             self.unit.status = BlockedStatus(msg)
             return False
 
-        if not self.kafka_config.zookeeper_connected or not self.peer_relation.data[self.app].get(
-            "broker-creds", None
+        if (
+            not self.kafka_config.zookeeper_connected
+            or not self.peer_relation.data[self.app].get("broker-creds", None)
+            or not self.model.storages.get("logs", None)
         ):
             return False
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,6 +94,7 @@ class KafkaCharm(CharmBase):
         self.unit_peer_data.update({"logs": "attached"})
 
     def _on_storage_detatched(self, _: StorageDetachingEvent) -> None:
+        # TODO: handle gracefully
         self.unit_peer_data.update({"logs": ""})
 
     def _on_install(self, _) -> None:
@@ -290,7 +291,7 @@ class KafkaCharm(CharmBase):
         storage_metadata = self.meta.storages["log-data"]
         min_storages = storage_metadata.multiple_range[0] if storage_metadata.multiple_range else 0
         if len(self.model.storages["log-data"]) < min_storages:
-            msg = f"Storage volumes lower than minimum"
+            msg = f"Storage volumes lower than minimum of {min_storages}"
             logger.error(msg)
             self.unit.status = BlockedStatus(msg)
             return False

--- a/src/charm.py
+++ b/src/charm.py
@@ -295,9 +295,8 @@ class KafkaCharm(CharmBase):
             self.unit.status = BlockedStatus(msg)
             return False
 
-        if (
-            not self.kafka_config.zookeeper_connected
-            or not self.peer_relation.data[self.app].get("broker-creds", None)
+        if not self.kafka_config.zookeeper_connected or not self.peer_relation.data[self.app].get(
+            "broker-creds", None
         ):
             return False
 

--- a/src/config.py
+++ b/src/config.py
@@ -190,16 +190,15 @@ class KafkaConfig:
         return ";".join(super_users_arg)
 
     @property
-    def log_dirs(self) -> List[str]:
+    def log_dirs(self) -> str:
         """Builds the necessary log.dirs based on mounted storage volumes.
 
         Returns:
-            List of property log.dirs to be set
+            String of log.dirs property value to be set
         """
-        log_dirs = ",".join(
+        return ",".join(
             [os.fspath(storage.location) for storage in self.charm.model.storages["log-data"]]
         )
-        return [f"log.dirs={log_dirs}"]
 
     @property
     def server_properties(self) -> List[str]:
@@ -222,6 +221,7 @@ class KafkaConfig:
                 f"log.retention.hours={self.charm.config['log-retention-hours']}",
                 f"auto.create.topics={self.charm.config['auto-create-topics']}",
                 f"super.users={self.super_users}",
+                f"log.dirs={self.log_dirs}",
                 f"listeners={protocol}://:{port}",
                 f"advertised.listeners={protocol}://{host}:{port}",
                 f'listener.name.{(protocol).lower()}.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="sync" password="{self.sync_password}";',
@@ -230,7 +230,6 @@ class KafkaConfig:
             ]
             + self.default_replication_properties
             + self.auth_properties
-            + self.log_dirs
             + DEFAULT_CONFIG_OPTIONS.split("\n")
         )
 

--- a/src/config.py
+++ b/src/config.py
@@ -197,7 +197,7 @@ class KafkaConfig:
             List of property log.dirs to be set
         """
         log_dirs = ",".join(
-            [os.fspath(storage.location) for storage in self.charm.model.storages["logs"]]
+            [os.fspath(storage.location) for storage in self.charm.model.storages["log-data"]]
         )
         return [f"log.dirs={log_dirs}"]
 

--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,7 @@
 """Manager for handling Kafka configuration."""
 
 import logging
+import os
 from typing import Dict, List, Optional
 
 from ops.model import Unit
@@ -190,7 +191,14 @@ class KafkaConfig:
 
     @property
     def log_dirs(self) -> List[str]:
-        log_dirs = [storage.location for storage in self.charm.model.storages.get("logs")]
+        """Builds the necessary log.dirs based on mounted storage volumes.
+
+        Returns:
+            List of property log.dirs to be set
+        """
+        log_dirs = ",".join(
+            [os.fspath(storage.location) for storage in self.charm.model.storages["logs"]]
+        )
         return [f"log.dirs={log_dirs}"]
 
     @property

--- a/src/config.py
+++ b/src/config.py
@@ -16,7 +16,6 @@ from utils import safe_write_to_file
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_OPTIONS = """
-log.dirs=/var/snap/kafka/common/log
 sasl.enabled.mechanisms=SCRAM-SHA-512
 sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
 authorizer.class.name=kafka.security.authorizer.AclAuthorizer
@@ -190,6 +189,11 @@ class KafkaConfig:
         return ";".join(super_users_arg)
 
     @property
+    def log_dirs(self) -> List[str]:
+        log_dirs = [storage.location for storage in self.charm.model.storages.get("logs")]
+        return [f"log.dirs={log_dirs}"]
+
+    @property
     def server_properties(self) -> List[str]:
         """Builds all properties necessary for starting Kafka service.
 
@@ -218,6 +222,7 @@ class KafkaConfig:
             ]
             + self.default_replication_properties
             + self.auth_properties
+            + self.log_dirs
             + DEFAULT_CONFIG_OPTIONS.split("\n")
         )
 

--- a/tests/integration/app-charm/charmcraft.yaml
+++ b/tests/integration/app-charm/charmcraft.yaml
@@ -5,7 +5,7 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -18,7 +18,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         ops_test.model.deploy(
             "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
         ),
-        ops_test.model.deploy(kafka_charm, application_name="kafka", num_units=1, series="focal"),
+        ops_test.model.deploy(kafka_charm, application_name="kafka", num_units=1, series="jammy"),
     )
     await ops_test.model.wait_for_idle(apps=["kafka", "zookeeper"])
     assert ops_test.model.applications["kafka"].status == "waiting"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,9 +16,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     kafka_charm = await ops_test.build_charm(".")
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=3
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
         ),
-        ops_test.model.deploy(kafka_charm, application_name="kafka", num_units=1),
+        ops_test.model.deploy(kafka_charm, application_name="kafka", num_units=1, series="focal"),
     )
     await ops_test.model.wait_for_idle(apps=["kafka", "zookeeper"])
     assert ops_test.model.applications["kafka"].status == "waiting"

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -23,8 +23,10 @@ logger = logging.getLogger(__name__)
 async def test_build_and_deploy(ops_test: OpsTest):
     kafka_charm = await ops_test.build_charm(".")
     await asyncio.gather(
-        ops_test.model.deploy(ZK_NAME, channel="edge", application_name=ZK_NAME, num_units=3),
-        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1),
+        ops_test.model.deploy(
+            ZK_NAME, channel="edge", application_name=ZK_NAME, num_units=3, series="focal"
+        ),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="focal"),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME])

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -26,7 +26,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         ops_test.model.deploy(
             ZK_NAME, channel="edge", application_name=ZK_NAME, num_units=3, series="focal"
         ),
-        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="focal"),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="jammy"),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME])

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -37,10 +37,12 @@ async def test_deploy_charms_relate_active(ops_test: OpsTest, usernames):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=3
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
         ),
-        ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1),
-        ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_1, num_units=1),
+        ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1, series="focal"),
+        ops_test.model.deploy(
+            app_charm, application_name=DUMMY_NAME_1, num_units=1, series="focal"
+        ),
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_NAME_1, ZK])
     await ops_test.model.add_relation(APP_NAME, ZK)
@@ -177,7 +179,7 @@ async def test_admin_removed_from_super_users(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_connection_updated_on_tls_enabled(ops_test: OpsTest):
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
-    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config)
+    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config, series="focal")
     await ops_test.model.add_relation(TLS_NAME, ZK)
     await ops_test.model.add_relation(TLS_NAME, APP_NAME)
 

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -39,7 +39,7 @@ async def test_deploy_charms_relate_active(ops_test: OpsTest, usernames):
         ops_test.model.deploy(
             "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
         ),
-        ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1, series="focal"),
+        ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1, series="jammy"),
         ops_test.model.deploy(
             app_charm, application_name=DUMMY_NAME_1, num_units=1, series="focal"
         ),

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -28,9 +28,9 @@ async def test_kafka_simple_scale_up(ops_test: OpsTest):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=3
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
         ),
-        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="focal"),
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK])
     await ops_test.model.add_relation(APP_NAME, ZK)

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -30,7 +30,7 @@ async def test_kafka_simple_scale_up(ops_test: OpsTest):
         ops_test.model.deploy(
             "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
         ),
-        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="focal"),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="jammy"),
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK])
     await ops_test.model.add_relation(APP_NAME, ZK)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -29,9 +29,9 @@ async def test_deploy_tls(ops_test: OpsTest):
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
 
     await asyncio.gather(
-        ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config),
-        ops_test.model.deploy(ZK_NAME, channel="edge", num_units=3),
-        ops_test.model.deploy(kafka_charm, application_name=APP_NAME),
+        ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config, series="focal"),
+        ops_test.model.deploy(ZK_NAME, channel="edge", num_units=3, series="focal"),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, series="jammy"),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME, TLS_NAME], timeout=1000)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -31,6 +31,13 @@ def harness():
     return harness
 
 
+def test_all_storages_in_server_properties_log_dirs(harness):
+    """Checks that the log.dirs property updates with all available storages."""
+    assert len(harness.charm.kafka_config.log_dirs) == len(
+        harness.charm.model.storages["log-data"]
+    )
+
+
 def test_zookeeper_config_succeeds_fails_config(harness):
     """Checks that no ZK config is returned if missing field."""
     zk_relation_id = harness.add_relation(ZK, CHARM_KEY)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -31,11 +31,43 @@ def harness():
     return harness
 
 
-def test_all_storages_in_server_properties_log_dirs(harness):
+def test_all_storages_in_log_dirs(harness):
     """Checks that the log.dirs property updates with all available storages."""
-    assert len(harness.charm.kafka_config.log_dirs) == len(
+    storage_metadata = harness.charm.meta.storages["log-data"]
+    min_storages = storage_metadata.multiple_range[0] if storage_metadata.multiple_range else 0
+    with harness.hooks_disabled():
+        harness.add_storage(storage_name="log-data", count=min_storages, attach=True)
+
+    assert len(harness.charm.kafka_config.log_dirs.split(",")) == len(
         harness.charm.model.storages["log-data"]
     )
+
+
+def test_log_dirs_in_server_properties(harness):
+    """Checks that log.dirs are added to server_properties."""
+    zk_relation_id = harness.add_relation(ZK, CHARM_KEY)
+    harness.update_relation_data(
+        zk_relation_id,
+        harness.charm.app.name,
+        {
+            "chroot": "/kafka",
+            "username": "moria",
+            "password": "mellon",
+            "endpoints": "1.1.1.1,2.2.2.2",
+            "uris": "1.1.1.1:2181/kafka,2.2.2.2:2181/kafka",
+            "tls": "disabled",
+        },
+    )
+    peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_relation_id, "kafka/1")
+    harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
+
+    found_log_dirs = False
+    for prop in harness.charm.kafka_config.server_properties:
+        if "log.dirs" in prop:
+            found_log_dirs = True
+
+    assert found_log_dirs
 
 
 def test_zookeeper_config_succeeds_fails_config(harness):

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8 == 4.0.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -82,7 +82,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -96,7 +96,7 @@ commands =
 description = Run base integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -110,7 +110,7 @@ commands =
 description = Run integration tests for provider
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -124,7 +124,7 @@ commands =
 description = Run scaling integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -138,7 +138,7 @@ commands =
 description = Run password rotation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -152,7 +152,7 @@ commands =
 description = Run TLS integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity


### PR DESCRIPTION
## Changes Made
##### `feat: add 12 small storage volumes by default`
##### `feat: configure Kafka log.dirs to use mounted storage volumes`
- Blocks and does not start if < minimum:range storages found

## Up Next
- More gracefully handle storage adding/removing/attach/detach events for currently running charm. Currently none handled
- Integration tests for all storage events
    - This is not added to this PR as to 'generate' logs to these mounted storage directories, we have to build a robust `producer` so that topic metadata is stored across these dirs
    - This hasn't been done yet, TBC
- NOTE - All future PR's will be merging to feature branch `feat/storage` to keep PRs more reviewable.