### PR TITLE
fix: add rolling storage events, add restart status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ log_cli_level = "INFO"
 # Formatting tools configuration
 [tool.black]
 line-length = 99
-target-version = ["py38"]
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"
@@ -34,19 +34,26 @@ kazoo = ">=2.8.0"
 tenacity = ">=8.0.1"
 pure-sasl = ">=0.6.2"
 
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff]
+line-length = 99
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104", "E999"]}
+target-version="py310"
+
+[tool.ruff.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"

--- a/src/charm.py
+++ b/src/charm.py
@@ -267,10 +267,10 @@ class KafkaCharm(CharmBase):
             )
             return
 
-    def _disable_enable_restart(self, event: EventBase) -> None:
+    def _disable_enable_restart(self, event: ActionEvent) -> None:
         """Handler for `rolling_ops` disable_enable restart events."""
         if not self.ready_to_start:
-            event.defer()
+            event.fail(message=f"Broker {self.unit.name.split('/')[1]} is not ready restart")
             return
 
         self.snap.disable_enable("kafka")
@@ -282,9 +282,9 @@ class KafkaCharm(CharmBase):
             logger.info(f'Broker {self.unit.name.split("/")[1]} restarted')
             self.unit.status = ActiveStatus()
         else:
-            self.unit.status = BlockedStatus(
-                f"Broker {self.unit.name.split('/')[1]} failed to restart"
-            )
+            msg = f"Broker {self.unit.name.split('/')[1]} failed to restart"
+            event.fail(message=msg)
+            self.unit.status = BlockedStatus(msg)
             return
 
     def _set_password_action(self, event: ActionEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,10 @@ import logging
 import subprocess
 from typing import MutableMapping, Optional
 
+from auth import KafkaAuth
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
+from config import KafkaConfig
+from literals import CHARM_KEY, CHARM_USERS, PEER, REL_NAME, ZK
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -22,10 +25,6 @@ from ops.charm import (
 from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus
-
-from auth import KafkaAuth
-from config import KafkaConfig
-from literals import CHARM_KEY, CHARM_USERS, PEER, REL_NAME, ZK
 from provider import KafkaProvider
 from snap import KafkaSnap
 from tls import KafkaTLS

--- a/src/config.py
+++ b/src/config.py
@@ -8,9 +8,8 @@ import logging
 import os
 from typing import Dict, List, Optional
 
-from ops.model import Unit
-
 from literals import PEER, REL_NAME, ZK
+from ops.model import Unit
 from snap import SNAP_CONFIG_PATH
 from utils import safe_write_to_file
 

--- a/src/provider.py
+++ b/src/provider.py
@@ -7,6 +7,9 @@
 import logging
 from typing import Dict
 
+from auth import KafkaAuth
+from config import KafkaConfig
+from literals import PEER, REL_NAME
 from ops.charm import (
     RelationBrokenEvent,
     RelationChangedEvent,
@@ -15,10 +18,6 @@ from ops.charm import (
 )
 from ops.framework import Object
 from ops.model import Relation
-
-from auth import KafkaAuth
-from config import KafkaConfig
-from literals import PEER, REL_NAME
 from utils import generate_password
 
 logger = logging.getLogger(__name__)

--- a/src/tls.py
+++ b/src/tls.py
@@ -15,11 +15,10 @@ from charms.tls_certificates_interface.v1.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
+from literals import TLS_RELATION
 from ops.charm import ActionEvent
 from ops.framework import Object
 from ops.model import Relation
-
-from literals import TLS_RELATION
 from snap import SNAP_CONFIG_PATH
 from utils import generate_password, parse_tls_file, safe_write_to_file
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -8,10 +8,9 @@ from subprocess import PIPE, check_output
 from typing import Any, Dict, List, Set, Tuple
 
 import yaml
+from auth import Acl, KafkaAuth
 from client import KafkaClient
 from pytest_operator.plugin import OpsTest
-
-from auth import Acl, KafkaAuth
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,9 +8,9 @@ import time
 from subprocess import PIPE, check_output
 
 import pytest
+from literals import CHARM_KEY
 from pytest_operator.plugin import OpsTest
 
-from literals import CHARM_KEY
 from tests.integration.helpers import produce_and_check_logs
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -6,13 +6,7 @@ import asyncio
 import logging
 
 import pytest
-from helpers import (
-    APP_NAME,
-    ZK_NAME,
-    get_kafka_zk_relation_data,
-    get_user,
-    set_password,
-)
+from helpers import APP_NAME, ZK_NAME, get_kafka_zk_relation_data, get_user, set_password
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -179,7 +179,7 @@ async def test_admin_removed_from_super_users(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_connection_updated_on_tls_enabled(ops_test: OpsTest):
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
-    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config, series="focal")
+    await ops_test.model.deploy(TLS_NAME, channel="beta", config=tls_config, series="focal")
     await ops_test.model.add_relation(TLS_NAME, ZK)
     await ops_test.model.add_relation(TLS_NAME, APP_NAME)
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -10,9 +10,9 @@ from pathlib import Path
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
+from utils import get_active_brokers
 
 from tests.integration.helpers import get_kafka_zk_relation_data
-from utils import get_active_brokers
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -29,7 +29,7 @@ async def test_deploy_tls(ops_test: OpsTest):
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
 
     await asyncio.gather(
-        ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config, series="focal"),
+        ops_test.model.deploy(TLS_NAME, channel="beta", config=tls_config, series="focal"),
         ops_test.model.deploy(ZK_NAME, channel="edge", num_units=3, series="focal"),
         ops_test.model.deploy(kafka_charm, application_name=APP_NAME, series="jammy"),
     )

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -6,15 +6,8 @@ import asyncio
 import logging
 
 import pytest
-from helpers import (
-    APP_NAME,
-    ZK_NAME,
-    check_tls,
-    get_address,
-    get_kafka_zk_relation_data,
-)
+from helpers import APP_NAME, ZK_NAME, check_tls, get_address, get_kafka_zk_relation_data
 from pytest_operator.plugin import OpsTest
-
 from utils import get_active_brokers
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -8,11 +8,10 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from ops.testing import Harness
-
 from auth import Acl, KafkaAuth
 from charm import KafkaCharm
 from literals import CHARM_KEY, PEER, ZK
+from ops.testing import Harness
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +37,7 @@ def harness():
 
 
 def test_acl():
-    assert sorted(list(Acl.__annotations__.keys())) == sorted(
+    assert sorted(Acl.__annotations__.keys()) == sorted(
         ["operation", "resource_name", "resource_type", "username"]
     )
     assert Acl.__hash__
@@ -74,7 +73,7 @@ def test_generate_producer_acls():
         operations.add(acl.operation)
         resource_types.add(acl.resource_type)
 
-    assert sorted(operations) == sorted(set(["CREATE", "WRITE", "DESCRIBE"]))
+    assert sorted(operations) == sorted({"CREATE", "WRITE", "DESCRIBE"})
     assert resource_types == {"TOPIC"}
 
 
@@ -92,8 +91,8 @@ def test_generate_consumer_acls():
         if acl.resource_type == "GROUP":
             assert acl.operation == "READ"
 
-    assert sorted(operations) == sorted(set(["READ", "DESCRIBE"]))
-    assert sorted(resource_types) == sorted(set(["TOPIC", "GROUP"]))
+    assert sorted(operations) == sorted({"READ", "DESCRIBE"})
+    assert sorted(resource_types) == sorted({"TOPIC", "GROUP"})
 
 
 def test_get_acls_tls_adds_zk_tls_flag(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -325,7 +325,6 @@ def test_storage_add_remove_triggers_restart(harness):
     harness.set_leader(True)
 
     with (
-        patch("snap.KafkaSnap.restart_snap_service") as patched_disable_enable,
         patch("charm.KafkaCharm.ready_to_start", new_callable=PropertyMock, return_value=True),
         patch("charm.safe_get_file", return_value=["log.dirs=/var/snap/kafka/common/logs/0"]),
         patch("config.KafkaConfig.set_server_properties"),
@@ -400,6 +399,7 @@ def test_config_changed_restarts(harness):
         patch("charm.safe_get_file", return_value=["gandalf=white"]),
         patch("config.safe_write_to_file", return_value=None),
         patch("snap.KafkaSnap.restart_snap_service") as patched_restart_snap_service,
+        patch("charm.broker_active", return_value=True),
     ):
         harness.set_leader(True)
         harness.charm.on.config_changed.emit()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,10 +6,9 @@ from pathlib import Path
 
 import pytest
 import yaml
-from ops.testing import Harness
-
 from charm import KafkaCharm
 from literals import CHARM_KEY, PEER, ZK
+from ops.testing import Harness
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -6,7 +6,6 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
-
 from snap import KafkaSnap
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,32 +38,28 @@ commands =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8
-    flake8-docstrings==1.6.0
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8<6.0.0
-    pep8-naming
-    isort
+    ruff==0.0.157
     codespell
 commands =
-    # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    codespell {toxinidir} \
+        --skip {toxinidir}/.git \
+        --skip {toxinidir}/.tox \
+        --skip {toxinidir}/build \
+        --skip {toxinidir}/lib \
+        --skip {toxinidir}/venv \
+        --skip {toxinidir}/.mypy_cache \
+        --skip {toxinidir}/icon.svg
+
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]


### PR DESCRIPTION
## Changes Made
##### `fix: ensure storage restart events are rolling`
- Use `callback_override` to ensure that storage restarts use state lock
- Avoids multiple units restarting at the same time
##### `fix: check broker_active after restart events`
- It's possible that after a restart a broker will be in an error state. Checking broker-active fixes that
- Has side-effect of slowing down rolling-ops due to potential retries on `broker_active`