### PR TITLE
feat: add admin user, improve administrator command UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 ## Kafka Operator - a Charmed Operator for running Apache Kafka from Canonical
-
 This repository hosts the Machine Python Operator for [Apache Kafka](https://kafka.apache.org).
 The Kafka Operator is a Python script that uses the latest upstream Kafka binaries released by the The Apache Software Foundation that comes with Kafka, made available using the [Kafka Snap](https://snapcraft.io/kafka) distributed by Canonical.
 
 As currently Kafka requires a paired ZooKeeper deployment in production, this operator makes use of the [ZooKeeper Operator](https://github.com/canonical/zookeeper-operator) for various essential functions. 
 
-### Usage
-
+### How to deploy
 The Kafka and ZooKeeper operators can both be deployed and connected to each other using the Juju command line as follows:
 
 ```bash
@@ -16,28 +14,94 @@ $ juju relate kafka zookeeper
 ```
 
 ## A fast and fault-tolerant, real-time event streaming platform!
-
 Manual, Day 2 operations for deploying and operating Apache Kafka, topic creation, client authentication, ACL management and more are all handled automatically using the [Juju Operator Lifecycle Manager](https://juju.is/docs/olm).
 
 ### Key Features
 - SASL/SCRAM auth for Broker-Broker and Client-Broker authenticaion enabled by default.
 - Access control management supported with user-provided ACL lists.
 - Fault-tolerance, replication and high-availability out-of-the-box.
-- Streamlined topic-creation through [Juju Actions](https://juju.is/docs/olm/working-with-actions) and [application relations](https://juju.is/docs/olm/relations)
+- Smooth topic-creation through [Juju Actions](https://juju.is/docs/olm/working-with-actions) and [application relations](https://juju.is/docs/olm/relations)
 
+#### **rolling-restart-unit Action**
+Manually triggers a rolling restart for specified units. The unit that this action runs on will be restarted, ensuring that no other application units are restarting at the same time. 
+
+Must be ran on each unit separately.
+
+##### Example Usage
+To restart the current Kafka Leader, run:
+```
+juju run-action kafka/leader rolling-restart-unit
+```
+
+#### **set-password Action**
+Change an internal system user's password. It is for internal charm users and SHOULD NOT be used by applications.
+
+This action must be called on the leader unit.
+
+##### Params
+- **password** string
+    The password will be auto-generated if this option is not specified.
+- **username** string
+    The username, the default value 'operator'. Possible values - `admin`, `sync`
+
+##### Example Usage
+To update the `admin` user password, run:
+```
+juju run-action kafka/leader set-password --params username=admin --params password=thisisapassword --wait
+```
+
+#### **set-tls-private-key Action**
+Sets the private key identifying the target unit, which will be used for certificate signing requests (CSR). When updated, certificates will be reissued to the unit.
+
+Must be ran on each unit separately.
+Requires a valid relation to an application providing the [`certificates`](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/tls_certificates/v1) relation interface. 
+
+##### Params
+- **internal-key** string
+    The content of private key for internal communications with clients. Content will be auto-generated if this option is not specified.
+    Can be raw string, or base64 encoded.
+
+##### Example Usage
+To update the private-key for the leader unit to a specific key, run:
+```
+juju run-action kafka/leader set-tls-private-key --params internal-key=<BASE64 STRING> --wait
+```
+
+#### **get-admin-credentials Action**
+Gets administrator authentication credentials for client commands.
+
+Kafka ships with `bin/*.sh` commands to do various administrative tasks. The returned `client_properties`, `username` and `password` can be used to run Kafka bin commands using `--bootstrap-server` and `--command-config` for admin level administration.
+
+This action must be called on the leader unit.
+
+##### Example Usage
+To get the current `admin` SASL credentials, run:
+```
+juju run-action kafka/leader get-admin-credentials --wait
+```
+This will return something similar to:
+```
+results:
+  client-properties: |-
+    sasl.mechanism=SCRAM-SHA-512
+    security.protocol=SASL_SSL
+    sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="E1RbjO78TUX5L3M428BTpdbEyJb1pqTJ";
+    bootstrap.servers=10.3.238.51:9092
+  password: E1RbjO78TUX5L3M428BTpdbEyJb1pqTJ
+  username: admin
+```
 
 ### Checklist
-
 - [x] Super-user creation
 - [x] Inter-broker auth
 - [x] Horizontally scale brokers
 - [x] Username/Password creation for related applications
-- [ ] Automatic topic creation with associated user ACLs
+- [x] Automatic topic creation with associated user ACLs
+- [x] Persistent storage support with [Juju Storage](https://juju.is/docs/olm/defining-and-using-persistent-storage)
+- [x] TLS/SSL encrypted connections
+- [ ]  mTLS
+- [ ] Multi-application clusters
 - [ ] Partition rebalancing during broker scaling
-- [ ] Rack awareness support
-- [ ] Persistent storage support with [Juju Storage](https://juju.is/docs/olm/defining-and-using-persistent-storage)
-- [ ] TLS/SSL support
 
-## Usage
-
+### Contributing
 This charm is still in active development. If you would like to contribute, please refer to [CONTRIBUTING.md](https://github.com/canonical/kafka-operator/blob/main/CONTRIBUTING.md)

--- a/actions.yaml
+++ b/actions.yaml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 # In Juju 3 this will be easier to copy
 set-password:
-  description: Change the system user's password, which is used by the charm.
+  description: Change an internal system user's password.
     It is for internal charm users and SHOULD NOT be used by applications.
     This action must be called on the leader unit.
   params:
@@ -16,13 +16,15 @@ set-password:
   required: [username]
 
 set-tls-private-key:
-  description: Set the private key, which will be used for certificate signing
-    requests (CSR). Run for each unit separately.
+  description: Sets the private key identifying the target unit, which will be used for certificate signing requests (CSR).
+    When updated, certificates will be reissued to the unit.
+    Run for each unit separately. Requires a valid relation to an application providing the `certificates` relation interface. 
   params:
     internal-key:
       type: string
       description: The content of private key for internal communications with clients.
         Content will be auto-generated if this option is not specified.
+        Can be raw-string, or base64 encoded.
 
 rolling-restart-unit:
   description: Manually triggers a rolling restart for specified units.

--- a/actions.yaml
+++ b/actions.yaml
@@ -8,11 +8,12 @@ set-password:
   params:
     username:
       type: string
-      description: The username, the default value 'operator'.
-        Possible values - operator
+      description: The internal username to set password for.
+      enum: [admin, sync]
     password:
       type: string
       description: The password will be auto-generated if this option is not specified.
+  required: [username]
 
 set-tls-private-key:
   description: Set the private key, which will be used for certificate signing
@@ -25,3 +26,8 @@ set-tls-private-key:
 
 rolling-restart-unit:
   description: Manually triggers a rolling restart for specified units.
+
+get-admin-credentials:
+  description: Get administrator authentication credentials for client commands
+    The returned client_properties can be used for Kafka bin commands using `--bootstrap-server` and `--command-config` for admin level administration
+    This action must be called on the leader unit.

--- a/src/auth.py
+++ b/src/auth.py
@@ -33,6 +33,8 @@ class KafkaAuth:
         self.zookeeper = zookeeper
         self.current_acls: Set[Acl] = set()
         self.new_user_acls: Set[Acl] = set()
+        # TODO: when we need to have --bootstrap-server bin commands, don't default to --zookeeper
+        # pass auth provider via command argument and handle it in run_bin_command
 
     def _get_acls_from_cluster(self) -> str:
         """Loads the currently active ACLs from the Kafka cluster."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -302,7 +302,7 @@ class KafkaCharm(CharmBase):
             event.fail(msg)
             return
 
-        username = event.params.get("username", "")
+        username = event.params["username"]
         new_password = event.params.get("password", generate_password())
 
         if new_password in self.kafka_config.internal_user_credentials.values():

--- a/src/charm.py
+++ b/src/charm.py
@@ -364,11 +364,13 @@ class KafkaCharm(CharmBase):
             event.fail(msg)
             return
 
+        admin_properties = set(client_properties) - set(self.kafka_config.tls_properties)
+
         event.set_results(
             {
                 "username": ADMIN_USER,
                 "password": self.kafka_config.internal_user_credentials[ADMIN_USER],
-                "client-properties": "\n".join(client_properties),
+                "client-properties": "\n".join(admin_properties),
             }
         )
 

--- a/src/config.py
+++ b/src/config.py
@@ -109,13 +109,11 @@ class KafkaConfig:
         Returns:
             Dict of usernames and passwords
         """
-        internal_user_credentials = {}
-        for user in [INTER_BROKER_USER, ADMIN_USER]:
-            password = self.charm.get_secret(scope="app", key=f"{user}-password")
-            if password:
-                internal_user_credentials[user] = password
-
-        return internal_user_credentials
+        return {
+            user: password
+            for user in [INTER_BROKER_USER, ADMIN_USER]
+            if (password := self.charm.get_secret(scope="app", key=f"{user}-password"))
+        }
 
     @property
     def zookeeper_config(self) -> Dict[str, str]:

--- a/src/config.py
+++ b/src/config.py
@@ -61,13 +61,17 @@ class Listener:
 
     @property
     def port(self) -> int:
-        """Port associated with the protocol/scope."""
-        if self.scope == "INTERNAL":
-            return SECURITY_PROTOCOL_PORTS[self.protocol].internal
-        elif self.scope == "EXTERNAL":
+        """Port associated with the protocol/scope.
+
+        Defaults to internal port.
+
+        Returns:
+            Integer of port number
+        """
+        if self.scope == "EXTERNAL":
             return SECURITY_PROTOCOL_PORTS[self.protocol].external
-        else:
-            raise ValueError("Only EXTERNAL and INTERNAL scopes are accepted")
+
+        return SECURITY_PROTOCOL_PORTS[self.protocol].internal
 
     @property
     def name(self) -> str:

--- a/src/config.py
+++ b/src/config.py
@@ -355,11 +355,16 @@ class KafkaConfig:
         Returns:
             List of properties to be set
         """
-        return [
+        client_properties = [
             f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{ADMIN_USER}" password="{self.internal_user_credentials[ADMIN_USER]}";',
             "sasl.mechanism=SCRAM-SHA-512",
             f"security.protocol={self.security_protocol}",  # FIXME: will need changing once multiple listener auth schemes
         ]
+
+        if self.charm.tls.enabled:
+            client_properties += self.tls_properties
+
+        return client_properties
 
     @property
     def server_properties(self) -> List[str]:

--- a/src/config.py
+++ b/src/config.py
@@ -227,22 +227,32 @@ class KafkaConfig:
         ]
 
     @property
-    def tls_properties(self) -> List[str]:
-        """Builds the properties necessary for TLS authentication.
+    def zookeeper_tls_properties(self) -> List[str]:
+        """Builds the properties necessary for SSL connections to ZooKeeper.
 
         Returns:
-            list of properties to be set
+            List of properties to be set
         """
         return [
             "zookeeper.ssl.client.enable=true",
             f"zookeeper.ssl.truststore.location={self.truststore_filepath}",
             f"zookeeper.ssl.truststore.password={self.charm.tls.truststore_password}",
             "zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty",
+            "zookeeper.ssl.endpoint.identification.algorithm=",
+        ]
+
+    @property
+    def tls_properties(self) -> List[str]:
+        """Builds the properties necessary for TLS authentication.
+
+        Returns:
+            List of properties to be set
+        """
+        return [
             f"ssl.truststore.location={self.truststore_filepath}",
             f"ssl.truststore.password={self.charm.tls.truststore_password}",
             f"ssl.keystore.location={self.keystore_filepath}",
             f"ssl.keystore.password={self.charm.tls.keystore_password}",
-            "zookeeper.ssl.endpoint.identification.algorithm=",
             "ssl.endpoint.identification.algorithm=",
             "ssl.client.auth=none",
         ]
@@ -386,7 +396,7 @@ class KafkaConfig:
         )
 
         if self.charm.tls.enabled:
-            properties += self.tls_properties
+            properties += self.tls_properties + self.zookeeper_tls_properties
 
         return properties
 

--- a/src/config.py
+++ b/src/config.py
@@ -359,6 +359,7 @@ class KafkaConfig:
             f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{ADMIN_USER}" password="{self.internal_user_credentials[ADMIN_USER]}";',
             "sasl.mechanism=SCRAM-SHA-512",
             f"security.protocol={self.security_protocol}",  # FIXME: will need changing once multiple listener auth schemes
+            f"bootstrap.servers={','.join(self.bootstrap_server)}",
         ]
 
         if self.charm.tls.enabled:

--- a/src/literals.py
+++ b/src/literals.py
@@ -12,7 +12,8 @@ CHARM_KEY = "kafka"
 PEER = "cluster"
 ZK = "zookeeper"
 REL_NAME = "kafka-client"
-CHARM_USERS = ["sync"]
+INTER_BROKER_USER = "sync"
+ADMIN_USER = "admin"
 TLS_RELATION = "certificates"
 
 AuthMechanism = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]

--- a/src/provider.py
+++ b/src/provider.py
@@ -35,7 +35,9 @@ class KafkaProvider(Object):
 
         self.framework.observe(self.charm.on[REL_NAME].relation_broken, self._on_relation_broken)
 
-        self.framework.observe(self.kafka_provider.on.topic_requested, self.on_topic_requested)
+        self.framework.observe(
+            getattr(self.kafka_provider.on, "topic_requested"), self.on_topic_requested
+        )
 
     def on_topic_requested(self, event: TopicRequestedEvent):
         """Handle the on topic requested event."""
@@ -52,8 +54,8 @@ class KafkaProvider(Object):
             event.defer()
             return
 
-        extra_user_roles = event.extra_user_roles
-        topic = event.topic
+        extra_user_roles = event.extra_user_roles or ""
+        topic = event.topic or ""
 
         relation = event.relation
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -43,10 +43,10 @@ class KafkaTLS(Object):
             self.charm.on[TLS_RELATION].relation_broken, self._tls_relation_broken
         )
         self.framework.observe(
-            self.certificates.on.certificate_available, self._on_certificate_available
+            getattr(self.certificates.on, "certificate_available"), self._on_certificate_available
         )
         self.framework.observe(
-            self.certificates.on.certificate_expiring, self._on_certificate_expiring
+            getattr(self.certificates.on, "certificate_expiring"), self._on_certificate_expiring
         )
         self.framework.observe(self.charm.on.set_tls_private_key_action, self._set_tls_private_key)
 
@@ -130,7 +130,7 @@ class KafkaTLS(Object):
 
     def _set_tls_private_key(self, event: ActionEvent) -> None:
         """Handler for `set_tls_private_key` action."""
-        private_key = parse_tls_file(event.params.get("internal-key", None))
+        private_key = parse_tls_file(event.params.get("internal-key", ""))
         self.charm.set_secret(scope="unit", key="private-key", value=private_key)
 
         self._on_certificate_expiring(event)
@@ -230,7 +230,7 @@ class KafkaTLS(Object):
         return [
             f"{self.charm.app.name}-{unit_id}",
             socket.getfqdn(),
-            self.peer_relation.data[self.charm.unit].get("private-address", None),
+            self.peer_relation.data[self.charm.unit].get("private-address", ""),
         ]
 
     def set_server_key(self) -> None:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -143,7 +143,7 @@ async def get_address(ops_test: OpsTest, app_name=APP_NAME, unit_num=0) -> str:
     return address
 
 
-async def set_password(ops_test: OpsTest, username="sync", password=None, num_unit=0) -> str:
+async def set_password(ops_test: OpsTest, username="sync", password=None, num_unit=0) -> Any:
     """Use the charm action to start a password rotation."""
     params = {"username": username}
     if password:
@@ -156,12 +156,12 @@ async def set_password(ops_test: OpsTest, username="sync", password=None, num_un
     return password.results
 
 
-def check_socket(host: str, port: int) -> bool:
+def check_socket(host: str, port: int) -> None:
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
         assert sock.connect_ex((host, port)) == 0
 
 
-def check_tls(ip: str, port: int) -> bool:
+def check_tls(ip: str, port: int) -> None:
     result = check_output(
         f"echo | openssl s_client -connect {ip}:{port}",
         stderr=PIPE,
@@ -234,9 +234,9 @@ def produce_and_check_logs(
     assert passed, "logs not found"
 
 
-def run_client_properties(ops_test: OpsTest, unit_name: str) -> str:
+async def run_client_properties(ops_test: OpsTest) -> str:
     """Runs command requiring admin permissions, authenticated with bootstrap-server."""
-    bootstrap_server = ops_test.model.units[unit_name].public_address + ":9092"
+    bootstrap_server = await get_address(ops_test=ops_test) + ":9092"
     result = check_output(
         f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'kafka.configs --bootstrap-server {bootstrap_server} --describe --all --command-config {SNAP_CONFIG_PATH}/client.properties --entity-type users'",
         stderr=PIPE,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -50,8 +50,9 @@ async def test_listeners(ops_test: OpsTest):
     check_socket(address, 9092)  # External listener
 
 
-def test_client_properties_makes_admin_connection(ops_test: OpsTest):
-    result = run_client_properties(ops_test=ops_test, unit_name=f"{CHARM_KEY}/0")
+@pytest.mark.abort_on_fail
+async def test_client_properties_makes_admin_connection(ops_test: OpsTest):
+    result = await run_client_properties(ops_test=ops_test)
     assert result
     assert len(result.strip().split("\n")) == 2
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -11,7 +11,12 @@ import pytest
 from literals import CHARM_KEY
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import check_socket, get_address, produce_and_check_logs
+from tests.integration.helpers import (
+    check_socket,
+    get_address,
+    produce_and_check_logs,
+    run_client_properties,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +48,12 @@ async def test_listeners(ops_test: OpsTest):
     address = await get_address(ops_test=ops_test)
     check_socket(address, 19092)  # Internal listener
     check_socket(address, 9092)  # External listener
+
+
+def test_client_properties_makes_admin_connection(ops_test: OpsTest):
+    result = run_client_properties(ops_test=ops_test, unit_name=f"{CHARM_KEY}/0")
+    assert result
+    assert len(result.strip().split("\n")) == 2
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -180,7 +180,7 @@ async def test_deploy_producer_same_topic(
 async def test_admin_added_to_super_users(ops_test: OpsTest):
     """Test relation with admin privileges."""
     super_users = load_super_users(model_full_name=ops_test.model_full_name)
-    assert len(super_users) == 1
+    assert len(super_users) == 2
 
     app_charm = await ops_test.build_charm("tests/integration/app-charm")
 
@@ -197,7 +197,7 @@ async def test_admin_added_to_super_users(ops_test: OpsTest):
     assert ops_test.model.applications[DUMMY_NAME_1].status == "active"
     # check the correct addition of super-users
     super_users = load_super_users(model_full_name=ops_test.model_full_name)
-    assert len(super_users) == 2
+    assert len(super_users) == 3
 
 
 @pytest.mark.abort_on_fail
@@ -211,7 +211,7 @@ async def test_admin_removed_from_super_users(ops_test: OpsTest):
     assert ops_test.model.applications[APP_NAME].status == "active"
 
     super_users = load_super_users(model_full_name=ops_test.model_full_name)
-    assert len(super_users) == 1
+    assert len(super_users) == 2
 
 
 @pytest.mark.abort_on_fail

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -101,8 +101,15 @@ def test_listeners_in_server_properties(harness):
     )
     expected_advertised_listeners = "advertised.listeners=INTERNAL_SASL_PLAINTEXT://treebeard:19092,EXTERNAL_SASL_PLAINTEXT://treebeard:9092"
 
-    assert expected_listeners in harness.charm.kafka_config.server_properties
-    assert expected_advertised_listeners in harness.charm.kafka_config.server_properties
+    with (
+        patch(
+            "config.KafkaConfig.internal_user_credentials",
+            new_callable=PropertyMock,
+            return_value={INTER_BROKER_USER: "fangorn", ADMIN_USER: "forest"},
+        )
+    ):
+        assert expected_listeners in harness.charm.kafka_config.server_properties
+        assert expected_advertised_listeners in harness.charm.kafka_config.server_properties
 
 
 def test_zookeeper_config_succeeds_fails_config(harness):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,11 +3,12 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
+from unittest.mock import PropertyMock, patch
 
 import pytest
 import yaml
 from charm import KafkaCharm
-from literals import CHARM_KEY, PEER, ZK
+from literals import ADMIN_USER, CHARM_KEY, INTER_BROKER_USER, PEER, ZK
 from ops.testing import Harness
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
@@ -62,11 +63,18 @@ def test_log_dirs_in_server_properties(harness):
     harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
 
     found_log_dirs = False
-    for prop in harness.charm.kafka_config.server_properties:
-        if "log.dirs" in prop:
-            found_log_dirs = True
+    with (
+        patch(
+            "config.KafkaConfig.internal_user_credentials",
+            new_callable=PropertyMock,
+            return_value={INTER_BROKER_USER: "fangorn", ADMIN_USER: "forest"},
+        )
+    ):
+        for prop in harness.charm.kafka_config.server_properties:
+            if "log.dirs" in prop:
+                found_log_dirs = True
 
-    assert found_log_dirs
+        assert found_log_dirs
 
 
 def test_listeners_in_server_properties(harness):
@@ -209,7 +217,7 @@ def test_auth_properties(harness):
 
 def test_super_users(harness):
     """Checks super-users property is updated for new admin clients."""
-    assert len(harness.charm.kafka_config.super_users.split(";")) == 1
+    assert len(harness.charm.kafka_config.super_users.split(";")) == 2
 
     client_relation_id = harness.add_relation("kafka-client", "app")
     harness.update_relation_data(client_relation_id, "app", {"extra-user-roles": "admin,producer"})
@@ -223,11 +231,11 @@ def test_super_users(harness):
     harness.update_relation_data(
         peer_relation_id, harness.charm.app.name, {"relation-1": "mellon"}
     )
-    assert len(harness.charm.kafka_config.super_users.split(";")) == 2
+    assert len(harness.charm.kafka_config.super_users.split(";")) == 3
 
     harness.update_relation_data(
         peer_relation_id, harness.charm.app.name, {"relation-2": "mellon"}
     )
 
     harness.update_relation_data(client_relation_id, "appii", {"extra-user-roles": "consumer"})
-    assert len(harness.charm.kafka_config.super_users.split(";")) == 2
+    assert len(harness.charm.kafka_config.super_users.split(";")) == 3


### PR DESCRIPTION
## Changes Made
##### `refactor: add admin super.user`
##### `refactor: restricting set-password action inputs, only internal users`
##### `refactor: collate common 'set internal user+pass' logic into dedicated method`
##### `refactor: split out zookeeper-tls settings to new property`
##### `style: fix some wonky types flagged by pyright`
##### `refactor: rename JAAS to zookeeper-jaas.cfg`
- This is to address the confusing purpose mentioned below
- As inter-broker SCRAM before cluster init, the charm must make an authenticated API call to ZooKeeper, and again at cluster init
- JAAS file contains credentials needed to authenticate, and path is written to `/etc/environment` so that it is recognized by `snap start kafka` command 
##### `feat: add with action and file for running admin commands`
- Kafka ships with `bin/*.sh` commands to do various administrative tasks. All the Kafka documentation points to these scripts to get started
- Up until now, our JAAS/SCRAM/auth setup made it challenging for a user to run any administrative actions from some admin client. This was because:
    - JAAS file was confusing, unclear what it was for
    - `KAFKA_OPTS` env-var pointing to the JAAS file was hidden
    - Commands would only work with `--zookeeper` as the connection, which requires hard to use JAAS, deprecated, minimal functionality
- Intent is to make it easier for administrator users of the charm to perform commands on their Kafka Cluster 
- In order to support `--bootstrap-server` as the connection to allow cluster commands, we add a `client.properties` file to the unit config directory
    - Supports SSH'ing in and use a new `client.properties` file when passing `bin/*.sh --bootstrap-server SERVER --command-config client.properties`
    - Supports `juju run-action kafka/leader get-admin-credentials --wait` to get `admin` username+password. Example Output: 
        ```
        results:
          client-properties: |-
            sasl.mechanism=SCRAM-SHA-512
            security.protocol=SASL_SSL
            sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="E1RbjO78TUX5L3M428BTpdbEyJb1pqTJ";
            bootstrap.servers=10.3.238.51:9092
          password: E1RbjO78TUX5L3M428BTpdbEyJb1pqTJ
          username: admin
       ```