### PR TITLE
chore: expand client args

### DIFF
--- a/lib/charms/kafka/v0/client.py
+++ b/lib/charms/kafka/v0/client.py
@@ -71,6 +71,16 @@ from kafka.admin import NewTopic
 logger = logging.getLogger(__name__)
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
+# The unique Charmhub library identifier, never change it
+LIBID = "67b2f3f3cefa49e9b225346049625251"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
 
 class KafkaClient:
     """Simplistic KafkaClient built on top of kafka-python."""

--- a/tests/integration/client.py
+++ b/tests/integration/client.py
@@ -28,6 +28,7 @@ def on_kafka_relation_created(self, event: RelationCreatedEvent):
         replication_factor=3,
     )
 
+    # if topic has not yet been created
     if "admin" in event.relation.data[event.app].get("extra-user-roles", ""):
         topic = NewTopic(
             name=client.topic,
@@ -36,7 +37,7 @@ def on_kafka_relation_created(self, event: RelationCreatedEvent):
         )
         client.create_topic(topic=topic)
 
-    for message in some_iterable:
+    for message in SOME_ITERABLE:
         client.produce_message(message_content=message)
 
 # OR
@@ -84,10 +85,10 @@ class KafkaClient:
         topic: str,
         consumer_group_prefix: Optional[str],
         security_protocol: str,
-        cafile_path: Optional[str],
-        certfile_path: Optional[str],
-        keyfile_path: Optional[str],
-        replication_factor: int,
+        cafile_path: Optional[str] = None,
+        certfile_path: Optional[str] = None,
+        keyfile_path: Optional[str] = None,
+        replication_factor: int = 3,
     ) -> None:
         self.servers = servers
         self.username = username

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,7 +10,7 @@ from subprocess import PIPE, check_output
 from typing import Any, Dict, List, Set, Tuple
 
 import yaml
-from client import KafkaClient
+from charms.kafka.v0.client import KafkaClient
 from kafka.admin import NewTopic
 from pytest_operator.plugin import OpsTest
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Set, Tuple
 
 import yaml
 from client import KafkaClient
+from kafka.admin import NewTopic
 from pytest_operator.plugin import OpsTest
 
 from auth import Acl, KafkaAuth
@@ -213,9 +214,16 @@ def produce_and_check_logs(
         consumer_group_prefix=None,
         security_protocol=security_protocol,
     )
+    topic_config = NewTopic(
+        name=client.topic,
+        num_partitions=5,
+        replication_factor=1,
+    )
 
-    client.create_topic()
-    client.run_producer()
+    client.create_topic(topic=topic_config)
+    for i in range(15):
+        message = f"Message #{i}"
+        client.produce_message(message_content=message)
 
     logs = check_output(
         f"JUJU_MODEL={model_full_name} juju ssh {kafka_unit_name} 'find /var/snap/kafka/common/log-data'",


### PR DESCRIPTION
## Changes Made
##### `refactor: move test client.py into dedicated lib`
- Implemented methods include:
    - Creating a topic with user-specified configuration
    - Producing a message to a topic name
    - Consuming messages from a topic name
- Lazy-loading `kafka-python` client objects where necessary
- Making `kafka-python` client objects internal
- Returning Generator of `KafkaConsumer` messages, as opposed to the raw object for modification