### PR TITLE
Fix Ruff import sorting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ ignore = ["E501", "D107"]
 extend-exclude = ["__pycache__", "*.egg_info"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104", "E999"], "src/literals.py" = ["D101"]}
 target-version="py310"
+src = ["src", "tests"]
 
 [tool.ruff.mccabe]
 max-complexity = 10

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,10 +8,7 @@ import logging
 import subprocess
 from typing import MutableMapping, Optional
 
-from auth import KafkaAuth
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
-from config import KafkaConfig
-from literals import ADMIN_USER, CHARM_KEY, INTER_BROKER_USER, PEER, REL_NAME, ZK
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -25,6 +22,10 @@ from ops.charm import (
 from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus
+
+from auth import KafkaAuth
+from config import KafkaConfig
+from literals import ADMIN_USER, CHARM_KEY, INTER_BROKER_USER, PEER, REL_NAME, ZK
 from provider import KafkaProvider
 from snap import KafkaSnap
 from tls import KafkaTLS

--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,8 @@ import logging
 import os
 from typing import Dict, List
 
+from ops.model import Unit
+
 from literals import (
     ADMIN_USER,
     INTER_BROKER_USER,
@@ -18,7 +20,6 @@ from literals import (
     AuthMechanism,
     Scope,
 )
-from ops.model import Unit
 from snap import SNAP_CONFIG_PATH
 from utils import safe_write_to_file
 

--- a/src/provider.py
+++ b/src/provider.py
@@ -6,13 +6,14 @@
 
 import logging
 
-from auth import KafkaAuth
 from charms.data_platform_libs.v0.data_interfaces import KafkaProvides, TopicRequestedEvent
-from config import KafkaConfig
-from literals import PEER, REL_NAME
 from ops.charm import RelationBrokenEvent
 from ops.framework import Object
 from ops.model import Relation
+
+from auth import KafkaAuth
+from config import KafkaConfig
+from literals import PEER, REL_NAME
 from utils import generate_password
 
 logger = logging.getLogger(__name__)

--- a/src/tls.py
+++ b/src/tls.py
@@ -15,10 +15,11 @@ from charms.tls_certificates_interface.v1.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
-from literals import TLS_RELATION
 from ops.charm import ActionEvent
 from ops.framework import Object
 from ops.model import Relation
+
+from literals import TLS_RELATION
 from snap import SNAP_CONFIG_PATH
 from utils import generate_password, parse_tls_file, safe_write_to_file
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,9 +10,10 @@ from subprocess import PIPE, check_output
 from typing import Any, Dict, List, Set, Tuple
 
 import yaml
-from auth import Acl, KafkaAuth
 from client import KafkaClient
 from pytest_operator.plugin import OpsTest
+
+from auth import Acl, KafkaAuth
 from snap import SNAP_CONFIG_PATH
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,15 +8,15 @@ import time
 from subprocess import PIPE, check_output
 
 import pytest
-from literals import CHARM_KEY
 from pytest_operator.plugin import OpsTest
-
 from tests.integration.helpers import (
     check_socket,
     get_address,
     produce_and_check_logs,
     run_client_properties,
 )
+
+from literals import CHARM_KEY
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -9,7 +9,6 @@ from typing import Set
 
 import pytest
 from pytest_operator.plugin import OpsTest
-
 from tests.integration.helpers import (
     check_user,
     get_provider_data,

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -10,9 +10,9 @@ from pathlib import Path
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
-from utils import get_active_brokers
-
 from tests.integration.helpers import get_kafka_zk_relation_data
+
+from utils import get_active_brokers
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -8,6 +8,7 @@ import logging
 import pytest
 from helpers import APP_NAME, ZK_NAME, check_tls, get_address, get_kafka_zk_relation_data
 from pytest_operator.plugin import OpsTest
+
 from utils import get_active_brokers
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -8,10 +8,11 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from ops.testing import Harness
+
 from auth import Acl, KafkaAuth
 from charm import KafkaCharm
 from literals import CHARM_KEY, PEER, ZK
-from ops.testing import Harness
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -7,9 +7,10 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 import yaml
+from ops.testing import Harness
+
 from charm import KafkaCharm
 from literals import ADMIN_USER, CHARM_KEY, INTER_BROKER_USER, PEER, ZK
-from ops.testing import Harness
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -6,6 +6,7 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
+
 from snap import KafkaSnap
 
 


### PR DESCRIPTION
Specifies source directories for ruff so imports are split following Python patterns.