### PR TITLE
Add itest fixture for kafka itself

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,12 +6,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-
 on:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 on:
   pull_request:
   schedule:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import pytest
 from pytest_operator.plugin import OpsTest
-from pathlib import Path
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 from pytest_operator.plugin import OpsTest
+from pathlib import Path
 
 
 @pytest.fixture(scope="module")
@@ -34,7 +35,14 @@ def usernames():
 
 
 @pytest.fixture(scope="module")
-async def app_charm(ops_test: OpsTest):
+async def kafka_charm(ops_test: OpsTest) -> Path:
+    """Kafka charm used for integration testing."""
+    charm = await ops_test.build_charm(".")
+    return charm
+
+
+@pytest.fixture(scope="module")
+async def app_charm(ops_test: OpsTest) -> Path:
     """Build the application charm."""
     charm_path = "tests/integration/app-charm"
     charm = await ops_test.build_charm(charm_path)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,7 +5,6 @@
 import asyncio
 import logging
 import time
-from pathlib import PosixPath
 from subprocess import PIPE, check_output
 
 import pytest
@@ -30,8 +29,7 @@ DUMMY_NAME = "app"
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest):
-    kafka_charm = await ops_test.build_charm(".")
+async def test_build_and_deploy(ops_test: OpsTest, kafka_charm):
     await asyncio.gather(
         ops_test.model.deploy(
             ZK_NAME, channel="edge", application_name=ZK_NAME, num_units=1, series="jammy"
@@ -49,7 +47,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-async def test_listeners(ops_test: OpsTest, app_charm: PosixPath):
+async def test_listeners(ops_test: OpsTest, app_charm):
     address = await get_address(ops_test=ops_test)
     assert check_socket(
         address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT"].internal

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -15,8 +15,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
-async def test_build_and_deploy(ops_test: OpsTest):
-    kafka_charm = await ops_test.build_charm(".")
+async def test_build_and_deploy(ops_test: OpsTest, kafka_charm):
     await asyncio.gather(
         ops_test.model.deploy(
             ZK_NAME, channel="edge", application_name=ZK_NAME, num_units=3, series="jammy"

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import logging
-from pathlib import PosixPath
 from typing import Set
 
 import pytest
@@ -137,9 +136,7 @@ async def test_remove_application_removes_user_and_acls(ops_test: OpsTest, usern
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_producer_same_topic(
-    ops_test: OpsTest, app_charm, usernames: Set[str]
-):
+async def test_deploy_producer_same_topic(ops_test: OpsTest, app_charm, usernames: Set[str]):
     """Test the correct deployment and relation with role producer."""
     await asyncio.gather(
         ops_test.model.deploy(

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -33,15 +33,14 @@ REL_NAME_ADMIN = "kafka-client-admin"
 
 @pytest.mark.abort_on_fail
 async def test_deploy_charms_relate_active(
-    ops_test: OpsTest, app_charm: PosixPath, usernames: Set[str]
+    ops_test: OpsTest, kafka_charm, app_charm, usernames: Set[str]
 ):
     """Test deploy and relate operations."""
-    charm = await ops_test.build_charm(".")
     await asyncio.gather(
         ops_test.model.deploy(
             "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="jammy"
         ),
-        ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1, series="jammy"),
+        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="jammy"),
         ops_test.model.deploy(
             app_charm, application_name=DUMMY_NAME_1, num_units=1, series="jammy"
         ),
@@ -77,7 +76,7 @@ async def test_deploy_charms_relate_active(
 
 @pytest.mark.abort_on_fail
 async def test_deploy_multiple_charms_same_topic_relate_active(
-    ops_test: OpsTest, app_charm: PosixPath, usernames: Set[str]
+    ops_test: OpsTest, app_charm, usernames: Set[str]
 ):
     """Test relation with multiple applications."""
     await ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_2, num_units=1),
@@ -139,7 +138,7 @@ async def test_remove_application_removes_user_and_acls(ops_test: OpsTest, usern
 
 @pytest.mark.abort_on_fail
 async def test_deploy_producer_same_topic(
-    ops_test: OpsTest, app_charm: PosixPath, usernames: Set[str]
+    ops_test: OpsTest, app_charm, usernames: Set[str]
 ):
     """Test the correct deployment and relation with role producer."""
     await asyncio.gather(
@@ -215,7 +214,7 @@ async def test_admin_removed_from_super_users(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-async def test_connection_updated_on_tls_enabled(ops_test: OpsTest, app_charm: PosixPath):
+async def test_connection_updated_on_tls_enabled(ops_test: OpsTest, app_charm):
     """Test relation when TLS is enabled."""
     await ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_1, num_units=1),
     await ops_test.model.wait_for_idle(apps=[DUMMY_NAME_1])

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -24,9 +24,7 @@ DUMMY_NAME_1 = "app"
 
 
 @pytest.mark.abort_on_fail
-async def test_kafka_simple_scale_up(ops_test: OpsTest):
-    kafka_charm = await ops_test.build_charm(".")
-
+async def test_kafka_simple_scale_up(ops_test: OpsTest, kafka_charm):
     await asyncio.gather(
         ops_test.model.deploy(
             "zookeeper", channel="edge", application_name="zookeeper", num_units=3, series="jammy"

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -33,8 +33,7 @@ TLS_NAME = "tls-certificates-operator"
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
-async def test_deploy_tls(ops_test: OpsTest):
-    kafka_charm = await ops_test.build_charm(".")
+async def test_deploy_tls(ops_test: OpsTest, kafka_charm):
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
 
     await asyncio.gather(
@@ -59,7 +58,7 @@ async def test_deploy_tls(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-async def test_kafka_tls(ops_test: OpsTest, app_charm: PosixPath):
+async def test_kafka_tls(ops_test: OpsTest, app_charm):
     """Tests TLS on Kafka.
 
     Relates Zookeper[TLS] with Kakfa[Non-TLS]. This leads to a blocked status.

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import logging
-from pathlib import PosixPath
 
 import pytest
 from charms.tls_certificates_interface.v1.tls_certificates import generate_private_key


### PR DESCRIPTION
Before this PR only the tester charm `app_charm` had a fixture. This PR adds a fixture for kafka itself.

Drive-by fixes:
- Auto-cancel concurrent workflows
- Charm's path type hint [is Path](https://github.com/charmed-kubernetes/pytest-operator/blob/257eec333092a31231a66bb7e6683ac265fe48e2/pytest_operator/plugin.py#L897) (not PosixPath)