### PR TITLE
Split internal and external listeners

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,3 @@ options:
     description: enables auto creation of topic on the server
     type: boolean
     default: false
-  external-listener:
-    description: host where to announce an external listener
-    type: string
-    default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,7 @@ options:
     description: enables auto creation of topic on the server
     type: boolean
     default: false
+  external-listener:
+    description: host where to announce an external listener
+    type: string
+    default: ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ extend-ignore = [
 ]
 ignore = ["E501", "D107"]
 extend-exclude = ["__pycache__", "*.egg_info"]
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104", "E999"]}
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104", "E999"], "src/literals.py" = ["D101"]}
 target-version="py310"
 
 [tool.ruff.mccabe]

--- a/src/charm.py
+++ b/src/charm.py
@@ -87,6 +87,11 @@ class KafkaCharm(CharmBase):
 
         return self.peer_relation.data[self.unit]
 
+    @property
+    def unit_host(self) -> str:
+        """Return the own host."""
+        return self.unit_peer_data.get("private-address", None)
+
     def _on_storage_attached(self, event: StorageAttachedEvent) -> None:
         """Handler for `storage_attached` events."""
         # checks first whether the broker is active before warning

--- a/src/config.py
+++ b/src/config.py
@@ -223,10 +223,16 @@ class KafkaConfig:
         Returns:
             list of scram properties to be set
         """
-        scram_properties = [f'listener.name.internal.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="sync" password="{self.sync_password}";']        
-        external_scram = [auth for auth in self.auth_mechanisms if auth.startswith("SASL_")]
-        for ext in external_scram:
-            scram_properties.append(f'listener.name.{ext.lower()}.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="sync" password="{self.sync_password}";')
+        scram_properties = [
+            f'listener.name.{self.internal_listener.name.lower()}.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="sync" password="{self.sync_password}";'
+        ]
+        external_scram = [
+            auth.name for auth in self.extra_listeners if auth.protocol.startswith("SASL_")
+        ]
+        for name in external_scram:
+            scram_properties.append(
+                f'listener.name.{name.lower()}.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="sync" password="{self.sync_password}";'
+            )
 
         return scram_properties
 

--- a/src/config.py
+++ b/src/config.py
@@ -314,13 +314,9 @@ class KafkaConfig:
         Returns:
             List of properties to be set
         """
-        protocol_map = []
-        listeners_repr = []
-        advertised_listeners = []
-        for listener in self.all_listeners:
-            protocol_map.append(listener.protocol_map)
-            listeners_repr.append(listener.listener)
-            advertised_listeners.append(listener.advertised_listener)
+        protocol_map = [listener.protocol_map for listener in self.all_listeners]
+        listeners_repr = [listener.listener for listener in self.all_listeners]
+        advertised_listeners = [listener.advertised_listener for listener in self.all_listeners]
 
         properties = (
             [

--- a/src/literals.py
+++ b/src/literals.py
@@ -2,6 +2,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+
 """Collection of globals common to the KafkaCharm."""
 
 CHARM_KEY = "kafka"
@@ -10,3 +11,9 @@ ZK = "zookeeper"
 REL_NAME = "kafka-client"
 CHARM_USERS = ["sync"]
 TLS_RELATION = "certificates"
+
+SECURITY_PROTOCOL_PORTS = {
+    "SASL_PLAINTEXT": (9092, 19092),
+    "SASL_SSL": (9093, 19093),
+    "SSL": (9094, 19094),
+}

--- a/src/literals.py
+++ b/src/literals.py
@@ -5,6 +5,9 @@
 
 """Collection of globals common to the KafkaCharm."""
 
+from dataclasses import dataclass
+from typing import Dict, Literal
+
 CHARM_KEY = "kafka"
 PEER = "cluster"
 ZK = "zookeeper"
@@ -12,8 +15,18 @@ REL_NAME = "kafka-client"
 CHARM_USERS = ["sync"]
 TLS_RELATION = "certificates"
 
-SECURITY_PROTOCOL_PORTS = {
-    "SASL_PLAINTEXT": (9092, 19092),
-    "SASL_SSL": (9093, 19093),
-    "SSL": (9094, 19094),
+AuthMechanism = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]
+Scope = Literal["INTERNAL", "EXTERNAL"]
+
+
+@dataclass
+class Ports:
+    external: int
+    internal: int
+
+
+SECURITY_PROTOCOL_PORTS: Dict[AuthMechanism, Ports] = {
+    "SASL_PLAINTEXT": Ports(9092, 19092),
+    "SASL_SSL": Ports(9093, 19093),
+    "SSL": Ports(9094, 19094),
 }

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,6 +3,8 @@
 # See LICENSE file for licensing details.
 import logging
 import re
+import socket
+from contextlib import closing
 from pathlib import Path
 from subprocess import PIPE, check_output
 from typing import Any, Dict, List, Set, Tuple
@@ -151,6 +153,11 @@ async def set_password(ops_test: OpsTest, username="sync", password=None, num_un
     )
     password = await action.wait()
     return password.results
+
+
+def check_socket(host: str, port: int) -> bool:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        assert sock.connect_ex((host, port)) == 0
 
 
 def check_tls(ip: str, port: int) -> bool:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -11,7 +11,7 @@ import pytest
 from literals import CHARM_KEY
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import produce_and_check_logs
+from tests.integration.helpers import check_socket, get_address, produce_and_check_logs
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +36,13 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(apps=["kafka", "zookeeper"])
     assert ops_test.model.applications["kafka"].status == "active"
     assert ops_test.model.applications["zookeeper"].status == "active"
+
+
+@pytest.mark.abort_on_fail
+async def test_listeners(ops_test: OpsTest):
+    address = await get_address(ops_test=ops_test)
+    check_socket(address, 9092)  # Internal listener
+    check_socket(address, 19092)  # External listener
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -41,8 +41,8 @@ async def test_build_and_deploy(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_listeners(ops_test: OpsTest):
     address = await get_address(ops_test=ops_test)
-    check_socket(address, 9092)  # Internal listener
-    check_socket(address, 19092)  # External listener
+    check_socket(address, 19092)  # Internal listener
+    check_socket(address, 9092)  # External listener
 
 
 @pytest.mark.abort_on_fail

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -69,6 +69,34 @@ def test_log_dirs_in_server_properties(harness):
     assert found_log_dirs
 
 
+def test_listeners_in_server_properties(harness):
+    """Checks that listeners are split into INTERNAL and EXTERNAL."""
+    zk_relation_id = harness.add_relation(ZK, CHARM_KEY)
+    harness.update_relation_data(
+        zk_relation_id,
+        harness.charm.app.name,
+        {
+            "chroot": "/kafka",
+            "username": "moria",
+            "password": "mellon",
+            "endpoints": "1.1.1.1,2.2.2.2",
+            "uris": "1.1.1.1:2181/kafka,2.2.2.2:2181/kafka",
+            "tls": "disabled",
+        },
+    )
+    peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_relation_id, "kafka/1")
+    harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
+
+    expected_listeners = "listeners=INTERNAL://:9092,EXTERNAL://:19092"
+    expected_advertised_listeners = (
+        "advertised.listeners=INTERNAL://treebeard:9092,EXTERNAL://treebeard:19092"
+    )
+
+    assert expected_listeners in harness.charm.kafka_config.server_properties
+    assert expected_advertised_listeners in harness.charm.kafka_config.server_properties
+
+
 def test_zookeeper_config_succeeds_fails_config(harness):
     """Checks that no ZK config is returned if missing field."""
     zk_relation_id = harness.add_relation(ZK, CHARM_KEY)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -88,9 +88,9 @@ def test_listeners_in_server_properties(harness):
     harness.add_relation_unit(peer_relation_id, "kafka/1")
     harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
 
-    expected_listeners = "listeners=INTERNAL://:9092,EXTERNAL://:19092"
+    expected_listeners = "listeners=INTERNAL_SASL_PLAINTEXT://:19092,EXTERNAL_SASL_PLAINTEXT://:9092"
     expected_advertised_listeners = (
-        "advertised.listeners=INTERNAL://treebeard:9092,EXTERNAL://treebeard:19092"
+        "advertised.listeners=INTERNAL_SASL_PLAINTEXT://treebeard:19092,EXTERNAL_SASL_PLAINTEXT://treebeard:9092"
     )
 
     assert expected_listeners in harness.charm.kafka_config.server_properties

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -88,10 +88,10 @@ def test_listeners_in_server_properties(harness):
     harness.add_relation_unit(peer_relation_id, "kafka/1")
     harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
 
-    expected_listeners = "listeners=INTERNAL_SASL_PLAINTEXT://:19092,EXTERNAL_SASL_PLAINTEXT://:9092"
-    expected_advertised_listeners = (
-        "advertised.listeners=INTERNAL_SASL_PLAINTEXT://treebeard:19092,EXTERNAL_SASL_PLAINTEXT://treebeard:9092"
+    expected_listeners = (
+        "listeners=INTERNAL_SASL_PLAINTEXT://:19092,EXTERNAL_SASL_PLAINTEXT://:9092"
     )
+    expected_advertised_listeners = "advertised.listeners=INTERNAL_SASL_PLAINTEXT://treebeard:19092,EXTERNAL_SASL_PLAINTEXT://treebeard:9092"
 
     assert expected_listeners in harness.charm.kafka_config.server_properties
     assert expected_advertised_listeners in harness.charm.kafka_config.server_properties


### PR DESCRIPTION
Addresses [DPE-1061](https://warthogs.atlassian.net/browse/DPE-1061).

Listeners are now split into two categories, INTERNAL and EXTERNAL. Both can still be used normally, but the external listener allows for a custom advertised listener, so Kafka clients on external networks can resolve the hostname.


[DPE-1061]: https://warthogs.atlassian.net/browse/DPE-1061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ