### PR TITLE
test: add test to ensure log data written to mounted volumes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -96,8 +96,10 @@ class KafkaCharm(CharmBase):
 
         # new dirs won't be used until topic partitions are assigned to it
         # either automatically for new topics, or manually for existing
-        message = "manual partition reassignment needed to use new storage"
-        logger.warning(f"Attaching storage - {message}")
+        message = (
+            "manual partition reassignment may be needed for Kafka to utilize new storage volumes"
+        )
+        logger.warning(f"attaching storage - {message}")
         self.unit.status = ActiveStatus(message)
 
         self._on_config_changed(event)
@@ -112,12 +114,12 @@ class KafkaCharm(CharmBase):
 
         # in the case where there may be replication recovery may be possible
         if self.peer_relation and len(self.peer_relation.units):
-            message = "manual partition reassignment suggested due to potential log data loss"
-            logger.warning(f"Removing storage - {message}")
+            message = "manual partition reassignment from replicated brokers recommended due to lost partitions on removed storage volumes"
+            logger.warning(f"removing storage - {message}")
             self.unit.status = BlockedStatus(message)
         else:
-            message = "potential log-data loss"
-            logger.error(f"Removing storage - {message}")
+            message = "potential log-data loss due to storage removal without replication"
+            logger.error(f"removing storage - {message}")
             self.unit.status = BlockedStatus(message)
 
         self._on_config_changed(event)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,11 +4,20 @@
 
 import asyncio
 import logging
+import time
+from asyncio.subprocess import PIPE
+from subprocess import check_output
 
 import pytest
+from client import KafkaClient
 from pytest_operator.plugin import OpsTest
 
+from literals import CHARM_KEY
+from tests.integration.helpers import get_provider_data
+
 logger = logging.getLogger(__name__)
+
+DUMMY_NAME = "app"
 
 
 @pytest.mark.abort_on_fail
@@ -16,7 +25,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     kafka_charm = await ops_test.build_charm(".")
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=1, series="focal"
         ),
         ops_test.model.deploy(kafka_charm, application_name="kafka", num_units=1, series="jammy"),
     )
@@ -28,3 +37,66 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(apps=["kafka", "zookeeper"])
     assert ops_test.model.applications["kafka"].status == "active"
     assert ops_test.model.applications["zookeeper"].status == "active"
+
+
+@pytest.mark.abort_on_fail
+async def test_logs_write_to_storage(ops_test: OpsTest):
+    app_charm = await ops_test.build_charm("tests/integration/app-charm")
+    await asyncio.gather(
+        ops_test.model.deploy(app_charm, application_name=DUMMY_NAME, num_units=1, series="jammy"),
+    )
+    await ops_test.model.wait_for_idle(apps=[CHARM_KEY, DUMMY_NAME])
+    await ops_test.model.add_relation(CHARM_KEY, DUMMY_NAME)
+    time.sleep(10)
+    assert ops_test.model.applications[CHARM_KEY].status == "active"
+    assert ops_test.model.applications[DUMMY_NAME].status == "active"
+
+    # run action to enable producer
+    action = await ops_test.model.units.get(f"{DUMMY_NAME}/0").run_action("make-admin")
+    await action.wait()
+    time.sleep(10)
+    await ops_test.model.wait_for_idle(apps=[CHARM_KEY, DUMMY_NAME])
+    assert ops_test.model.applications[CHARM_KEY].status == "active"
+    assert ops_test.model.applications[DUMMY_NAME].status == "active"
+
+    relation_data = get_provider_data(
+        unit_name=f"{DUMMY_NAME}/0", model_full_name=ops_test.model_full_name
+    )
+    logger.debug(f"{relation_data=}")
+
+    topic = "new-topic"
+    username = relation_data.get("username", None)
+    password = relation_data.get("password", None)
+    servers = relation_data.get("uris", "").split(",")
+    security_protocol = "SASL_PLAINTEXT"
+
+    if not (username and password and servers):
+        pytest.fail("missing relation data from app charm")
+
+    client = KafkaClient(
+        servers=servers,
+        username=username,
+        password=password,
+        topic=topic,
+        consumer_group_prefix=None,
+        security_protocol=security_protocol,
+    )
+
+    client.create_topic()
+    client.run_producer()
+
+    logs = check_output(
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'find /var/snap/kafka/common/log-data'",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    ).splitlines()
+
+    logger.debug(f"{logs=}")
+
+    passed = False
+    for log in logs:
+        if topic and "index" in log:
+            passed = True
+
+    assert passed, "logs not written to log directory"


### PR DESCRIPTION
## Changes Made
##### `test: add  test to ensure log data written to mounted volumes`
- Test spins up existing `app-charm` charm, sets the charm to be able to create topics + produce, then pings HackerNews to get some messages to write to a new topic
- These topic logs and their metadata will populate the mounted `log-data` directory, which then gets checked

## TODO
- Test that during `storage_attached` events, new topics successfully write to them
    - Currently due to snap confinement this isn't solved without a workaround of `snap disable kafka && snap enable kafka` as mounted volumes aren't exposed to a confined Snap by default, only at snap `enable`. Am looking into this to see if there's a better solution with Snap team