### PR TITLE
feat: add storage support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
 
   integration-charm:
     name: Integration tests for (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -46,7 +46,7 @@ jobs:
 
   integration-provider:
     name: Integration tests for provider (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -63,7 +63,7 @@ jobs:
 
   integration-scaling:
     name: Integration tests for scaling (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -80,7 +80,7 @@ jobs:
 
   integration-password-rotation:
     name: Integration tests for password rotation (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -97,7 +97,7 @@ jobs:
 
   integration-tls:
     name: Integration tests for TLS (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release to latest/edge
+name: Release to 22.04/edge
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 jobs:
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
 
   integration-charm:
     name: Integration tests for (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -61,7 +61,7 @@ jobs:
 
   integration-provider:
     name: Integration tests for provider (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -79,7 +79,7 @@ jobs:
 
   integration-scaling:
     name: Integration tests for scaling (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -97,7 +97,7 @@ jobs:
 
   integration-password-rotation:
     name: Integration tests for password rotation (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -115,7 +115,7 @@ jobs:
 
   integration-tls:
     name: Integration tests for TLS (lxd)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - unit-test
@@ -142,7 +142,7 @@ jobs:
       - integration-scaling
       - integration-password-rotation
       - integration-tls
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,6 +4,8 @@
 type: charm
 parts:
   charm:
+    charm-binary-python-packages:
+      - setuptools
     build-packages:
       - libffi-dev
       - libssl-dev
@@ -12,7 +14,7 @@ parts:
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -67,6 +67,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from subprocess import CalledProcessError, CompletedProcess
 from typing import Any, Dict, Iterable, List, Optional, Union
@@ -81,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 6
 
 
 def _cache_init(func):
@@ -283,6 +284,15 @@ class Snap(object):
         command: List[str],
         services: Optional[List[str]] = None,
     ) -> CompletedProcess:
+        """Perform snap app commands.
+
+        Args:
+          command: the snap command to execute
+          services: the snap service to execute command on
+
+        Raises:
+          SnapError if there is a problem encountered
+        """
 
         if services:
             # an attempt to keep the command constrained to the snap instance's services
@@ -353,6 +363,32 @@ class Snap(object):
         """
         args = ["logs", "-n={}".format(num_lines)] if num_lines else ["logs"]
         return self._snap_daemons(args, services).stdout
+
+    def connect(
+        self, plug: str, service: Optional[str] = None, slot: Optional[str] = None
+    ) -> None:
+        """Connects a plug to a slot.
+
+        Args:
+            plug (str): the plug to connect
+            service (str): (optional) the snap service name to plug into
+            slot (str): (optional) the snap service slot to plug in to
+
+        Raises:
+            SnapError if there is a problem encountered
+        """
+        command = ["connect", "{}:{}".format(self._name, plug)]
+
+        if service and slot:
+            command = command + ["{}:{}".format(service, slot)]
+        elif slot:
+            command = command + [slot]
+
+        _cmd = ["snap", *command]
+        try:
+            subprocess.run(_cmd, universal_newlines=True, check=True, capture_output=True)
+        except CalledProcessError as e:
+            raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
 
     def restart(
         self, services: Optional[List[str]] = None, reload: Optional[bool] = False
@@ -884,7 +920,7 @@ def _wrap_snap_operations(
 
 
 def install_local(
-    self, filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
+    filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
 ) -> Snap:
     """Perform a snap operation.
 
@@ -900,9 +936,11 @@ def install_local(
         "snap",
         "install",
         filename,
-        "--classic" if classic else "",
-        "--dangerous" if dangerous else "",
     ]
+    if classic:
+        _cmd.append("--classic")
+    if dangerous:
+        _cmd.append("--dangerous")
     try:
         result = subprocess.check_output(_cmd, universal_newlines=True).splitlines()[0]
         snap_name, _ = result.split(" ", 1)
@@ -912,3 +950,41 @@ def install_local(
         return c[snap_name]
     except CalledProcessError as e:
         raise SnapError("Could not install snap {}: {}".format(filename, e.output))
+
+
+def _system_set(config_item: str, value: str) -> None:
+    """Helper for setting snap system config values.
+
+    Args:
+        config_item: name of snap system setting. E.g. 'refresh.hold'
+        value: value to assign
+    """
+    _cmd = ["snap", "set", "system", "{}={}".format(config_item, value)]
+    try:
+        subprocess.check_call(_cmd, universal_newlines=True)
+    except CalledProcessError:
+        raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
+
+
+def hold_refresh(days: int = 90) -> bool:
+    """Set the system-wide snap refresh hold.
+
+    Args:
+        days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
+    """
+    # Currently the snap daemon can only hold for a maximum of 90 days
+    if not isinstance(days, int) or days > 90:
+        raise ValueError("days must be an int between 1 and 90")
+    elif days == 0:
+        _system_set("refresh.hold", "")
+        logger.info("Removed system-wide snap refresh hold")
+    else:
+        # Add the number of days to current time
+        target_date = datetime.now(timezone.utc).astimezone() + timedelta(days=days)
+        # Format for the correct datetime format
+        hold_date = target_date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        # Python dumps the offset in format '+0100', we need '+01:00'
+        hold_date = "{0}:{1}".format(hold_date[:-2], hold_date[-2:])
+        # Actually set the hold date
+        _system_set("refresh.hold", hold_date)
+        logger.info("Set system-wide snap refresh hold to: %s", hold_date)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,6 +24,7 @@ requires:
   certificates:
     interface: tls-certificates
     limit: 1
+    optional: true
 
 provides:
   kafka-client:
@@ -33,7 +34,7 @@ storage:
   log-data:
     type: filesystem
     description: Directories where the log data is stored
-    minimum-size: 50M
+    minimum-size: 10G
     location: /var/snap/kafka/common
     multiple:
-      range: 1-12
+      range: 1-

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,4 +36,4 @@ storage:
     minimum-size: 50M
     location: /var/snap/kafka/common
     multiple:
-      range: "12"
+      range: 1-12

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,6 +9,8 @@ description: |
   ""
 maintainers:
   - Marc Oppenheimer <marc.oppenheimer@canonical.com>
+series:
+  - jammy
 
 peers:
   cluster:
@@ -26,3 +28,12 @@ requires:
 provides:
   kafka-client:
     interface: kafka_client
+
+storage:
+  log-data:
+    type: filesystem
+    description: Directories where the log data is stored
+    minimum-size: 50M
+    location: /var/snap/kafka/common
+    multiple:
+      range: "12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops >= 1.5.0
+ops >= 1.5.3
 kazoo >= 2.8.0
 tenacity >= 8.0.1
 pure-sasl >= 0.6.2

--- a/src/charm.py
+++ b/src/charm.py
@@ -96,8 +96,10 @@ class KafkaCharm(CharmBase):
 
         # new dirs won't be used until topic partitions are assigned to it
         # either automatically for new topics, or manually for existing
-        message = "manual partition reassignment needed to use new storage"
-        logger.warning(f"Attaching storage - {message}")
+        message = (
+            "manual partition reassignment may be needed for Kafka to utilize new storage volumes"
+        )
+        logger.warning(f"attaching storage - {message}")
         self.unit.status = ActiveStatus(message)
 
         self._on_config_changed(event)
@@ -112,12 +114,12 @@ class KafkaCharm(CharmBase):
 
         # in the case where there may be replication recovery may be possible
         if self.peer_relation and len(self.peer_relation.units):
-            message = "manual partition reassignment suggested due to potential log data loss"
-            logger.warning(f"Removing storage - {message}")
+            message = "manual partition reassignment from replicated brokers recommended due to lost partitions on removed storage volumes"
+            logger.warning(f"removing storage - {message}")
             self.unit.status = BlockedStatus(message)
         else:
-            message = "potential log-data loss"
-            logger.error(f"Removing storage - {message}")
+            message = "potential log-data loss due to storage removal without replication"
+            logger.error(f"removing storage - {message}")
             self.unit.status = BlockedStatus(message)
 
         self._on_config_changed(event)

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@ from ops.charm import (
     RelationJoinedEvent,
     StorageAttachedEvent,
     StorageDetachingEvent,
+    StorageEvent,
 )
 from ops.framework import EventBase
 from ops.main import main
@@ -234,7 +235,11 @@ class KafkaCharm(CharmBase):
             )
             self.kafka_config.set_server_properties()
 
-            self.on[f"{self.restart.name}"].acquire_lock.emit()
+            if isinstance(event, StorageEvent):  # to get new storages
+                self.snap.disable_enable("kafka")
+                return
+            else:
+                self.on[f"{self.restart.name}"].acquire_lock.emit()
 
         # If Kafka is related to client charms, update their information.
         if self.model.relations.get(REL_NAME, None) and self.unit.is_leader():

--- a/src/snap.py
+++ b/src/snap.py
@@ -40,6 +40,7 @@ class KafkaSnap:
                 kafka.ensure(snap.SnapState.Latest, channel="rock/edge")
 
             self.kafka = kafka
+            self.kafka.connect(plug="removable-media")
             return True
         except (snap.SnapError, apt.PackageNotFoundError) as e:
             logger.error(str(e))
@@ -95,6 +96,20 @@ class KafkaSnap:
         except snap.SnapError as e:
             logger.exception(str(e))
             return False
+
+    def disable_enable(self, snap_service: str) -> None:
+        """Disables then enables snap service.
+
+        Necessary for snap services to recognise new storage mounts
+
+        Args:
+            snap_service: The desired service to disable+enable
+
+        Raises:
+            subprocess.CalledProcessError if error occurs
+        """
+        subprocess.run(f"snap disable {snap_service}", shell=True)
+        subprocess.run(f"snap enable {snap_service}", shell=True)
 
     @staticmethod
     def run_bin_command(bin_keyword: str, bin_args: List[str], opts: List[str]) -> str:

--- a/tests/integration/app-charm/charmcraft.yaml
+++ b/tests/integration/app-charm/charmcraft.yaml
@@ -5,7 +5,7 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"

--- a/tests/integration/app-charm/metadata.yaml
+++ b/tests/integration/app-charm/metadata.yaml
@@ -7,6 +7,8 @@ description: |
 summary: |
   Dummy charm application meant to be used
   only for testing of the libs in this repository.
+series:
+  - jammy
 
 peers:
   cluster:

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -61,6 +61,11 @@ class ApplicationCharm(CharmBase):
             {"extra-user-roles": "admin,consumer"}
         )
 
+    def _make_producer(self, _):
+        self.model.get_relation(REL_NAME).data[self.app].update(
+            {"extra-user-roles": "admin,consumer,producer"}
+        )
+
     def _remove_admin(self, _):
         self.model.get_relation(REL_NAME).data[self.app].update({"extra-user-roles": "producer"})
 

--- a/tests/integration/client.py
+++ b/tests/integration/client.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import argparse
+import json
+import logging
+import sys
+import time
+from typing import List, Optional
+
+import requests
+from kafka import KafkaAdminClient, KafkaConsumer, KafkaProducer
+from kafka.admin import NewTopic
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+
+class KafkaClient:
+
+    API_VERSION = (2, 5, 0)
+
+    def __init__(
+        self,
+        servers: List[str],
+        username: Optional[str],
+        password: Optional[str],
+        topic: str,
+        consumer_group_prefix: Optional[str],
+        security_protocol: str,
+    ) -> None:
+        self.servers = servers
+        self.username = username
+        self.password = password
+        self.topic = topic
+        self.consumer_group_prefix = consumer_group_prefix
+        self.security_protocol = security_protocol
+
+        self.sasl = "SASL" in self.security_protocol
+        self.ssl = "SSL" in self.security_protocol
+        self.mtls = self.security_protocol == "SSL"
+
+    def create_topic(self):
+        admin_client = KafkaAdminClient(
+            client_id=self.username,
+            bootstrap_servers=self.servers,
+            ssl_check_hostname=False,
+            security_protocol=self.security_protocol,
+            sasl_plain_username=self.username if self.sasl else None,
+            sasl_plain_password=self.password if self.sasl else None,
+            sasl_mechanism="SCRAM-SHA-512" if self.sasl else None,
+            ssl_cafile="certs/ca.pem" if self.ssl else None,
+            ssl_certfile="certs/cert.pem" if self.ssl else None,
+            ssl_keyfile="certs/key.pem" if self.mtls else None,
+            api_version=KafkaClient.API_VERSION if self.mtls else None,
+        )
+
+        topic_list = [NewTopic(name=self.topic, num_partitions=5, replication_factor=1)]
+        admin_client.create_topics(new_topics=topic_list, validate_only=False)
+
+    def run_consumer(self):
+        consumer = KafkaConsumer(
+            self.topic,
+            bootstrap_servers=self.servers,
+            ssl_check_hostname=False,
+            security_protocol=self.security_protocol,
+            sasl_plain_username=self.username if self.sasl else None,
+            sasl_plain_password=self.password if self.sasl else None,
+            sasl_mechanism="SCRAM-SHA-512" if self.sasl else None,
+            ssl_cafile="certs/ca.pem" if self.ssl else None,
+            ssl_certfile="certs/cert.pem" if self.ssl else None,
+            ssl_keyfile="certs/key.pem" if self.mtls else None,
+            api_version=KafkaClient.API_VERSION if self.mtls else None,
+            group_id=self.consumer_group_prefix + "1" if self.consumer_group_prefix else None,
+            enable_auto_commit=True,
+            auto_offset_reset="earliest",
+            consumer_timeout_ms=15000,
+        )
+
+        for message in consumer:
+            logger.info(str(message))
+
+    def run_producer(self):
+        producer = KafkaProducer(
+            bootstrap_servers=self.servers,
+            ssl_check_hostname=False,
+            security_protocol=self.security_protocol,
+            sasl_plain_username=self.username if self.sasl else None,
+            sasl_plain_password=self.password if self.sasl else None,
+            sasl_mechanism="SCRAM-SHA-512" if self.sasl else None,
+            ssl_cafile="certs/ca.pem" if self.ssl else None,
+            ssl_certfile="certs/cert.pem" if self.ssl else None,
+            ssl_keyfile="certs/key.pem" if self.mtls else None,
+            api_version=KafkaClient.API_VERSION if self.mtls else None,
+        )
+
+        for _ in range(3):
+            logger.info("Requesting NewStories from HN...")
+            response = requests.get(
+                url="https://hacker-news.firebaseio.com/v0/newstories.json?print=pretty"
+            )
+            content = json.loads(response._content.decode("utf-8")) if response._content else {}
+
+            if content:
+                logger.info("Successfully retrieved NewStories...")
+            else:
+                logger.warning("Failed retrieving NewStories...")
+                time.sleep(5)
+                continue
+
+            for i, content_id in enumerate(content):
+                if i <= 5:
+                    response = requests.get(
+                        url=f"https://hacker-news.firebaseio.com/v0/item/{content_id}.json"
+                    )
+                    item_content = response._content or b""
+                    item_id = json.loads(item_content.decode("utf-8")).get("id", None)
+                    title = json.loads(item_content.decode("utf-8")).get("title", None)
+                    url = json.loads(item_content.decode("utf-8")).get("url", None)
+
+                    if item_id:
+                        future = producer.send(self.topic, item_content)
+                        future.get(timeout=60)
+                        logger.info(
+                            f"Message published to topic={self.topic}, item_id={item_id}, title={title}, url={url}"
+                        )
+                    else:
+                        logger.warning(f"Missing item_id for content_id={content_id}")
+
+                    time.sleep(5)
+
+                    continue
+                else:
+                    break
+
+            break
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Handler for running a Kafka client")
+    parser.add_argument(
+        "-t",
+        "--topic",
+        help="Kafka topic provided by Kafka Charm",
+        type=str,
+        default="demo",
+    )
+    parser.add_argument(
+        "-u",
+        "--username",
+        help="Kafka username provided by Kafka Charm",
+        type=str,
+    )
+    parser.add_argument(
+        "-p",
+        "--password",
+        help="Kafka password provided by Kafka Charm",
+        type=str,
+    )
+    parser.add_argument(
+        "-c",
+        "--consumer-group-prefix",
+        help="Kafka consumer-group-prefix provided by Kafka Charm",
+        type=str,
+    )
+    parser.add_argument(
+        "-s",
+        "--servers",
+        help="comma delimited list of Kafka bootstrap-server strings",
+        type=str,
+    )
+    parser.add_argument(
+        "-x",
+        "--security-protocol",
+        help="security protocol used for authentication",
+        type=str,
+        default="SASL_PLAINTEXT",
+    )
+
+    parser.add_argument("--producer", action="store_true", default=False)
+    parser.add_argument("--consumer", action="store_true", default=False)
+
+    args = parser.parse_args()
+    servers = args.servers.split(",")
+    if not args.consumer_group_prefix:
+        args.consumer_group_prefix = f"{args.username}-" if args.username else None
+
+    client = KafkaClient(
+        servers=servers,
+        username=args.username,
+        password=args.password,
+        topic=args.topic,
+        consumer_group_prefix=args.consumer_group_prefix,
+        security_protocol=args.security_protocol,
+    )
+
+    if args.producer:
+        logger.info(f"Creating new topic - {args.topic}")
+        client.create_topic()
+        logger.info("--producer - Starting...")
+        producer = client.run_producer()
+    if args.consumer:
+        logger.info("--consumer - Starting...")
+        consumer = client.run_consumer()
+    else:
+        logger.info("No client type args found. Exiting...")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,11 +4,20 @@
 
 import asyncio
 import logging
+import time
+from asyncio.subprocess import PIPE
+from subprocess import check_output
 
 import pytest
+from client import KafkaClient
 from pytest_operator.plugin import OpsTest
 
+from literals import CHARM_KEY
+from tests.integration.helpers import get_provider_data
+
 logger = logging.getLogger(__name__)
+
+DUMMY_NAME = "app"
 
 
 @pytest.mark.abort_on_fail
@@ -16,7 +25,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     kafka_charm = await ops_test.build_charm(".")
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=1, series="focal"
         ),
         ops_test.model.deploy(kafka_charm, application_name="kafka", num_units=1, series="jammy"),
     )
@@ -28,3 +37,66 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(apps=["kafka", "zookeeper"])
     assert ops_test.model.applications["kafka"].status == "active"
     assert ops_test.model.applications["zookeeper"].status == "active"
+
+
+@pytest.mark.abort_on_fail
+async def test_logs_write_to_storage(ops_test: OpsTest):
+    app_charm = await ops_test.build_charm("tests/integration/app-charm")
+    await asyncio.gather(
+        ops_test.model.deploy(app_charm, application_name=DUMMY_NAME, num_units=1, series="jammy"),
+    )
+    await ops_test.model.wait_for_idle(apps=[CHARM_KEY, DUMMY_NAME])
+    await ops_test.model.add_relation(CHARM_KEY, DUMMY_NAME)
+    time.sleep(10)
+    assert ops_test.model.applications[CHARM_KEY].status == "active"
+    assert ops_test.model.applications[DUMMY_NAME].status == "active"
+
+    # run action to enable producer
+    action = await ops_test.model.units.get(f"{DUMMY_NAME}/0").run_action("make-admin")
+    await action.wait()
+    time.sleep(10)
+    await ops_test.model.wait_for_idle(apps=[CHARM_KEY, DUMMY_NAME])
+    assert ops_test.model.applications[CHARM_KEY].status == "active"
+    assert ops_test.model.applications[DUMMY_NAME].status == "active"
+
+    relation_data = get_provider_data(
+        unit_name=f"{DUMMY_NAME}/0", model_full_name=ops_test.model_full_name
+    )
+    logger.debug(f"{relation_data=}")
+
+    topic = "new-topic"
+    username = relation_data.get("username", None)
+    password = relation_data.get("password", None)
+    servers = relation_data.get("uris", "").split(",")
+    security_protocol = "SASL_PLAINTEXT"
+
+    if not (username and password and servers):
+        pytest.fail("missing relation data from app charm")
+
+    client = KafkaClient(
+        servers=servers,
+        username=username,
+        password=password,
+        topic=topic,
+        consumer_group_prefix=None,
+        security_protocol=security_protocol,
+    )
+
+    client.create_topic()
+    client.run_producer()
+
+    logs = check_output(
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'find /var/snap/kafka/common/log-data'",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    ).splitlines()
+
+    logger.debug(f"{logs=}")
+
+    passed = False
+    for log in logs:
+        if topic and "index" in log:
+            passed = True
+
+    assert passed, "logs not written to log directory"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,9 +16,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     kafka_charm = await ops_test.build_charm(".")
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=3
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
         ),
-        ops_test.model.deploy(kafka_charm, application_name="kafka", num_units=1),
+        ops_test.model.deploy(kafka_charm, application_name="kafka", num_units=1, series="jammy"),
     )
     await ops_test.model.wait_for_idle(apps=["kafka", "zookeeper"])
     assert ops_test.model.applications["kafka"].status == "waiting"

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -23,8 +23,10 @@ logger = logging.getLogger(__name__)
 async def test_build_and_deploy(ops_test: OpsTest):
     kafka_charm = await ops_test.build_charm(".")
     await asyncio.gather(
-        ops_test.model.deploy(ZK_NAME, channel="edge", application_name=ZK_NAME, num_units=3),
-        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1),
+        ops_test.model.deploy(
+            ZK_NAME, channel="edge", application_name=ZK_NAME, num_units=3, series="focal"
+        ),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="jammy"),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME])

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -37,10 +37,12 @@ async def test_deploy_charms_relate_active(ops_test: OpsTest, usernames):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=3
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
         ),
-        ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1),
-        ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_1, num_units=1),
+        ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1, series="jammy"),
+        ops_test.model.deploy(
+            app_charm, application_name=DUMMY_NAME_1, num_units=1, series="focal"
+        ),
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_NAME_1, ZK])
     await ops_test.model.add_relation(APP_NAME, ZK)
@@ -177,7 +179,7 @@ async def test_admin_removed_from_super_users(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_connection_updated_on_tls_enabled(ops_test: OpsTest):
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
-    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config)
+    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config, series="focal")
     await ops_test.model.add_relation(TLS_NAME, ZK)
     await ops_test.model.add_relation(TLS_NAME, APP_NAME)
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -28,9 +28,9 @@ async def test_kafka_simple_scale_up(ops_test: OpsTest):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            "zookeeper", channel="edge", application_name="zookeeper", num_units=3
+            "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="focal"
         ),
-        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="jammy"),
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK])
     await ops_test.model.add_relation(APP_NAME, ZK)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -29,9 +29,9 @@ async def test_deploy_tls(ops_test: OpsTest):
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
 
     await asyncio.gather(
-        ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config),
-        ops_test.model.deploy(ZK_NAME, channel="edge", num_units=3),
-        ops_test.model.deploy(kafka_charm, application_name=APP_NAME),
+        ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config, series="focal"),
+        ops_test.model.deploy(ZK_NAME, channel="edge", num_units=3, series="focal"),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, series="jammy"),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME, TLS_NAME], timeout=1000)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,9 +44,10 @@ def harness():
 
 def test_install_sets_opts(harness):
     """Checks KAFKA_OPTS is written to /etc/environment on install hook."""
-    with patch("snap.KafkaSnap.install"), patch(
-        "config.KafkaConfig.set_kafka_opts"
-    ) as patched_kafka_opts:
+    with (
+        patch("snap.KafkaSnap.install"),
+        patch("config.KafkaConfig.set_kafka_opts") as patched_kafka_opts,
+    ):
         harness.charm.on.install.emit()
 
         patched_kafka_opts.assert_called_once()
@@ -54,15 +55,16 @@ def test_install_sets_opts(harness):
 
 def test_install_waits_until_zookeeper_relation(harness):
     """Checks unit goes to WaitingStatus without ZK relation on install hook."""
-    with patch("snap.KafkaSnap.install"), patch("config.KafkaConfig.set_kafka_opts"):
+    with (patch("snap.KafkaSnap.install"), patch("config.KafkaConfig.set_kafka_opts")):
         harness.charm.on.install.emit()
         assert isinstance(harness.charm.unit.status, WaitingStatus)
 
 
 def test_install_blocks_snap_install_failure(harness):
     """Checks unit goes to BlockedStatus after snap failure on install hook."""
-    with patch("snap.KafkaSnap.install", return_value=False), patch(
-        "config.KafkaConfig.set_kafka_opts"
+    with (
+        patch("snap.KafkaSnap.install", return_value=False),
+        patch("config.KafkaConfig.set_kafka_opts"),
     ):
         harness.charm.on.install.emit()
         assert isinstance(harness.charm.unit.status, BlockedStatus)
@@ -127,9 +129,10 @@ def test_start_sets_necessary_config(harness):
         },
     )
 
-    with patch("config.KafkaConfig.set_jaas_config") as patched_jaas, patch(
-        "config.KafkaConfig.set_server_properties"
-    ) as patched_properties:
+    with (
+        patch("config.KafkaConfig.set_jaas_config") as patched_jaas,
+        patch("config.KafkaConfig.set_server_properties") as patched_properties,
+    ):
         harness.charm.on.start.emit()
         patched_jaas.assert_called_once()
         patched_properties.assert_called_once()
@@ -154,11 +157,12 @@ def test_start_sets_auth_and_broker_creds_on_leader(harness):
     )
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
 
-    with patch("auth.KafkaAuth.add_user") as patched_add_user, patch(
-        "config.KafkaConfig.set_jaas_config"
-    ), patch("config.KafkaConfig.set_server_properties"), patch(
-        "charm.broker_active"
-    ) as patched_broker_active:
+    with (
+        patch("auth.KafkaAuth.add_user") as patched_add_user,
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("charm.broker_active") as patched_broker_active,
+    ):
         # verify non-leader does not set creds
         patched_broker_active.retry.wait = wait_none
         harness.charm.on.start.emit()
@@ -191,15 +195,14 @@ def test_start_does_not_start_if_not_ready(harness):
     )
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
 
-    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False
-    ), patch(
-        "snap.KafkaSnap.start_snap_service"
-    ) as patched_start_snap_service, patch(
-        "ops.framework.EventBase.defer"
-    ) as patched_defer:
+    with (
+        patch("auth.KafkaAuth.add_user"),
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False),
+        patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service,
+        patch("ops.framework.EventBase.defer") as patched_defer,
+    ):
         harness.charm.on.start.emit()
 
         patched_start_snap_service.assert_not_called()
@@ -225,9 +228,12 @@ def test_start_does_not_start_if_not_same_tls_as_zk(harness):
     )
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
 
-    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service:
+    with (
+        patch("auth.KafkaAuth.add_user"),
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service,
+    ):
         harness.charm.on.start.emit()
 
         patched_start_snap_service.assert_not_called()
@@ -253,9 +259,11 @@ def test_start_does_not_start_if_leader_has_not_set_creds(harness):
     )
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
 
-    with patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service:
+    with (
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service,
+    ):
         harness.charm.on.start.emit()
 
         patched_start_snap_service.assert_not_called()
@@ -282,11 +290,13 @@ def test_start_blocks_if_service_failed_silently(harness):
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
     harness.set_leader(True)
 
-    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service, patch(
-        "charm.broker_active", return_value=False
-    ) as patched_broker_active:
+    with (
+        patch("auth.KafkaAuth.add_user"),
+        patch("config.KafkaConfig.set_jaas_config"),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service,
+        patch("charm.broker_active", return_value=False) as patched_broker_active,
+    ):
         patched_broker_active.retry.wait = wait_none
         harness.charm.on.start.emit()
 
@@ -294,12 +304,8 @@ def test_start_blocks_if_service_failed_silently(harness):
         assert isinstance(harness.charm.unit.status, BlockedStatus)
 
 
-def test_start_blocks_if_missing_storage(harness):
-    """Checks unit is not ActiveStatus if missing storage mount."""
-    # removing single storage, less than minimum present
-    harness.detach_storage(storage_id="log-data/0")
-    harness.remove_storage(storage_id="log-data/0")
-
+def test_storage_add_remove_triggers_restart(harness):
+    """Checks if unit restarts during storage events."""
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     zk_rel_id = harness.add_relation(ZK, ZK)
     harness.add_relation_unit(zk_rel_id, "zookeeper/0")
@@ -318,16 +324,22 @@ def test_start_blocks_if_missing_storage(harness):
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
     harness.set_leader(True)
 
-    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
-        "config.KafkaConfig.set_server_properties"
-    ), patch("snap.KafkaSnap.start_snap_service") as patched_start_snap_service, patch(
-        "charm.broker_active", return_value=False
-    ) as patched_broker_active:
-        patched_broker_active.retry.wait = wait_none
-        harness.charm.on.start.emit()
+    with (
+        patch("snap.KafkaSnap.restart_snap_service") as patched_restart_snap_service,
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("charm.safe_get_file", return_value=["log.dirs=/var/snap/kafka/common/logs/0"]),
+        patch("config.KafkaConfig.set_server_properties"),
+        patch("charm.broker_active", return_value=True),
+    ):
+        harness.add_storage(storage_name="log-data", count=2)
+        harness.attach_storage(storage_id="log-data/1")
+        patched_restart_snap_service.assert_called_once()
+        assert not isinstance(harness.charm.unit.status, BlockedStatus)
 
-        patched_start_snap_service.assert_not_called()
-        assert isinstance(harness.charm.unit.status, BlockedStatus)
+        patched_restart_snap_service.reset_mock()
+
+        harness.remove_storage(storage_id="log-data/1")
+        patched_restart_snap_service.assert_called_once()
 
 
 def test_config_changed_updates_properties(harness):
@@ -335,17 +347,16 @@ def test_config_changed_updates_properties(harness):
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
 
-    with patch(
-        "config.KafkaConfig.server_properties",
-        new_callable=PropertyMock,
-        return_value=["gandalf=white"],
-    ), patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch(
-        "charm.safe_get_file", return_value=["gandalf=grey"]
-    ), patch(
-        "config.KafkaConfig.set_server_properties"
-    ) as set_props:
+    with (
+        patch(
+            "config.KafkaConfig.server_properties",
+            new_callable=PropertyMock,
+            return_value=["gandalf=white"],
+        ),
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("charm.safe_get_file", return_value=["gandalf=grey"]),
+        patch("config.KafkaConfig.set_server_properties") as set_props,
+    ):
         harness.charm.on.config_changed.emit()
 
         set_props.assert_called_once()
@@ -357,17 +368,16 @@ def test_config_changed_updates_client_data(harness):
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
     harness.add_relation(REL_NAME, "app")
 
-    with patch(
-        "config.KafkaConfig.server_properties",
-        new_callable=PropertyMock,
-        return_value=["gandalf=white"],
-    ), patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch(
-        "charm.safe_get_file", return_value=["gandalf=white"]
-    ), patch(
-        "provider.KafkaProvider.update_connection_info"
-    ) as patched_update_connection_info:
+    with (
+        patch(
+            "config.KafkaConfig.server_properties",
+            new_callable=PropertyMock,
+            return_value=["gandalf=white"],
+        ),
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("charm.safe_get_file", return_value=["gandalf=white"]),
+        patch("provider.KafkaProvider.update_connection_info") as patched_update_connection_info,
+    ):
         harness.set_leader(True)
         harness.charm.on.config_changed.emit()
 
@@ -379,19 +389,17 @@ def test_config_changed_restarts(harness):
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
 
-    with patch(
-        "config.KafkaConfig.server_properties",
-        new_callable=PropertyMock,
-        return_value=["gandalf=grey"],
-    ), patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch(
-        "charm.safe_get_file", return_value=["gandalf=white"]
-    ), patch(
-        "config.safe_write_to_file", return_value=None
-    ), patch(
-        "snap.KafkaSnap.restart_snap_service"
-    ) as patched_restart_snap_service:
+    with (
+        patch(
+            "config.KafkaConfig.server_properties",
+            new_callable=PropertyMock,
+            return_value=["gandalf=grey"],
+        ),
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("charm.safe_get_file", return_value=["gandalf=white"]),
+        patch("config.safe_write_to_file", return_value=None),
+        patch("snap.KafkaSnap.restart_snap_service") as patched_restart_snap_service,
+    ):
         harness.set_leader(True)
         harness.charm.on.config_changed.emit()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -325,21 +325,22 @@ def test_storage_add_remove_triggers_restart(harness):
     harness.set_leader(True)
 
     with (
-        patch("snap.KafkaSnap.restart_snap_service") as patched_restart_snap_service,
+        patch("snap.KafkaSnap.restart_snap_service") as patched_disable_enable,
         patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
         patch("charm.safe_get_file", return_value=["log.dirs=/var/snap/kafka/common/logs/0"]),
         patch("config.KafkaConfig.set_server_properties"),
         patch("charm.broker_active", return_value=True),
+        patch("snap.KafkaSnap.disable_enable") as patched_disable_enable,
     ):
         harness.add_storage(storage_name="log-data", count=2)
         harness.attach_storage(storage_id="log-data/1")
-        patched_restart_snap_service.assert_called_once()
+        patched_disable_enable.assert_called_once()
         assert not isinstance(harness.charm.unit.status, BlockedStatus)
 
-        patched_restart_snap_service.reset_mock()
+        patched_disable_enable.reset_mock()
 
         harness.remove_storage(storage_id="log-data/1")
-        patched_restart_snap_service.assert_called_once()
+        patched_disable_enable.assert_called_once()
 
 
 def test_config_changed_updates_properties(harness):

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -41,11 +41,11 @@ def test_client_relation_created_defers_if_not_ready(harness):
     with harness.hooks_disabled():
         harness.add_relation(PEER, CHARM_KEY)
 
-    with patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False
-    ), patch("auth.KafkaAuth.add_user") as patched_add_user, patch(
-        "ops.framework.EventBase.defer"
-    ) as patched_defer:
+    with (
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=False),
+        patch("auth.KafkaAuth.add_user") as patched_add_user,
+        patch("ops.framework.EventBase.defer") as patched_defer,
+    ):
         harness.set_leader(True)
         harness.add_relation(REL_NAME, "app")
 
@@ -56,9 +56,10 @@ def test_client_relation_created_defers_if_not_ready(harness):
 def test_client_relation_created_adds_user(harness):
     """Checks if new users are added on clientrelationcreated hook."""
     harness.add_relation(PEER, CHARM_KEY)
-    with patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch("auth.KafkaAuth.add_user") as patched_add_user:
+    with (
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("auth.KafkaAuth.add_user") as patched_add_user,
+    ):
         harness.set_leader(True)
         client_rel_id = harness.add_relation(REL_NAME, "app")
 
@@ -70,14 +71,12 @@ def test_client_relation_created_adds_user(harness):
 def test_client_relation_broken_removes_user(harness):
     """Checks if users are removed on clientrelationbroken hook."""
     harness.add_relation(PEER, CHARM_KEY)
-    with patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch("auth.KafkaAuth.add_user"), patch(
-        "auth.KafkaAuth.delete_user"
-    ) as patched_delete_user, patch(
-        "auth.KafkaAuth.remove_all_user_acls"
-    ) as patched_remove_acls, patch(
-        "snap.KafkaSnap.run_bin_command"
+    with (
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("auth.KafkaAuth.add_user"),
+        patch("auth.KafkaAuth.delete_user") as patched_delete_user,
+        patch("auth.KafkaAuth.remove_all_user_acls") as patched_remove_acls,
+        patch("snap.KafkaSnap.run_bin_command"),
     ):
         harness.set_leader(True)
         client_rel_id = harness.add_relation(REL_NAME, "app")
@@ -98,14 +97,18 @@ def test_client_relation_broken_removes_user(harness):
 def test_client_relation_joined_sets_necessary_relation_data(harness):
     """Checks if all needed provider relation data is set on clientrelationjoined hook."""
     harness.add_relation(PEER, CHARM_KEY)
-    with patch(
-        "charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True
-    ), patch("auth.KafkaAuth.add_user"), patch("snap.KafkaSnap.run_bin_command"), patch(
-        "config.KafkaConfig.zookeeper_connected", new_callable=PropertyMock, return_value=True
-    ), patch(
-        "config.KafkaConfig.zookeeper_config",
-        new_callable=PropertyMock,
-        return_value={"connect": "yes"},
+    with (
+        patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
+        patch("auth.KafkaAuth.add_user"),
+        patch("snap.KafkaSnap.run_bin_command"),
+        patch(
+            "config.KafkaConfig.zookeeper_connected", new_callable=PropertyMock, return_value=True
+        ),
+        patch(
+            "config.KafkaConfig.zookeeper_config",
+            new_callable=PropertyMock,
+            return_value={"connect": "yes"},
+        ),
     ):
         harness.set_leader(True)
         client_rel_id = harness.add_relation(REL_NAME, "app")

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ description = Check code against coding style standards
 deps =
     black
     flake8
-    flake8-docstrings
+    flake8-docstrings==1.6.0
     flake8-copyright
     flake8-builtins
     pyproject-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8 == 4.0.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -82,7 +82,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -96,7 +96,7 @@ commands =
 description = Run base integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -110,7 +110,7 @@ commands =
 description = Run integration tests for provider
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -124,7 +124,7 @@ commands =
 description = Run scaling integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -138,7 +138,7 @@ commands =
 description = Run password rotation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -152,7 +152,7 @@ commands =
 description = Run TLS integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity

--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -102,6 +103,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_charm.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -116,6 +118,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_provider.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -130,6 +133,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_scaling.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -144,6 +148,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_password_rotation.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -158,6 +163,7 @@ deps =
     tenacity
     pure-sasl
     kafka-python
+    requests
     -r{toxinidir}/requirements.txt
 commands =
     pytest tests/integration/test_tls.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Changes Made
#### `feat: add functionality for managing juju-storage mounts`
- By default supports 1+ storage volumes. A 10G storage volume will be installed by default for `log.dirs`
- When storage is added or removed, the Kafka service will restart to ensure it uses the new volumes
- When storage is added or removed, log + charm status messages will prompt users to manually reassign partitions so that the new storage volumes are populated. By default, Kafka will not assign partitions to new directories/units until existing topic partitions are assigned to it, or a new topic is created  
#### `feat: use py3.10 in charm + Ubuntu22.04 for CI + charm`
#### `chore: various bugfixes`
  