### PR TITLE
chore: enable useful status/logging messages for storage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
 
   integration-charm:
     name: Integration tests for (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -46,7 +46,7 @@ jobs:
 
   integration-provider:
     name: Integration tests for provider (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -63,7 +63,7 @@ jobs:
 
   integration-scaling:
     name: Integration tests for scaling (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -80,7 +80,7 @@ jobs:
 
   integration-password-rotation:
     name: Integration tests for password rotation (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -97,7 +97,7 @@ jobs:
 
   integration-tls:
     name: Integration tests for TLS (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release to latest/edge
+name: Release to 22.04/edge
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 jobs:
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
 
   integration-charm:
     name: Integration tests for (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -61,7 +61,7 @@ jobs:
 
   integration-provider:
     name: Integration tests for provider (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -79,7 +79,7 @@ jobs:
 
   integration-scaling:
     name: Integration tests for scaling (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -97,7 +97,7 @@ jobs:
 
   integration-password-rotation:
     name: Integration tests for password rotation (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -115,7 +115,7 @@ jobs:
 
   integration-tls:
     name: Integration tests for TLS (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -142,7 +142,7 @@ jobs:
       - integration-scaling
       - integration-password-rotation
       - integration-tls
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,4 +36,4 @@ storage:
     minimum-size: 50M
     location: /var/snap/kafka/common
     multiple:
-      range: "12"
+      range: 1-12

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,6 @@ from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from ops.charm import (
     ActionEvent,
     CharmBase,
-    ConfigChangedEvent,
     LeaderElectedEvent,
     RelationEvent,
     RelationJoinedEvent,
@@ -62,6 +61,9 @@ class KafkaCharm(CharmBase):
         self.framework.observe(
             getattr(self.on, "log_data_storage_attached"), self._on_storage_attached
         )
+        self.framework.observe(
+            getattr(self.on, "log_data_storage_detaching"), self._on_storage_detaching
+        )
 
     @property
     def peer_relation(self) -> Optional[Relation]:
@@ -85,17 +87,36 @@ class KafkaCharm(CharmBase):
         return self.peer_relation.data[self.unit]
 
     def _on_storage_attached(self, event: StorageAttachedEvent) -> None:
-        path = event.storage.location if event.storage else None
-        if not path:
-            logger.error("Unable to find storage in StorageAttachedEvent")
-            event.defer()
-            return
+        """Handler for `storage_attached` events."""
+        # checks first whether the broker is active before warning
+        if self.kafka_config.zookeeper_connected and broker_active(
+            unit=self.unit, zookeeper_config=self.kafka_config.zookeeper_config
+        ):
+            # new dirs won't be used until topic partitions are assigned to it
+            # either automatically for new topics, or manually for existing
+            message = "manual partition reassignment needed to use new storage"
+            logger.warning(f"Attaching storage - {message}")
+            self.unit.status = ActiveStatus(message)
 
-        self.unit_peer_data.update({"logs": "attached"})
+        self._on_config_changed(event)
 
-    def _on_storage_detatched(self, _: StorageDetachingEvent) -> None:
-        # TODO: handle gracefully
-        self.unit_peer_data.update({"logs": ""})
+    def _on_storage_detaching(self, event: StorageDetachingEvent) -> None:
+        """Handler for `storage_detaching` events."""
+        # checks first whether the broker is active before warning
+        if self.kafka_config.zookeeper_connected and broker_active(
+            unit=self.unit, zookeeper_config=self.kafka_config.zookeeper_config
+        ):
+            # in the case where there may be replication recovery may be possible
+            if self.peer_relation and len(self.peer_relation.units):
+                message = "manual partition reassignment suggested due to potential log data loss"
+                logger.warning(f"Removing storage - {message}")
+                self.unit.status = BlockedStatus(message)
+            else:
+                message = "potential log-data loss"
+                logger.error(f"Removing storage - {message}")
+                self.unit.status = BlockedStatus(message)
+
+        self._on_config_changed(event)
 
     def _on_install(self, _) -> None:
         """Handler for `install` event."""
@@ -184,7 +205,7 @@ class KafkaCharm(CharmBase):
             self.unit.status = BlockedStatus("kafka unit not connected to ZooKeeper")
             return
 
-    def _on_config_changed(self, event: ConfigChangedEvent) -> None:
+    def _on_config_changed(self, event: EventBase) -> None:
         """Generic handler for most `config_changed` events across relations."""
         if not self.ready_to_start:
             event.defer()
@@ -201,8 +222,8 @@ class KafkaCharm(CharmBase):
             logger.info(
                 (
                     f'Broker {self.unit.name.split("/")[1]} updating config - '
-                    f"OLD PROPERTIES = {set(properties) - set(self.kafka_config.server_properties)=}, "
-                    f"NEW PROPERTIES = {set(self.kafka_config.server_properties) - set(properties)=}"
+                    f"OLD PROPERTIES = {set(properties) - set(self.kafka_config.server_properties)}, "
+                    f"NEW PROPERTIES = {set(self.kafka_config.server_properties) - set(properties)}"
                 )
             )
             self.kafka_config.set_server_properties()

--- a/tests/integration/app-charm/metadata.yaml
+++ b/tests/integration/app-charm/metadata.yaml
@@ -7,6 +7,8 @@ description: |
 summary: |
   Dummy charm application meant to be used
   only for testing of the libs in this repository.
+series:
+  - jammy
 
 peers:
   cluster:

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -61,6 +61,11 @@ class ApplicationCharm(CharmBase):
             {"extra-user-roles": "admin,consumer"}
         )
 
+    def _make_producer(self, _):
+        self.model.get_relation(REL_NAME).data[self.app].update(
+            {"extra-user-roles": "admin,consumer,producer"}
+        )
+
     def _remove_admin(self, _):
         self.model.get_relation(REL_NAME).data[self.app].update({"extra-user-roles": "producer"})
 

--- a/tests/integration/client.py
+++ b/tests/integration/client.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import argparse
+import json
+import logging
+import sys
+import time
+from typing import List, Optional
+
+import requests
+from kafka import KafkaAdminClient, KafkaConsumer, KafkaProducer
+from kafka.admin import NewTopic
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+
+class KafkaClient:
+
+    API_VERSION = (2, 5, 0)
+
+    def __init__(
+        self,
+        servers: List[str],
+        username: Optional[str],
+        password: Optional[str],
+        topic: str,
+        consumer_group_prefix: Optional[str],
+        security_protocol: str,
+    ) -> None:
+        self.servers = servers
+        self.username = username
+        self.password = password
+        self.topic = topic
+        self.consumer_group_prefix = consumer_group_prefix
+        self.security_protocol = security_protocol
+
+        self.sasl = "SASL" in self.security_protocol
+        self.ssl = "SSL" in self.security_protocol
+        self.mtls = self.security_protocol == "SSL"
+
+    def create_topic(self):
+        admin_client = KafkaAdminClient(
+            client_id=self.username,
+            bootstrap_servers=self.servers,
+            ssl_check_hostname=False,
+            security_protocol=self.security_protocol,
+            sasl_plain_username=self.username if self.sasl else None,
+            sasl_plain_password=self.password if self.sasl else None,
+            sasl_mechanism="SCRAM-SHA-512" if self.sasl else None,
+            ssl_cafile="certs/ca.pem" if self.ssl else None,
+            ssl_certfile="certs/cert.pem" if self.ssl else None,
+            ssl_keyfile="certs/key.pem" if self.mtls else None,
+            api_version=KafkaClient.API_VERSION if self.mtls else None,
+        )
+
+        topic_list = [NewTopic(name=self.topic, num_partitions=5, replication_factor=1)]
+        admin_client.create_topics(new_topics=topic_list, validate_only=False)
+
+    def run_consumer(self):
+        consumer = KafkaConsumer(
+            self.topic,
+            bootstrap_servers=self.servers,
+            ssl_check_hostname=False,
+            security_protocol=self.security_protocol,
+            sasl_plain_username=self.username if self.sasl else None,
+            sasl_plain_password=self.password if self.sasl else None,
+            sasl_mechanism="SCRAM-SHA-512" if self.sasl else None,
+            ssl_cafile="certs/ca.pem" if self.ssl else None,
+            ssl_certfile="certs/cert.pem" if self.ssl else None,
+            ssl_keyfile="certs/key.pem" if self.mtls else None,
+            api_version=KafkaClient.API_VERSION if self.mtls else None,
+            group_id=self.consumer_group_prefix + "1" if self.consumer_group_prefix else None,
+            enable_auto_commit=True,
+            auto_offset_reset="earliest",
+            consumer_timeout_ms=15000,
+        )
+
+        for message in consumer:
+            logger.info(str(message))
+
+    def run_producer(self):
+        producer = KafkaProducer(
+            bootstrap_servers=self.servers,
+            ssl_check_hostname=False,
+            security_protocol=self.security_protocol,
+            sasl_plain_username=self.username if self.sasl else None,
+            sasl_plain_password=self.password if self.sasl else None,
+            sasl_mechanism="SCRAM-SHA-512" if self.sasl else None,
+            ssl_cafile="certs/ca.pem" if self.ssl else None,
+            ssl_certfile="certs/cert.pem" if self.ssl else None,
+            ssl_keyfile="certs/key.pem" if self.mtls else None,
+            api_version=KafkaClient.API_VERSION if self.mtls else None,
+        )
+
+        for _ in range(3):
+            logger.info("Requesting NewStories from HN...")
+            response = requests.get(
+                url="https://hacker-news.firebaseio.com/v0/newstories.json?print=pretty"
+            )
+            content = json.loads(response._content.decode("utf-8")) if response._content else {}
+
+            if content:
+                logger.info("Successfully retrieved NewStories...")
+            else:
+                logger.warning("Failed retrieving NewStories...")
+                time.sleep(5)
+                continue
+
+            for i, content_id in enumerate(content):
+                if i <= 5:
+                    response = requests.get(
+                        url=f"https://hacker-news.firebaseio.com/v0/item/{content_id}.json"
+                    )
+                    item_content = response._content or b""
+                    item_id = json.loads(item_content.decode("utf-8")).get("id", None)
+                    title = json.loads(item_content.decode("utf-8")).get("title", None)
+                    url = json.loads(item_content.decode("utf-8")).get("url", None)
+
+                    if item_id:
+                        future = producer.send(self.topic, item_content)
+                        future.get(timeout=60)
+                        logger.info(
+                            f"Message published to topic={self.topic}, item_id={item_id}, title={title}, url={url}"
+                        )
+                    else:
+                        logger.warning(f"Missing item_id for content_id={content_id}")
+
+                    time.sleep(5)
+
+                    continue
+                else:
+                    break
+
+            break
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Handler for running a Kafka client")
+    parser.add_argument(
+        "-t",
+        "--topic",
+        help="Kafka topic provided by Kafka Charm",
+        type=str,
+        default="demo",
+    )
+    parser.add_argument(
+        "-u",
+        "--username",
+        help="Kafka username provided by Kafka Charm",
+        type=str,
+    )
+    parser.add_argument(
+        "-p",
+        "--password",
+        help="Kafka password provided by Kafka Charm",
+        type=str,
+    )
+    parser.add_argument(
+        "-c",
+        "--consumer-group-prefix",
+        help="Kafka consumer-group-prefix provided by Kafka Charm",
+        type=str,
+    )
+    parser.add_argument(
+        "-s",
+        "--servers",
+        help="comma delimited list of Kafka bootstrap-server strings",
+        type=str,
+    )
+    parser.add_argument(
+        "-x",
+        "--security-protocol",
+        help="security protocol used for authentication",
+        type=str,
+        default="SASL_PLAINTEXT",
+    )
+
+    parser.add_argument("--producer", action="store_true", default=False)
+    parser.add_argument("--consumer", action="store_true", default=False)
+
+    args = parser.parse_args()
+    servers = args.servers.split(",")
+    if not args.consumer_group_prefix:
+        args.consumer_group_prefix = f"{args.username}-" if args.username else None
+
+    client = KafkaClient(
+        servers=servers,
+        username=args.username,
+        password=args.password,
+        topic=args.topic,
+        consumer_group_prefix=args.consumer_group_prefix,
+        security_protocol=args.security_protocol,
+    )
+
+    if args.producer:
+        logger.info(f"Creating new topic - {args.topic}")
+        client.create_topic()
+        logger.info("--producer - Starting...")
+        producer = client.run_producer()
+    if args.consumer:
+        logger.info("--consumer - Starting...")
+        consumer = client.run_consumer()
+    else:
+        logger.info("No client type args found. Exiting...")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,9 +44,10 @@ def harness():
 
 def test_install_sets_opts(harness):
     """Checks KAFKA_OPTS is written to /etc/environment on install hook."""
-    with patch("snap.KafkaSnap.install"), patch(
-        "config.KafkaConfig.set_kafka_opts"
-    ) as patched_kafka_opts:
+    with (
+        patch("snap.KafkaSnap.install"),
+        patch("config.KafkaConfig.set_kafka_opts") as patched_kafka_opts,
+    ):
         harness.charm.on.install.emit()
 
         patched_kafka_opts.assert_called_once()
@@ -54,15 +55,16 @@ def test_install_sets_opts(harness):
 
 def test_install_waits_until_zookeeper_relation(harness):
     """Checks unit goes to WaitingStatus without ZK relation on install hook."""
-    with patch("snap.KafkaSnap.install"), patch("config.KafkaConfig.set_kafka_opts"):
+    with (patch("snap.KafkaSnap.install"), patch("config.KafkaConfig.set_kafka_opts")):
         harness.charm.on.install.emit()
         assert isinstance(harness.charm.unit.status, WaitingStatus)
 
 
 def test_install_blocks_snap_install_failure(harness):
     """Checks unit goes to BlockedStatus after snap failure on install hook."""
-    with patch("snap.KafkaSnap.install", return_value=False), patch(
-        "config.KafkaConfig.set_kafka_opts"
+    with (
+        patch("snap.KafkaSnap.install", return_value=False),
+        patch("config.KafkaConfig.set_kafka_opts"),
     ):
         harness.charm.on.install.emit()
         assert isinstance(harness.charm.unit.status, BlockedStatus)
@@ -127,9 +129,10 @@ def test_start_sets_necessary_config(harness):
         },
     )
 
-    with patch("config.KafkaConfig.set_jaas_config") as patched_jaas, patch(
-        "config.KafkaConfig.set_server_properties"
-    ) as patched_properties:
+    with (
+        patch("config.KafkaConfig.set_jaas_config") as patched_jaas,
+        patch("config.KafkaConfig.set_server_properties") as patched_properties,
+    ):
         harness.charm.on.start.emit()
         patched_jaas.assert_called_once()
         patched_properties.assert_called_once()
@@ -154,11 +157,12 @@ def test_start_sets_auth_and_broker_creds_on_leader(harness):
     )
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
 
-    with patch("auth.KafkaAuth.add_user") as patched_add_user, patch(
-        "config.KafkaConfig.set_jaas_config"
-    ), patch("config.KafkaConfig.set_server_properties"), patch(
-        "charm.broker_active"
-    ) as patched_broker_active:
+    with (
+        patch("auth.KafkaAuth.add_user") as patched_add_user,
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("charm.broker_active") as patched_broker_active,
+    ):
         # verify non-leader does not set creds
         patched_broker_active.retry.wait = wait_none
         harness.charm.on.start.emit()
@@ -191,15 +195,14 @@ def test_start_does_not_start_if_not_ready(harness):
     )
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
 
-    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False
-    ), patch(
-        "snap.KafkaSnap.start_snap_service"
-    ) as patched_start_snap_service, patch(
-        "ops.framework.EventBase.defer"
-    ) as patched_defer:
+    with (
+        patch("auth.KafkaAuth.add_user"),
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False),
+        patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service,
+        patch("ops.framework.EventBase.defer") as patched_defer,
+    ):
         harness.charm.on.start.emit()
 
         patched_start_snap_service.assert_not_called()
@@ -225,9 +228,12 @@ def test_start_does_not_start_if_not_same_tls_as_zk(harness):
     )
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
 
-    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service:
+    with (
+        patch("auth.KafkaAuth.add_user"),
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service,
+    ):
         harness.charm.on.start.emit()
 
         patched_start_snap_service.assert_not_called()
@@ -253,9 +259,11 @@ def test_start_does_not_start_if_leader_has_not_set_creds(harness):
     )
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
 
-    with patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service:
+    with (
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service,
+    ):
         harness.charm.on.start.emit()
 
         patched_start_snap_service.assert_not_called()
@@ -282,11 +290,13 @@ def test_start_blocks_if_service_failed_silently(harness):
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
     harness.set_leader(True)
 
-    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service, patch(
-        "charm.broker_active", return_value=False
-    ) as patched_broker_active:
+    with (
+        patch("auth.KafkaAuth.add_user"),
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service,
+        patch("charm.broker_active", return_value=False) as patched_broker_active,
+    ):
         patched_broker_active.retry.wait = wait_none
         harness.charm.on.start.emit()
 
@@ -294,12 +304,8 @@ def test_start_blocks_if_service_failed_silently(harness):
         assert isinstance(harness.charm.unit.status, BlockedStatus)
 
 
-def test_start_blocks_if_missing_storage(harness):
-    """Checks unit is not ActiveStatus if missing storage mount."""
-    # removing single storage, less than minimum present
-    harness.detach_storage(storage_id="log-data/0")
-    harness.remove_storage(storage_id="log-data/0")
-
+def test_storage_add_remove_triggers_restart(harness):
+    """Checks if unit restarts during storage events."""
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     zk_rel_id = harness.add_relation(ZK, ZK)
     harness.add_relation_unit(zk_rel_id, "zookeeper/0")
@@ -318,16 +324,22 @@ def test_start_blocks_if_missing_storage(harness):
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
     harness.set_leader(True)
 
-    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service, patch(
-        "charm.broker_active", return_value=False
-    ) as patched_broker_active:
-        patched_broker_active.retry.wait = wait_none
-        harness.charm.on.start.emit()
+    with (
+        patch("snap.KafkaSnap.restart_snap_service") as patched_restart_snap_service,
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("charm.safe_get_file", return_value=["log.dirs=/var/snap/kafka/common/logs/0"]),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("charm.broker_active", return_value=True),
+    ):
+        harness.add_storage(storage_name="log-data", count=2)
+        harness.attach_storage(storage_id="log-data/1")
+        patched_restart_snap_service.assert_called_once()
+        assert not isinstance(harness.charm.unit.status, BlockedStatus)
 
-        patched_start_snap_service.assert_not_called()
-        assert isinstance(harness.charm.unit.status, BlockedStatus)
+        patched_restart_snap_service.reset_mock()
+
+        harness.remove_storage(storage_id="log-data/1")
+        patched_restart_snap_service.assert_called_once()
 
 
 def test_config_changed_updates_properties(harness):
@@ -335,17 +347,16 @@ def test_config_changed_updates_properties(harness):
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
 
-    with patch(
-        "config.KafkaConfig.server_properties",
-        new_callable=PropertyMock,
-        return_value=["gandalf=white"],
-    ), patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch(
-        "charm.safe_get_file", return_value=["gandalf=grey"]
-    ), patch(
-        "config.KafkaConfig.set_server_properties"
-    ) as set_props:
+    with (
+        patch(
+            "config.KafkaConfig.server_properties",
+            new_callable=PropertyMock,
+            return_value=["gandalf=white"],
+        ),
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("charm.safe_get_file", return_value=["gandalf=grey"]),
+        patch("config.KafkaConfig.set_server_properties") as set_props,
+    ):
         harness.charm.on.config_changed.emit()
 
         set_props.assert_called_once()
@@ -357,17 +368,16 @@ def test_config_changed_updates_client_data(harness):
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
     harness.add_relation(REL_NAME, "app")
 
-    with patch(
-        "config.KafkaConfig.server_properties",
-        new_callable=PropertyMock,
-        return_value=["gandalf=white"],
-    ), patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch(
-        "charm.safe_get_file", return_value=["gandalf=white"]
-    ), patch(
-        "provider.KafkaProvider.update_connection_info"
-    ) as patched_update_connection_info:
+    with (
+        patch(
+            "config.KafkaConfig.server_properties",
+            new_callable=PropertyMock,
+            return_value=["gandalf=white"],
+        ),
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("charm.safe_get_file", return_value=["gandalf=white"]),
+        patch("provider.KafkaProvider.update_connection_info") as patched_update_connection_info,
+    ):
         harness.set_leader(True)
         harness.charm.on.config_changed.emit()
 
@@ -379,19 +389,17 @@ def test_config_changed_restarts(harness):
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
 
-    with patch(
-        "config.KafkaConfig.server_properties",
-        new_callable=PropertyMock,
-        return_value=["gandalf=grey"],
-    ), patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch(
-        "charm.safe_get_file", return_value=["gandalf=white"]
-    ), patch(
-        "config.safe_write_to_file", return_value=None
-    ), patch(
-        "snap.KafkaSnap.restart_snap_service"
-    ) as patched_restart_snap_service:
+    with (
+        patch(
+            "config.KafkaConfig.server_properties",
+            new_callable=PropertyMock,
+            return_value=["gandalf=grey"],
+        ),
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("charm.safe_get_file", return_value=["gandalf=white"]),
+        patch("config.safe_write_to_file", return_value=None),
+        patch("snap.KafkaSnap.restart_snap_service") as patched_restart_snap_service,
+    ):
         harness.set_leader(True)
         harness.charm.on.config_changed.emit()
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -41,11 +41,11 @@ def test_client_relation_created_defers_if_not_ready(harness):
     with harness.hooks_disabled():
         harness.add_relation(PEER, CHARM_KEY)
 
-    with patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False
-    ), patch("auth.KafkaAuth.add_user") as patched_add_user, patch(
-        "ops.framework.EventBase.defer"
-    ) as patched_defer:
+    with (
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False),
+        patch("auth.KafkaAuth.add_user") as patched_add_user,
+        patch("ops.framework.EventBase.defer") as patched_defer,
+    ):
         harness.set_leader(True)
         harness.add_relation(REL_NAME, "app")
 
@@ -56,9 +56,10 @@ def test_client_relation_created_defers_if_not_ready(harness):
 def test_client_relation_created_adds_user(harness):
     """Checks if new users are added on clientrelationcreated hook."""
     harness.add_relation(PEER, CHARM_KEY)
-    with patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch("auth.KafkaAuth.add_user") as patched_add_user:
+    with (
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("auth.KafkaAuth.add_user") as patched_add_user,
+    ):
         harness.set_leader(True)
         client_rel_id = harness.add_relation(REL_NAME, "app")
 
@@ -70,14 +71,12 @@ def test_client_relation_created_adds_user(harness):
 def test_client_relation_broken_removes_user(harness):
     """Checks if users are removed on clientrelationbroken hook."""
     harness.add_relation(PEER, CHARM_KEY)
-    with patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch("auth.KafkaAuth.add_user"), patch(
-        "auth.KafkaAuth.delete_user"
-    ) as patched_delete_user, patch(
-        "auth.KafkaAuth.remove_all_user_acls"
-    ) as patched_remove_acls, patch(
-        "snap.KafkaSnap.run_bin_command"
+    with (
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("auth.KafkaAuth.add_user"),
+        patch("auth.KafkaAuth.delete_user") as patched_delete_user,
+        patch("auth.KafkaAuth.remove_all_user_acls") as patched_remove_acls,
+        patch("snap.KafkaSnap.run_bin_command"),
     ):
         harness.set_leader(True)
         client_rel_id = harness.add_relation(REL_NAME, "app")
@@ -98,14 +97,18 @@ def test_client_relation_broken_removes_user(harness):
 def test_client_relation_joined_sets_necessary_relation_data(harness):
     """Checks if all needed provider relation data is set on clientrelationjoined hook."""
     harness.add_relation(PEER, CHARM_KEY)
-    with patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch("auth.KafkaAuth.add_user"), patch("snap.KafkaSnap.run_bin_command"), patch(
-        "config.KafkaConfig.zookeeper_connected", new_callable=PropertyMock, return_value=True
-    ), patch(
-        "config.KafkaConfig.zookeeper_config",
-        new_callable=PropertyMock,
-        return_value={"connect": "yes"},
+    with (
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("auth.KafkaAuth.add_user"),
+        patch("snap.KafkaSnap.run_bin_command"),
+        patch(
+            "config.KafkaConfig.zookeeper_connected", new_callable=PropertyMock, return_value=True
+        ),
+        patch(
+            "config.KafkaConfig.zookeeper_config",
+            new_callable=PropertyMock,
+            return_value={"connect": "yes"},
+        ),
     ):
         harness.set_leader(True)
         client_rel_id = harness.add_relation(REL_NAME, "app")

--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -102,6 +103,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_charm.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -116,6 +118,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_provider.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -130,6 +133,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_scaling.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -144,6 +148,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_password_rotation.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -158,6 +163,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_tls.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Changes Made
- `feat: added conditional logging + status messages during storage events`
    - Adding/Removing storage is fairly destructive and will require manual intervention from an administrator to return cluster to a healthy state 
- `feat: rolling-restart units during storage events`
    - Needed to actually update kafka service to use new `log.dirs` 
- `feat: set storage range to allow for 1 storage only`
    - This will be used in development
- `style: use parameterized context managers in unittests`
    - Aesthetic preference 