### PR TITLE
feat: disable+enable snap service on storage events

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -67,6 +67,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from subprocess import CalledProcessError, CompletedProcess
 from typing import Any, Dict, Iterable, List, Optional, Union
@@ -81,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 6
 
 
 def _cache_init(func):
@@ -283,6 +284,15 @@ class Snap(object):
         command: List[str],
         services: Optional[List[str]] = None,
     ) -> CompletedProcess:
+        """Perform snap app commands.
+
+        Args:
+          command: the snap command to execute
+          services: the snap service to execute command on
+
+        Raises:
+          SnapError if there is a problem encountered
+        """
 
         if services:
             # an attempt to keep the command constrained to the snap instance's services
@@ -353,6 +363,32 @@ class Snap(object):
         """
         args = ["logs", "-n={}".format(num_lines)] if num_lines else ["logs"]
         return self._snap_daemons(args, services).stdout
+
+    def connect(
+        self, plug: Optional[str] = None, service: Optional[str] = None, slot: Optional[str] = None
+    ) -> None:
+        """Connects a plug to a slot.
+
+        Args:
+            plug (str): the plug to connect
+            service (str): (optional) the snap service name to plug into
+            slot (str): (optional) the snap service slot to plug in to
+
+        Raises:
+            SnapError if there is a problem encountered
+        """
+        command = ["connect", "{}:{}".format(self._name, plug)]
+
+        if service and slot:
+            command = command + ["{}:{}".format(service, slot)]
+        elif slot:
+            command = command + [slot]
+
+        _cmd = ["snap", *command]
+        try:
+            subprocess.run(_cmd, universal_newlines=True, check=True, capture_output=True)
+        except CalledProcessError as e:
+            raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
 
     def restart(
         self, services: Optional[List[str]] = None, reload: Optional[bool] = False
@@ -884,7 +920,7 @@ def _wrap_snap_operations(
 
 
 def install_local(
-    self, filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
+    filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
 ) -> Snap:
     """Perform a snap operation.
 
@@ -900,9 +936,11 @@ def install_local(
         "snap",
         "install",
         filename,
-        "--classic" if classic else "",
-        "--dangerous" if dangerous else "",
     ]
+    if classic:
+        _cmd.append("--classic")
+    if dangerous:
+        _cmd.append("--dangerous")
     try:
         result = subprocess.check_output(_cmd, universal_newlines=True).splitlines()[0]
         snap_name, _ = result.split(" ", 1)
@@ -912,3 +950,41 @@ def install_local(
         return c[snap_name]
     except CalledProcessError as e:
         raise SnapError("Could not install snap {}: {}".format(filename, e.output))
+
+
+def _system_set(config_item: str, value: str) -> None:
+    """Helper for setting snap system config values.
+
+    Args:
+        config_item: name of snap system setting. E.g. 'refresh.hold'
+        value: value to assign
+    """
+    _cmd = ["snap", "set", "system", "{}={}".format(config_item, value)]
+    try:
+        subprocess.check_call(_cmd, universal_newlines=True)
+    except CalledProcessError:
+        raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
+
+
+def hold_refresh(days: int = 90) -> bool:
+    """Set the system-wide snap refresh hold.
+
+    Args:
+        days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
+    """
+    # Currently the snap daemon can only hold for a maximum of 90 days
+    if not isinstance(days, int) or days > 90:
+        raise ValueError("days must be an int between 1 and 90")
+    elif days == 0:
+        _system_set("refresh.hold", "")
+        logger.info("Removed system-wide snap refresh hold")
+    else:
+        # Add the number of days to current time
+        target_date = datetime.now(timezone.utc).astimezone() + timedelta(days=days)
+        # Format for the correct datetime format
+        hold_date = target_date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        # Python dumps the offset in format '+0100', we need '+01:00'
+        hold_date = "{0}:{1}".format(hold_date[:-2], hold_date[-2:])
+        # Actually set the hold date
+        _system_set("refresh.hold", hold_date)
+        logger.info("Set system-wide snap refresh hold to: %s", hold_date)

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -365,7 +365,7 @@ class Snap(object):
         return self._snap_daemons(args, services).stdout
 
     def connect(
-        self, plug: Optional[str] = None, service: Optional[str] = None, slot: Optional[str] = None
+        self, plug: str, service: Optional[str] = None, slot: Optional[str] = None
     ) -> None:
         """Connects a plug to a slot.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -236,8 +236,7 @@ class KafkaCharm(CharmBase):
             self.kafka_config.set_server_properties()
 
             if isinstance(event, StorageEvent):  # to get new storages
-                subprocess.run(["snap", "disable", "kafka"], shell=True)
-                subprocess.run(["snap", "enable", "kafka"], shell=True)
+                self.snap.disable_enable("kafka")
                 return
             else:
                 self.on[f"{self.restart.name}"].acquire_lock.emit()

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,7 +102,6 @@ class KafkaCharm(CharmBase):
         logger.warning(f"attaching storage - {message}")
         self.unit.status = ActiveStatus(message)
 
-        self.unit_peer_data.update({"storage-changed": "true"})
         self._on_config_changed(event)
 
     def _on_storage_detaching(self, event: StorageDetachingEvent) -> None:
@@ -123,7 +122,6 @@ class KafkaCharm(CharmBase):
             logger.error(f"removing storage - {message}")
             self.unit.status = BlockedStatus(message)
 
-        self.unit_peer_data.update({"storage-changed": "true"})
         self._on_config_changed(event)
 
     def _on_install(self, _) -> None:
@@ -236,16 +234,7 @@ class KafkaCharm(CharmBase):
             )
             self.kafka_config.set_server_properties()
 
-            if self.unit_peer_data.get("storage-changed", None):
-                # calling override restart to see new storage mounts
-                self.on[f"{self.restart.name}"].acquire_lock.emit(
-                    callback_override="_disable_enable_snap"
-                )
-                self.unit_peer_data.update(
-                    {"storage-changed": ""}
-                )  # unsetting after restart event called
-            else:
-                self.on[f"{self.restart.name}"].acquire_lock.emit()
+            self.on[f"{self.restart.name}"].acquire_lock.emit()
 
         # If Kafka is related to client charms, update their information.
         if self.model.relations.get(REL_NAME, None) and self.unit.is_leader():
@@ -258,24 +247,6 @@ class KafkaCharm(CharmBase):
             return
 
         self.snap.restart_snap_service("kafka")
-
-    def _disable_enable_snap(self, event: EventBase) -> None:
-        """Callback override for `rolling_ops` restart events.
-
-        This is needed as standard `restart snap` does not re-load mounted volumes
-        We instead have to `stop`+`disable` then `enable`+`start`
-        """
-        if not self.ready_to_start:
-            event.defer()
-            return
-
-        # FIXME: there is probably a smart snap plug for fixing this
-        subprocess.check_output(
-            "snap disable kafka && snap enable kafka",
-            stderr=subprocess.PIPE,
-            shell=True,
-            universal_newlines=True,
-        )
 
     def _set_password_action(self, event: ActionEvent) -> None:
         """Handler for set-password action.

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@ from ops.charm import (
     RelationJoinedEvent,
     StorageAttachedEvent,
     StorageDetachingEvent,
+    StorageEvent,
 )
 from ops.framework import EventBase
 from ops.main import main
@@ -234,7 +235,12 @@ class KafkaCharm(CharmBase):
             )
             self.kafka_config.set_server_properties()
 
-            self.on[f"{self.restart.name}"].acquire_lock.emit()
+            if isinstance(event, StorageEvent):  # to get new storages
+                subprocess.run(["snap", "disable", "kafka"], shell=True)
+                subprocess.run(["snap", "enable", "kafka"], shell=True)
+                return
+            else:
+                self.on[f"{self.restart.name}"].acquire_lock.emit()
 
         # If Kafka is related to client charms, update their information.
         if self.model.relations.get(REL_NAME, None) and self.unit.is_leader():

--- a/src/snap.py
+++ b/src/snap.py
@@ -97,6 +97,20 @@ class KafkaSnap:
             logger.exception(str(e))
             return False
 
+    def disable_enable(self, snap_service: str) -> None:
+        """Disables then enables snap service.
+
+        Necessary for snap services to recognise new storage mounts
+
+        Args:
+            snap_service: The desired service to disable+enable
+
+        Raises:
+            subprocess.CalledProcessError if error occurs
+        """
+        subprocess.run(f"snap disable {snap_service}", shell=True)
+        subprocess.run(f"snap enable {snap_service}", shell=True)
+
     @staticmethod
     def run_bin_command(bin_keyword: str, bin_args: List[str], opts: List[str]) -> str:
         """Runs kafka bin command with desired args.

--- a/src/snap.py
+++ b/src/snap.py
@@ -40,6 +40,7 @@ class KafkaSnap:
                 kafka.ensure(snap.SnapState.Latest, channel="rock/edge")
 
             self.kafka = kafka
+            self.kafka.connect(plug="removable-media")
             return True
         except (snap.SnapError, apt.PackageNotFoundError) as e:
             logger.error(str(e))

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -220,3 +220,5 @@ def produce_and_check_logs(
     for log in logs:
         if topic and "index" in log:
             passed = True
+
+    assert passed, "logs not found"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
+import logging
 import re
 from pathlib import Path
 from subprocess import PIPE, check_output
 from typing import Any, Dict, List, Set, Tuple
 
 import yaml
+from client import KafkaClient
 from pytest_operator.plugin import OpsTest
 
 from auth import Acl, KafkaAuth
@@ -14,6 +16,8 @@ from auth import Acl, KafkaAuth
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 ZK_NAME = "zookeeper"
+
+logger = logging.getLogger(__name__)
 
 
 def load_acls(model_full_name: str, zookeeper_uri: str) -> Set[Acl]:
@@ -161,3 +165,61 @@ def check_tls(ip: str, port: int) -> bool:
     # from self-signed certificates. This is indication enough that the server is sending a
     # self-signed key.
     assert "CN = kafka" in result
+
+
+def produce_and_check_logs(
+    model_full_name: str, kafka_unit_name: str, provider_unit_name: str, topic: str
+) -> None:
+    """Produces messages from HN to chosen Kafka topic.
+
+    Args:
+        model_full_name: the full name of the model
+        kafka_unit_name: the kafka unit to checks logs on
+        proider_unit_name: the app to grab credentials from
+        topic: the desired topic to produce to
+
+    Raises:
+        KeyError: if missing relation data
+        AssertionError: if logs aren't found for desired topic
+    """
+    relation_data = get_provider_data(
+        unit_name=provider_unit_name, model_full_name=model_full_name
+    )
+    logger.debug(f"{relation_data=}")
+
+    topic = topic
+    username = relation_data.get("username", None)
+    password = relation_data.get("password", None)
+    servers = relation_data.get("uris", "").split(",")
+    security_protocol = "SASL_PLAINTEXT"
+
+    if not (username and password and servers):
+        raise KeyError("missing relation data from app charm")
+
+    client = KafkaClient(
+        servers=servers,
+        username=username,
+        password=password,
+        topic=topic,
+        consumer_group_prefix=None,
+        security_protocol=security_protocol,
+    )
+
+    client.create_topic()
+    client.run_producer()
+
+    logs = check_output(
+        f"JUJU_MODEL={model_full_name} juju ssh {kafka_unit_name} 'find /var/snap/kafka/common/log-data'",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    ).splitlines()
+
+    logger.debug(f"{logs=}")
+
+    passed = False
+    for log in logs:
+        if topic and "index" in log:
+            passed = True
+
+    assert passed, "logs not written to log directory"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -220,5 +220,6 @@ def produce_and_check_logs(
     for log in logs:
         if topic and "index" in log:
             passed = True
+            break
 
     assert passed, "logs not found"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -185,7 +185,6 @@ def produce_and_check_logs(
     relation_data = get_provider_data(
         unit_name=provider_unit_name, model_full_name=model_full_name
     )
-    logger.debug(f"{relation_data=}")
 
     topic = topic
     username = relation_data.get("username", None)
@@ -221,5 +220,3 @@ def produce_and_check_logs(
     for log in logs:
         if topic and "index" in log:
             passed = True
-
-    assert passed, "logs not written to log directory"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,7 +5,7 @@
 import asyncio
 import logging
 import time
-from subprocess import check_output
+from subprocess import PIPE, check_output
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -66,9 +66,15 @@ async def test_logs_write_to_storage(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.skip  # skipping as we can't add storage without losing Juju conn
 async def test_logs_write_to_new_storage(ops_test: OpsTest):
-    check_output(f"JUJU_MODEL={ops_test.model_full_name} juju add-storage kafka/0 log-data")
-    time.sleep(10)  # to give time for storage to complete
+    check_output(
+        f"JUJU_MODEL={ops_test.model_full_name} juju add-storage kafka/0 log-data",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+    time.sleep(5)  # to give time for storage to complete
 
     produce_and_check_logs(
         model_full_name=ops_test.model_full_name,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,15 +5,13 @@
 import asyncio
 import logging
 import time
-from asyncio.subprocess import PIPE
 from subprocess import check_output
 
 import pytest
-from client import KafkaClient
 from pytest_operator.plugin import OpsTest
 
 from literals import CHARM_KEY
-from tests.integration.helpers import get_provider_data
+from tests.integration.helpers import produce_and_check_logs
 
 logger = logging.getLogger(__name__)
 
@@ -59,75 +57,22 @@ async def test_logs_write_to_storage(ops_test: OpsTest):
     assert ops_test.model.applications[CHARM_KEY].status == "active"
     assert ops_test.model.applications[DUMMY_NAME].status == "active"
 
-    relation_data = get_provider_data(
-        unit_name=f"{DUMMY_NAME}/0", model_full_name=ops_test.model_full_name
-    )
-    logger.debug(f"{relation_data=}")
-
-    topic = "new-topic"
-    username = relation_data.get("username", None)
-    password = relation_data.get("password", None)
-    servers = relation_data.get("uris", "").split(",")
-    security_protocol = "SASL_PLAINTEXT"
-
-    if not (username and password and servers):
-        pytest.fail("missing relation data from app charm")
-
-    client = KafkaClient(
-        servers=servers,
-        username=username,
-        password=password,
-        topic=topic,
-        consumer_group_prefix=None,
-        security_protocol=security_protocol,
+    produce_and_check_logs(
+        model_full_name=ops_test.model_full_name,
+        kafka_unit_name="kafka/0",
+        provider_unit_name=f"{DUMMY_NAME}/0",
+        topic="hot-topic",
     )
 
-    client.create_topic()
-    client.run_producer()
 
-    logs = check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'find /var/snap/kafka/common/log-data'",
-        stderr=PIPE,
-        shell=True,
-        universal_newlines=True,
-    ).splitlines()
+@pytest.mark.abort_on_fail
+async def test_logs_write_to_new_storage(ops_test: OpsTest):
+    check_output(f"JUJU_MODEL={ops_test.model_full_name} juju add-storage kafka/0 log-data")
+    time.sleep(10)  # to give time for storage to complete
 
-    logger.debug(f"{logs=}")
-
-    passed = False
-    for log in logs:
-        if topic and "index" in log:
-            passed = True
-
-    assert passed, "logs not written to log directory"
-
-    topic = "brand-new-topic"
-    client = KafkaClient(
-        servers=servers,
-        username=username,
-        password=password,
-        topic=topic,
-        consumer_group_prefix=None,
-        security_protocol=security_protocol,
+    produce_and_check_logs(
+        model_full_name=ops_test.model_full_name,
+        kafka_unit_name="kafka/0",
+        provider_unit_name=f"{DUMMY_NAME}/0",
+        topic="cold-topic",
     )
-
-    client.create_topic()
-    client.run_producer()
-
-    logs = check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'find /var/snap/kafka/common/log-data'",
-        stderr=PIPE,
-        shell=True,
-        universal_newlines=True,
-    ).splitlines()
-
-    logger.debug(f"{logs=}")
-
-    passed = False
-    for log in logs:
-        if topic and "index" in log:
-            passed = True
-
-    assert passed, "new logs not written to new log directory"
-
-

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -325,21 +325,22 @@ def test_storage_add_remove_triggers_restart(harness):
     harness.set_leader(True)
 
     with (
-        patch("snap.KafkaSnap.restart_snap_service") as patched_restart_snap_service,
+        patch("snap.KafkaSnap.restart_snap_service") as patched_disable_enable,
         patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
         patch("charm.safe_get_file", return_value=["log.dirs=/var/snap/kafka/common/logs/0"]),
         patch("config.KafkaConfig.set_server_properties"),
         patch("charm.broker_active", return_value=True),
+        patch("snap.KafkaSnap.disable_enable") as patched_disable_enable,
     ):
         harness.add_storage(storage_name="log-data", count=2)
         harness.attach_storage(storage_id="log-data/1")
-        patched_restart_snap_service.assert_called_once()
+        patched_disable_enable.assert_called_once()
         assert not isinstance(harness.charm.unit.status, BlockedStatus)
 
-        patched_restart_snap_service.reset_mock()
+        patched_disable_enable.reset_mock()
 
         harness.remove_storage(storage_id="log-data/1")
-        patched_restart_snap_service.assert_called_once()
+        patched_disable_enable.assert_called_once()
 
 
 def test_config_changed_updates_properties(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -325,7 +325,7 @@ def test_storage_add_remove_triggers_restart(harness):
     harness.set_leader(True)
 
     with (
-        patch("snap.KafkaSnap.restart_snap_service") as patched_restart_snap_service,
+        patch("charm.KafkaCharm._disable_enable_snap") as patched_disable_enable_snap,
         patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
         patch("charm.safe_get_file", return_value=["log.dirs=/var/snap/kafka/common/logs/0"]),
         patch("config.KafkaConfig.set_server_properties"),
@@ -333,13 +333,13 @@ def test_storage_add_remove_triggers_restart(harness):
     ):
         harness.add_storage(storage_name="log-data", count=2)
         harness.attach_storage(storage_id="log-data/1")
-        patched_restart_snap_service.assert_called_once()
+        patched_disable_enable_snap.assert_called_once()
         assert not isinstance(harness.charm.unit.status, BlockedStatus)
 
-        patched_restart_snap_service.reset_mock()
+        patched_disable_enable_snap.reset_mock()
 
         harness.remove_storage(storage_id="log-data/1")
-        patched_restart_snap_service.assert_called_once()
+        patched_disable_enable_snap.assert_called_once()
 
 
 def test_config_changed_updates_properties(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -325,7 +325,7 @@ def test_storage_add_remove_triggers_restart(harness):
     harness.set_leader(True)
 
     with (
-        patch("charm.KafkaCharm._disable_enable_snap") as patched_disable_enable_snap,
+        patch("snap.KafkaSnap.restart_snap_service") as patched_restart_snap_service,
         patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
         patch("charm.safe_get_file", return_value=["log.dirs=/var/snap/kafka/common/logs/0"]),
         patch("config.KafkaConfig.set_server_properties"),
@@ -333,13 +333,13 @@ def test_storage_add_remove_triggers_restart(harness):
     ):
         harness.add_storage(storage_name="log-data", count=2)
         harness.attach_storage(storage_id="log-data/1")
-        patched_disable_enable_snap.assert_called_once()
+        patched_restart_snap_service.assert_called_once()
         assert not isinstance(harness.charm.unit.status, BlockedStatus)
 
-        patched_disable_enable_snap.reset_mock()
+        patched_restart_snap_service.reset_mock()
 
         harness.remove_storage(storage_id="log-data/1")
-        patched_disable_enable_snap.assert_called_once()
+        patched_restart_snap_service.assert_called_once()
 
 
 def test_config_changed_updates_properties(harness):

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ description = Check code against coding style standards
 deps =
     black
     flake8
-    flake8-docstrings
+    flake8-docstrings==1.6.0
     flake8-copyright
     flake8-builtins
     pyproject-flake8


### PR DESCRIPTION
## Changes Made
##### `feat: disable+enable snap service on storage events`
- This is needed as new storage mounts aren't found by the snap, even with plug `removable-devices`. This is likely a bug, but am unable to resolve without this workaround