### PR TITLE
feature: mTLS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -74,8 +74,3 @@ options:
     description: Specifies the enabled cipher suites to be used in ZooKeeper TLS negotiation (csv). Overrides any explicit value set via the zookeeper.ssl.ciphersuites system property (note the single word "ciphersuites"). The default value of null means the list of enabled cipher suites is determined by the Java runtime being used.
     type: string
     default: ""
-  ssl_principal_mapping_rules:
-    description: A list of rules for mapping from distinguished name from the client certificate to short name.
-    type: string
-    default: "DEFAULT"
-  

--- a/config.yaml
+++ b/config.yaml
@@ -74,4 +74,8 @@ options:
     description: Specifies the enabled cipher suites to be used in ZooKeeper TLS negotiation (csv). Overrides any explicit value set via the zookeeper.ssl.ciphersuites system property (note the single word "ciphersuites"). The default value of null means the list of enabled cipher suites is determined by the Java runtime being used.
     type: string
     default: ""
+  ssl_principal_mapping_rules:
+    description: A list of rules for mapping from distinguished name from the client certificate to short name.
+    type: string
+    default: "DEFAULT"
   

--- a/lib/charms/tls_certificates_interface/v1/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v1/tls_certificates.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+
 """Library for the tls-certificates relation.
 
 This library contains the Requires and Provides classes for handling the tls-certificates
@@ -271,7 +272,8 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
+
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -1267,7 +1269,7 @@ class TLSCertificatesRequiresV1(Object):
             return False
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggerred on relation changed events.
+        """Handler triggered on relation changed events.
 
         Args:
             event: Juju event

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,6 +24,14 @@ requires:
     interface: tls-certificates
     limit: 1
     optional: true
+  trusted-ca:
+    interface: tls-certificates
+    limit: 10
+    optional: true
+  trusted-certificates:
+    interface: tls-certificates
+    limit: 10
+    optional: true
 
 provides:
   kafka-client:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,11 +26,9 @@ requires:
     optional: true
   trusted-ca:
     interface: tls-certificates
-    limit: 10
     optional: true
-  trusted-certificates:
+  trusted-certificate:
     interface: tls-certificates
-    limit: 10
     optional: true
 
 provides:

--- a/src/config.py
+++ b/src/config.py
@@ -258,12 +258,13 @@ class KafkaConfig:
         Returns:
             List of properties to be set
         """
+        mtls = "required" if self.charm.tls.mtls_enabled else "none"
         return [
             f"ssl.truststore.location={self.truststore_filepath}",
             f"ssl.truststore.password={self.charm.tls.truststore_password}",
             f"ssl.keystore.location={self.keystore_filepath}",
             f"ssl.keystore.password={self.charm.tls.keystore_password}",
-            "ssl.client.auth=none",
+            f"ssl.client.auth={mtls}",
         ]
 
     @property

--- a/src/config.py
+++ b/src/config.py
@@ -297,8 +297,10 @@ class KafkaConfig:
         """Return a list of enabled auth mechanisms."""
         # TODO: At the moment only one mechanism for extra listeners. Will need to be
         # extended with more depending on configuration settings.
-        protocol = self.security_protocol
-        return [protocol]
+        protocol = [self.security_protocol]
+        if self.charm.tls.mtls_enabled:
+            protocol += ["SSL"]
+        return protocol
 
     @property
     def internal_listener(self) -> Listener:

--- a/src/literals.py
+++ b/src/literals.py
@@ -17,7 +17,7 @@ REL_NAME = "kafka-client"
 INTER_BROKER_USER = "sync"
 ADMIN_USER = "admin"
 TLS_RELATION = "certificates"
-TRUSTED_CERTIFICATES_RELATION = "trusted-certificates"
+TRUSTED_CERTIFICATE_RELATION = "trusted-certificate"
 TRUSTED_CA_RELATION = "trusted-ca"
 
 AuthMechanism = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]

--- a/src/literals.py
+++ b/src/literals.py
@@ -17,6 +17,8 @@ REL_NAME = "kafka-client"
 INTER_BROKER_USER = "sync"
 ADMIN_USER = "admin"
 TLS_RELATION = "certificates"
+TRUSTED_CERTIFICATES_RELATION = "trusted-certificates"
+TRUSTED_CA_RELATION = "trusted-ca"
 
 AuthMechanism = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]
 Scope = Literal["INTERNAL", "CLIENT"]

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -59,6 +59,7 @@ class CharmConfig(BaseConfigModel):
     ssl_cipher_suites: Optional[str]
     replication_quota_window_num: int
     zookeeper_ssl_cipher_suites: Optional[str]
+    ssl_principal_mapping_rules: str
 
     @validator("*", pre=True)
     @classmethod

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -59,7 +59,6 @@ class CharmConfig(BaseConfigModel):
     ssl_cipher_suites: Optional[str]
     replication_quota_window_num: int
     zookeeper_ssl_cipher_suites: Optional[str]
-    ssl_principal_mapping_rules: str
 
     @validator("*", pre=True)
     @classmethod

--- a/src/tls.py
+++ b/src/tls.py
@@ -10,15 +10,16 @@ import subprocess
 from typing import Dict, List, Optional
 
 from charms.tls_certificates_interface.v1.tls_certificates import (
+    CertificateAvailableEvent,
     TLSCertificatesRequiresV1,
     generate_csr,
     generate_private_key,
 )
-from ops.charm import ActionEvent
+from ops.charm import ActionEvent, RelationCreatedEvent
 from ops.framework import Object
-from ops.model import Relation
+from ops.model import ActiveStatus, BlockedStatus, Relation
 
-from literals import TLS_RELATION
+from literals import TLS_RELATION, TRUSTED_CA_RELATION, TRUSTED_CERTIFICATES_RELATION
 from snap import SNAP_CONFIG_PATH
 from utils import generate_password, parse_tls_file, safe_write_to_file
 
@@ -32,7 +33,12 @@ class KafkaTLS(Object):
         super().__init__(charm, "tls")
         self.charm = charm
         self.certificates = TLSCertificatesRequiresV1(self.charm, TLS_RELATION)
+        self.trusted_certificates = TLSCertificatesRequiresV1(
+            self.charm, TRUSTED_CERTIFICATES_RELATION
+        )
+        self.trusted_ca = TLSCertificatesRequiresV1(self.charm, TRUSTED_CA_RELATION)
 
+        # Own certificates handlers
         self.framework.observe(
             self.charm.on[TLS_RELATION].relation_created, self._tls_relation_created
         )
@@ -49,6 +55,24 @@ class KafkaTLS(Object):
             getattr(self.certificates.on, "certificate_expiring"), self._on_certificate_expiring
         )
         self.framework.observe(self.charm.on.set_tls_private_key_action, self._set_tls_private_key)
+
+        # External certificates handlers (for mTLS)
+        self.framework.observe(
+            self.charm.on[TRUSTED_CERTIFICATES_RELATION].relation_created,
+            self._trusted_relation_created,
+        )
+        self.framework.observe(
+            self.charm.on[TRUSTED_CA_RELATION].relation_created,
+            self._trusted_relation_created,
+        )
+        self.framework.observe(
+            getattr(self.trusted_certificates.on, "certificate_available"),
+            self._on_trusted_cert_available,
+        )
+        self.framework.observe(
+            getattr(self.trusted_ca.on, "certificate_available"),
+            self._on_trusted_cert_available,
+        )
 
     def _tls_relation_created(self, _) -> None:
         """Handler for `certificates_relation_created` event."""
@@ -87,9 +111,63 @@ class KafkaTLS(Object):
         if not self.charm.unit.is_leader():
             return
 
-        self.peer_relation.data[self.charm.app].update({"tls": ""})
+        self.charm.app_peer_data.update({"tls": ""})
 
-    def _on_certificate_available(self, event) -> None:
+    def _trusted_relation_created(self, event: RelationCreatedEvent) -> None:
+        """Relate to trusted tls charm."""
+        if not self.charm.unit.is_leader():
+            return
+
+        if not self.enabled:
+            msg = "Own certificates are not set. Please relate using 'certificates' relation first"
+            logger.error(msg)
+            self.charm.unit.status = BlockedStatus(msg)
+            return
+
+        self.charm.app_peer_data.update({"mtls": "enabled"})
+
+        alias = self.generate_alias(app_name=event.app.name, relation_id=event.relation.id)
+        ### CREATE CSR
+        csr = generate_csr(
+            add_unique_id_to_subject_name=alias,
+            private_key=self.private_key.encode("utf-8"),
+            subject=self.charm.unit_peer_data.get("private-address", ""),
+            **self._sans,
+        )
+        self.charm.set_secret(scope="app", key=f"csr-{alias}", value=csr.decode("utf-8").strip())
+
+        if event.relation.name == TRUSTED_CERTIFICATES_RELATION:
+            self.trusted_certificates.request_certificate_creation(certificate_signing_request=csr)
+        elif event.relation.name == TRUSTED_CA_RELATION:
+            self.trusted_ca.request_certificate_creation(certificate_signing_request=csr)
+        ###############
+
+        self.charm.unit.status = ActiveStatus()
+
+    def _on_trusted_cert_available(self, event: CertificateAvailableEvent):
+        """dsa."""
+        if not self.enabled:
+            msg = "Own certificates are not set. Please relate using 'certificates' relation first"
+            logger.error(msg)
+            self.charm.unit.status = BlockedStatus(msg)
+            event.defer()
+            return
+
+        relation = self.discover_relation(csr=event.certificate_signing_request)
+        alias = self.generate_alias(relation.app.name, relation.id)
+        content = event.certificate if relation.name == TRUSTED_CERTIFICATES_RELATION else event.ca
+        filename = (
+            f"{alias}_cert.crt"
+            if relation.name == TRUSTED_CERTIFICATES_RELATION
+            else f"{alias}_ca.crt"
+        )
+
+        safe_write_to_file(content=content, path=f"{SNAP_CONFIG_PATH}/{filename}")
+        self.import_cert(alias=f"{alias}", filename=filename)
+
+        self.charm.unit.status = ActiveStatus()
+
+    def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Handler for `certificates_available` event after provider updates signed certs."""
         if not self.peer_relation:
             logger.warning("No peer relation on certificate available")
@@ -152,7 +230,16 @@ class KafkaTLS(Object):
         Returns:
             True if TLS encryption should be active. Otherwise False
         """
-        return self.peer_relation.data[self.charm.app].get("tls", "disabled") == "enabled"
+        return self.charm.app_peer_data.get("tls", "disabled") == "enabled"
+
+    @property
+    def mtls_enabled(self) -> bool:
+        """Flag to check if the cluster should run with mTLS.
+
+        Returns:
+            True if TLS encryption should be active. Otherwise False
+        """
+        return self.charm.app_peer_data.get("mtls", "disabled") == "enabled"
 
     @property
     def private_key(self) -> Optional[str]:
@@ -240,6 +327,10 @@ class KafkaTLS(Object):
             "sans_dns": [unit_name, socket.getfqdn()],
         }
 
+    def generate_alias(self, app_name: str, relation_id: int) -> str:
+        """Generate an alias from a relation. Used to identify ca certs."""
+        return f"{app_name}-{relation_id}"
+
     def set_server_key(self) -> None:
         """Sets the unit private-key."""
         if not self.private_key:
@@ -294,6 +385,34 @@ class KafkaTLS(Object):
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
             raise e
+
+    def import_cert(self, alias: str, filename: str) -> None:
+        """Tries to add a certificate to the truststore."""
+        try:
+            subprocess.check_output(
+                f"keytool -import -v -alias {alias} -file {filename} -keystore truststore.jks -storepass {self.truststore_password} -noprompt",
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+                cwd=SNAP_CONFIG_PATH,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(e.output)
+            raise e
+
+    def discover_relation(self, csr: str) -> Relation:
+        """Discover a relation matching the csr."""
+        all_relations = {
+            **self.model.relations[TRUSTED_CERTIFICATES_RELATION],
+            **self.model.relations[TRUSTED_CA_RELATION],
+        }
+        for rel in all_relations:
+            alias = self.generate_alias(rel.app.name, rel.id)
+            stored_csr = self.charm.get_secret(scope="app", key=f"csr-{alias}")
+            if stored_csr == csr:
+                return rel
+
+        return None
 
     def remove_stores(self) -> None:
         """Cleans up all keys/certs/stores on a unit."""

--- a/src/tls.py
+++ b/src/tls.py
@@ -40,10 +40,6 @@ class KafkaTLS(Object):
         super().__init__(charm, "tls")
         self.charm = charm
         self.certificates = TLSCertificatesRequiresV1(self.charm, TLS_RELATION)
-        # self.trusted_certificates = TLSCertificatesRequiresV1(
-        #     self.charm, TRUSTED_CERTIFICATES_RELATION
-        # )
-        # self.trusted_ca = TLSCertificatesRequiresV1(self.charm, TRUSTED_CA_RELATION)
 
         # Own certificates handlers
         self.framework.observe(
@@ -98,7 +94,6 @@ class KafkaTLS(Object):
         if not self.charm.unit.is_leader():
             return
 
-        # Create a "mtls" flag so a new listener (CLIENT_SSL) is created
         self.peer_relation.data[self.charm.app].update({"tls": "enabled"})
 
     def _tls_relation_joined(self, _) -> None:
@@ -144,6 +139,7 @@ class KafkaTLS(Object):
             self.charm.unit.status = BlockedStatus(msg)
             return
 
+        # Create a "mtls" flag so a new listener (CLIENT_SSL) is created
         self.charm.app_peer_data.update({"mtls": "enabled"})
         self.charm.unit.status = ActiveStatus()
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -212,7 +212,7 @@ class KafkaTLS(Object):
         )
         all_relations.remove(relation)
         logger.debug(f"Remaining relations: {all_relations}")
-        
+
         # No relations means that there are no certificates left in the truststore
         if not all_relations:
             self.charm.app_peer_data.update({"mtls": ""})

--- a/src/tls.py
+++ b/src/tls.py
@@ -136,12 +136,12 @@ class KafkaTLS(Object):
         if not self.enabled:
             msg = "Own certificates are not set. Please relate using 'certificates' relation first"
             logger.error(msg)
-            self.charm.unit.status = BlockedStatus(msg)
+            self.charm.app.status = BlockedStatus(msg)
             return
 
         # Create a "mtls" flag so a new listener (CLIENT_SSL) is created
         self.charm.app_peer_data.update({"mtls": "enabled"})
-        self.charm.unit.status = ActiveStatus()
+        self.charm.app.status = ActiveStatus()
 
     def _trusted_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Generate a CSR so the tls-certificates operator works as expected."""
@@ -187,8 +187,6 @@ class KafkaTLS(Object):
 
         safe_write_to_file(content=content, path=f"{SNAP_CONFIG_PATH}/{filename}")
         self.import_cert(alias=f"{alias}", filename=filename)
-
-        self.charm.unit.status = ActiveStatus()
 
     def _trusted_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handle relation broken for a trusted certificate/ca relation."""

--- a/src/tls.py
+++ b/src/tls.py
@@ -183,12 +183,7 @@ class KafkaTLS(Object):
             if event.relation.name == TRUSTED_CERTIFICATE_RELATION
             else provider_certificates[0]["ca"]
         )
-        filename = (
-            f"{alias}_cert.pem"
-            if event.relation.name == TRUSTED_CERTIFICATE_RELATION
-            else f"{alias}_ca.pem"
-        )
-
+        filename = f"{alias}.pem"
         safe_write_to_file(content=content, path=f"{SNAP_CONFIG_PATH}/{filename}")
         self.import_cert(alias=f"{alias}", filename=filename)
 
@@ -200,11 +195,7 @@ class KafkaTLS(Object):
         # All units will need to remove the cert from their truststore
         relation = event.relation
         alias = self.generate_alias(app_name=relation.app.name, relation_id=relation.id)
-        filename = (
-            f"{alias}_cert.pem"
-            if relation.name == TRUSTED_CERTIFICATE_RELATION
-            else f"{alias}_ca.pem"
-        )
+        filename = f"{alias}.pem"
         self.remove_cert(alias=alias, filename=filename)
 
         # The leader will also handle removing the "mtls" flag if needed
@@ -460,11 +451,18 @@ class KafkaTLS(Object):
             logger.error(e.output)
             raise e
 
-    def remove_cert(self, alias: str, filename: str) -> None:
+    def remove_cert(self, alias: str) -> None:
         """Remove a cert from the truststore."""
         try:
             subprocess.check_output(
-                f"keytool -delete -v -alias {alias} -keystore truststore.jks -storepass {self.truststore_password} -noprompt ; rm {filename}",
+                f"keytool -delete -v -alias {alias} -keystore truststore.jks -storepass {self.truststore_password} -noprompt",
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+                cwd=SNAP_CONFIG_PATH,
+            )
+            subprocess.check_output(
+                f"rm -f {alias}.pem",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,

--- a/src/tls.py
+++ b/src/tls.py
@@ -71,15 +71,7 @@ class KafkaTLS(Object):
             self._trusted_relation_created,
         )
         self.framework.observe(
-            self.charm.on[TRUSTED_CA_RELATION].relation_created,
-            self._trusted_relation_created,
-        )
-        self.framework.observe(
             self.charm.on[TRUSTED_CERTIFICATES_RELATION].relation_joined,
-            self._trusted_relation_joined,
-        )
-        self.framework.observe(
-            self.charm.on[TRUSTED_CA_RELATION].relation_joined,
             self._trusted_relation_joined,
         )
         self.framework.observe(
@@ -87,16 +79,20 @@ class KafkaTLS(Object):
             self._trusted_relation_changed,
         )
         self.framework.observe(
-            self.charm.on[TRUSTED_CA_RELATION].relation_changed,
-            self._trusted_relation_changed,
-        )
-        self.framework.observe(
-            self.charm.on[TRUSTED_CA_RELATION].relation_broken,
+            self.charm.on[TRUSTED_CERTIFICATES_RELATION].relation_broken,
             self._trusted_relation_broken,
         )
         self.framework.observe(
-            self.charm.on[TRUSTED_CA_RELATION].relation_broken,
-            self._trusted_relation_broken,
+            self.charm.on[TRUSTED_CA_RELATION].relation_created, self._trusted_relation_created
+        )
+        self.framework.observe(
+            self.charm.on[TRUSTED_CA_RELATION].relation_joined, self._trusted_relation_joined
+        )
+        self.framework.observe(
+            self.charm.on[TRUSTED_CA_RELATION].relation_changed, self._trusted_relation_changed
+        )
+        self.framework.observe(
+            self.charm.on[TRUSTED_CA_RELATION].relation_broken, self._trusted_relation_broken
         )
 
     def _tls_relation_created(self, _) -> None:
@@ -440,6 +436,7 @@ class KafkaTLS(Object):
         except subprocess.CalledProcessError as e:
             # in case this reruns and fails
             if "already exists" in e.output:
+                logger.warning(e.output)
                 return
             logger.error(e.output)
             raise e
@@ -455,6 +452,9 @@ class KafkaTLS(Object):
                 cwd=SNAP_CONFIG_PATH,
             )
         except subprocess.CalledProcessError as e:
+            if "does not exist" in e.output:
+                logger.warning(e.output)
+                return
             logger.error(e.output)
             raise e
 

--- a/tests/integration/app-charm/actions.yaml
+++ b/tests/integration/app-charm/actions.yaml
@@ -1,12 +1,15 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-create-keystore:
-  description: Creates JKS keystore on unit
+create-certificate:
+  description: Creates JKS keystore and signed certificate on unit
 
-create-truststore:
-  description: Creates JKS truststore on unit
+run-mtls-producer:
+  description: Runs producer
   params:
+    bootstrap-server:
+      type: string
+      description: The address for mtls Kafka
     broker-ca:
       type: string
       description: The CA used for broker identity from certificates relation

--- a/tests/integration/app-charm/actions.yaml
+++ b/tests/integration/app-charm/actions.yaml
@@ -1,11 +1,12 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-make-admin:
-  description: Adds admin to relation data
+create-keystore:
+  description: Creates JKS keystore on unit
 
-remove-admin:
-  description: Adds admin to relation data
-
-change-topic:
-  description: Changes topic
+create-truststore:
+  description: Creates JKS truststore on unit
+  params:
+    broker-ca:
+      type: string
+      description: The CA used for broker identity from certificates relation

--- a/tests/integration/app-charm/lib/charms/operator_libs_linux/v0/apt.py
+++ b/tests/integration/app-charm/lib/charms/operator_libs_linux/v0/apt.py
@@ -1,0 +1,1362 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Abstractions for the system's Debian/Ubuntu package information and repositories.
+
+This module contains abstractions and wrappers around Debian/Ubuntu-style repositories and
+packages, in order to easily provide an idiomatic and Pythonic mechanism for adding packages and/or
+repositories to systems for use in machine charms.
+
+A sane default configuration is attainable through nothing more than instantiation of the
+appropriate classes. `DebianPackage` objects provide information about the architecture, version,
+name, and status of a package.
+
+`DebianPackage` will try to look up a package either from `dpkg -L` or from `apt-cache` when
+provided with a string indicating the package name. If it cannot be located, `PackageNotFoundError`
+will be returned, as `apt` and `dpkg` otherwise return `100` for all errors, and a meaningful error
+message if the package is not known is desirable.
+
+To install packages with convenience methods:
+
+```python
+try:
+    # Run `apt-get update`
+    apt.update()
+    apt.add_package("zsh")
+    apt.add_package(["vim", "htop", "wget"])
+except PackageNotFoundError:
+    logger.error("a specified package not found in package cache or on system")
+except PackageError as e:
+    logger.error("could not install package. Reason: %s", e.message)
+````
+
+To find details of a specific package:
+
+```python
+try:
+    vim = apt.DebianPackage.from_system("vim")
+
+    # To find from the apt cache only
+    # apt.DebianPackage.from_apt_cache("vim")
+
+    # To find from installed packages only
+    # apt.DebianPackage.from_installed_package("vim")
+
+    vim.ensure(PackageState.Latest)
+    logger.info("updated vim to version: %s", vim.fullversion)
+except PackageNotFoundError:
+    logger.error("a specified package not found in package cache or on system")
+except PackageError as e:
+    logger.error("could not install package. Reason: %s", e.message)
+```
+
+
+`RepositoryMapping` will return a dict-like object containing enabled system repositories
+and their properties (available groups, baseuri. gpg key). This class can add, disable, or
+manipulate repositories. Items can be retrieved as `DebianRepository` objects.
+
+In order add a new repository with explicit details for fields, a new `DebianRepository` can
+be added to `RepositoryMapping`
+
+`RepositoryMapping` provides an abstraction around the existing repositories on the system,
+and can be accessed and iterated over like any `Mapping` object, to retrieve values by key,
+iterate, or perform other operations.
+
+Keys are constructed as `{repo_type}-{}-{release}` in order to uniquely identify a repository.
+
+Repositories can be added with explicit values through a Python constructor.
+
+Example:
+
+```python
+repositories = apt.RepositoryMapping()
+
+if "deb-example.com-focal" not in repositories:
+    repositories.add(DebianRepository(enabled=True, repotype="deb",
+                     uri="https://example.com", release="focal", groups=["universe"]))
+```
+
+Alternatively, any valid `sources.list` line may be used to construct a new
+`DebianRepository`.
+
+Example:
+
+```python
+repositories = apt.RepositoryMapping()
+
+if "deb-us.archive.ubuntu.com-xenial" not in repositories:
+    line = "deb http://us.archive.ubuntu.com/ubuntu xenial main restricted"
+    repo = DebianRepository.from_repo_line(line)
+    repositories.add(repo)
+```
+"""
+
+import fileinput
+import glob
+import logging
+import os
+import re
+import subprocess
+from collections.abc import Mapping
+from enum import Enum
+from subprocess import PIPE, CalledProcessError, check_call, check_output
+from typing import Iterable, List, Optional, Tuple, Union
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "7c3dbc9c2ad44a47bd6fcb25caa270e5"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 10
+
+
+VALID_SOURCE_TYPES = ("deb", "deb-src")
+OPTIONS_MATCHER = re.compile(r"\[.*?\]")
+
+
+class Error(Exception):
+    """Base class of most errors raised by this library."""
+
+    def __repr__(self):
+        """String representation of Error."""
+        return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
+
+    @property
+    def name(self):
+        """Return a string representation of the model plus class."""
+        return "<{}.{}>".format(type(self).__module__, type(self).__name__)
+
+    @property
+    def message(self):
+        """Return the message passed as an argument."""
+        return self.args[0]
+
+
+class PackageError(Error):
+    """Raised when there's an error installing or removing a package."""
+
+
+class PackageNotFoundError(Error):
+    """Raised when a requested package is not known to the system."""
+
+
+class PackageState(Enum):
+    """A class to represent possible package states."""
+
+    Present = "present"
+    Absent = "absent"
+    Latest = "latest"
+    Available = "available"
+
+
+class DebianPackage:
+    """Represents a traditional Debian package and its utility functions.
+
+    `DebianPackage` wraps information and functionality around a known package, whether installed
+    or available. The version, epoch, name, and architecture can be easily queried and compared
+    against other `DebianPackage` objects to determine the latest version or to install a specific
+    version.
+
+    The representation of this object as a string mimics the output from `dpkg` for familiarity.
+
+    Installation and removal of packages is handled through the `state` property or `ensure`
+    method, with the following options:
+
+        apt.PackageState.Absent
+        apt.PackageState.Available
+        apt.PackageState.Present
+        apt.PackageState.Latest
+
+    When `DebianPackage` is initialized, the state of a given `DebianPackage` object will be set to
+    `Available`, `Present`, or `Latest`, with `Absent` implemented as a convenience for removal
+    (though it operates essentially the same as `Available`).
+    """
+
+    def __init__(
+        self, name: str, version: str, epoch: str, arch: str, state: PackageState
+    ) -> None:
+        self._name = name
+        self._arch = arch
+        self._state = state
+        self._version = Version(version, epoch)
+
+    def __eq__(self, other) -> bool:
+        """Equality for comparison.
+
+        Args:
+          other: a `DebianPackage` object for comparison
+
+        Returns:
+          A boolean reflecting equality
+        """
+        return isinstance(other, self.__class__) and (
+            self._name,
+            self._version.number,
+        ) == (other._name, other._version.number)
+
+    def __hash__(self):
+        """A basic hash so this class can be used in Mappings and dicts."""
+        return hash((self._name, self._version.number))
+
+    def __repr__(self):
+        """A representation of the package."""
+        return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
+
+    def __str__(self):
+        """A human-readable representation of the package."""
+        return "<{}: {}-{}.{} -- {}>".format(
+            self.__class__.__name__,
+            self._name,
+            self._version,
+            self._arch,
+            str(self._state),
+        )
+
+    @staticmethod
+    def _apt(
+        command: str,
+        package_names: Union[str, List],
+        optargs: Optional[List[str]] = None,
+    ) -> None:
+        """Wrap package management commands for Debian/Ubuntu systems.
+
+        Args:
+          command: the command given to `apt-get`
+          package_names: a package name or list of package names to operate on
+          optargs: an (Optional) list of additioanl arguments
+
+        Raises:
+          PackageError if an error is encountered
+        """
+        optargs = optargs if optargs is not None else []
+        if isinstance(package_names, str):
+            package_names = [package_names]
+        _cmd = ["apt-get", "-y", *optargs, command, *package_names]
+        try:
+            env = os.environ.copy()
+            env["DEBIAN_FRONTEND"] = "noninteractive"
+            check_call(_cmd, env=env, stderr=PIPE, stdout=PIPE)
+        except CalledProcessError as e:
+            raise PackageError(
+                "Could not {} package(s) [{}]: {}".format(command, [*package_names], e.output)
+            ) from None
+
+    def _add(self) -> None:
+        """Add a package to the system."""
+        self._apt(
+            "install",
+            "{}={}".format(self.name, self.version),
+            optargs=["--option=Dpkg::Options::=--force-confold"],
+        )
+
+    def _remove(self) -> None:
+        """Removes a package from the system. Implementation-specific."""
+        return self._apt("remove", "{}={}".format(self.name, self.version))
+
+    @property
+    def name(self) -> str:
+        """Returns the name of the package."""
+        return self._name
+
+    def ensure(self, state: PackageState):
+        """Ensures that a package is in a given state.
+
+        Args:
+          state: a `PackageState` to reconcile the package to
+
+        Raises:
+          PackageError from the underlying call to apt
+        """
+        if self._state is not state:
+            if state not in (PackageState.Present, PackageState.Latest):
+                self._remove()
+            else:
+                self._add()
+        self._state = state
+
+    @property
+    def present(self) -> bool:
+        """Returns whether or not a package is present."""
+        return self._state in (PackageState.Present, PackageState.Latest)
+
+    @property
+    def latest(self) -> bool:
+        """Returns whether the package is the most recent version."""
+        return self._state is PackageState.Latest
+
+    @property
+    def state(self) -> PackageState:
+        """Returns the current package state."""
+        return self._state
+
+    @state.setter
+    def state(self, state: PackageState) -> None:
+        """Sets the package state to a given value.
+
+        Args:
+          state: a `PackageState` to reconcile the package to
+
+        Raises:
+          PackageError from the underlying call to apt
+        """
+        if state in (PackageState.Latest, PackageState.Present):
+            self._add()
+        else:
+            self._remove()
+        self._state = state
+
+    @property
+    def version(self) -> "Version":
+        """Returns the version for a package."""
+        return self._version
+
+    @property
+    def epoch(self) -> str:
+        """Returns the epoch for a package. May be unset."""
+        return self._version.epoch
+
+    @property
+    def arch(self) -> str:
+        """Returns the architecture for a package."""
+        return self._arch
+
+    @property
+    def fullversion(self) -> str:
+        """Returns the name+epoch for a package."""
+        return "{}.{}".format(self._version, self._arch)
+
+    @staticmethod
+    def _get_epoch_from_version(version: str) -> Tuple[str, str]:
+        """Pull the epoch, if any, out of a version string."""
+        epoch_matcher = re.compile(r"^((?P<epoch>\d+):)?(?P<version>.*)")
+        matches = epoch_matcher.search(version).groupdict()
+        return matches.get("epoch", ""), matches.get("version")
+
+    @classmethod
+    def from_system(
+        cls, package: str, version: Optional[str] = "", arch: Optional[str] = ""
+    ) -> "DebianPackage":
+        """Locates a package, either on the system or known to apt, and serializes the information.
+
+        Args:
+            package: a string representing the package
+            version: an optional string if a specific version is requested
+            arch: an optional architecture, defaulting to `dpkg --print-architecture`. If an
+                architecture is not specified, this will be used for selection.
+
+        """
+        try:
+            return DebianPackage.from_installed_package(package, version, arch)
+        except PackageNotFoundError:
+            logger.debug(
+                "package '%s' is not currently installed or has the wrong architecture.", package
+            )
+
+        # Ok, try `apt-cache ...`
+        try:
+            return DebianPackage.from_apt_cache(package, version, arch)
+        except (PackageNotFoundError, PackageError):
+            # If we get here, it's not known to the systems.
+            # This seems unnecessary, but virtually all `apt` commands have a return code of `100`,
+            # and providing meaningful error messages without this is ugly.
+            raise PackageNotFoundError(
+                "Package '{}{}' could not be found on the system or in the apt cache!".format(
+                    package, ".{}".format(arch) if arch else ""
+                )
+            ) from None
+
+    @classmethod
+    def from_installed_package(
+        cls, package: str, version: Optional[str] = "", arch: Optional[str] = ""
+    ) -> "DebianPackage":
+        """Check whether the package is already installed and return an instance.
+
+        Args:
+            package: a string representing the package
+            version: an optional string if a specific version is requested
+            arch: an optional architecture, defaulting to `dpkg --print-architecture`.
+                If an architecture is not specified, this will be used for selection.
+        """
+        system_arch = check_output(
+            ["dpkg", "--print-architecture"], universal_newlines=True
+        ).strip()
+        arch = arch if arch else system_arch
+
+        # Regexps are a really terrible way to do this. Thanks dpkg
+        output = ""
+        try:
+            output = check_output(["dpkg", "-l", package], stderr=PIPE, universal_newlines=True)
+        except CalledProcessError:
+            raise PackageNotFoundError("Package is not installed: {}".format(package)) from None
+
+        # Pop off the output from `dpkg -l' because there's no flag to
+        # omit it`
+        lines = str(output).splitlines()[5:]
+
+        dpkg_matcher = re.compile(
+            r"""
+        ^(?P<package_status>\w+?)\s+
+        (?P<package_name>.*?)(?P<throwaway_arch>:\w+?)?\s+
+        (?P<version>.*?)\s+
+        (?P<arch>\w+?)\s+
+        (?P<description>.*)
+        """,
+            re.VERBOSE,
+        )
+
+        for line in lines:
+            try:
+                matches = dpkg_matcher.search(line).groupdict()
+                package_status = matches["package_status"]
+
+                if not package_status.endswith("i"):
+                    logger.debug(
+                        "package '%s' in dpkg output but not installed, status: '%s'",
+                        package,
+                        package_status,
+                    )
+                    break
+
+                epoch, split_version = DebianPackage._get_epoch_from_version(matches["version"])
+                pkg = DebianPackage(
+                    matches["package_name"],
+                    split_version,
+                    epoch,
+                    matches["arch"],
+                    PackageState.Present,
+                )
+                if (pkg.arch == "all" or pkg.arch == arch) and (
+                    version == "" or str(pkg.version) == version
+                ):
+                    return pkg
+            except AttributeError:
+                logger.warning("dpkg matcher could not parse line: %s", line)
+
+        # If we didn't find it, fail through
+        raise PackageNotFoundError("Package {}.{} is not installed!".format(package, arch))
+
+    @classmethod
+    def from_apt_cache(
+        cls, package: str, version: Optional[str] = "", arch: Optional[str] = ""
+    ) -> "DebianPackage":
+        """Check whether the package is already installed and return an instance.
+
+        Args:
+            package: a string representing the package
+            version: an optional string if a specific version is requested
+            arch: an optional architecture, defaulting to `dpkg --print-architecture`.
+                If an architecture is not specified, this will be used for selection.
+        """
+        system_arch = check_output(
+            ["dpkg", "--print-architecture"], universal_newlines=True
+        ).strip()
+        arch = arch if arch else system_arch
+
+        # Regexps are a really terrible way to do this. Thanks dpkg
+        keys = ("Package", "Architecture", "Version")
+
+        try:
+            output = check_output(
+                ["apt-cache", "show", package], stderr=PIPE, universal_newlines=True
+            )
+        except CalledProcessError as e:
+            raise PackageError(
+                "Could not list packages in apt-cache: {}".format(e.output)
+            ) from None
+
+        pkg_groups = output.strip().split("\n\n")
+        keys = ("Package", "Architecture", "Version")
+
+        for pkg_raw in pkg_groups:
+            lines = str(pkg_raw).splitlines()
+            vals = {}
+            for line in lines:
+                if line.startswith(keys):
+                    items = line.split(":", 1)
+                    vals[items[0]] = items[1].strip()
+                else:
+                    continue
+
+            epoch, split_version = DebianPackage._get_epoch_from_version(vals["Version"])
+            pkg = DebianPackage(
+                vals["Package"],
+                split_version,
+                epoch,
+                vals["Architecture"],
+                PackageState.Available,
+            )
+
+            if (pkg.arch == "all" or pkg.arch == arch) and (
+                version == "" or str(pkg.version) == version
+            ):
+                return pkg
+
+        # If we didn't find it, fail through
+        raise PackageNotFoundError("Package {}.{} is not in the apt cache!".format(package, arch))
+
+
+class Version:
+    """An abstraction around package versions.
+
+    This seems like it should be strictly unnecessary, except that `apt_pkg` is not usable inside a
+    venv, and wedging version comparisons into `DebianPackage` would overcomplicate it.
+
+    This class implements the algorithm found here:
+    https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+    """
+
+    def __init__(self, version: str, epoch: str):
+        self._version = version
+        self._epoch = epoch or ""
+
+    def __repr__(self):
+        """A representation of the package."""
+        return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
+
+    def __str__(self):
+        """A human-readable representation of the package."""
+        return "{}{}".format("{}:".format(self._epoch) if self._epoch else "", self._version)
+
+    @property
+    def epoch(self):
+        """Returns the epoch for a package. May be empty."""
+        return self._epoch
+
+    @property
+    def number(self) -> str:
+        """Returns the version number for a package."""
+        return self._version
+
+    def _get_parts(self, version: str) -> Tuple[str, str]:
+        """Separate the version into component upstream and Debian pieces."""
+        try:
+            version.rindex("-")
+        except ValueError:
+            # No hyphens means no Debian version
+            return version, "0"
+
+        upstream, debian = version.rsplit("-", 1)
+        return upstream, debian
+
+    def _listify(self, revision: str) -> List[str]:
+        """Split a revision string into a listself.
+
+        This list is comprised of  alternating between strings and numbers,
+        padded on either end to always be "str, int, str, int..." and
+        always be of even length.  This allows us to trivially implement the
+        comparison algorithm described.
+        """
+        result = []
+        while revision:
+            rev_1, remains = self._get_alphas(revision)
+            rev_2, remains = self._get_digits(remains)
+            result.extend([rev_1, rev_2])
+            revision = remains
+        return result
+
+    def _get_alphas(self, revision: str) -> Tuple[str, str]:
+        """Return a tuple of the first non-digit characters of a revision."""
+        # get the index of the first digit
+        for i, char in enumerate(revision):
+            if char.isdigit():
+                if i == 0:
+                    return "", revision
+                return revision[0:i], revision[i:]
+        # string is entirely alphas
+        return revision, ""
+
+    def _get_digits(self, revision: str) -> Tuple[int, str]:
+        """Return a tuple of the first integer characters of a revision."""
+        # If the string is empty, return (0,'')
+        if not revision:
+            return 0, ""
+        # get the index of the first non-digit
+        for i, char in enumerate(revision):
+            if not char.isdigit():
+                if i == 0:
+                    return 0, revision
+                return int(revision[0:i]), revision[i:]
+        # string is entirely digits
+        return int(revision), ""
+
+    def _dstringcmp(self, a, b):  # noqa: C901
+        """Debian package version string section lexical sort algorithm.
+
+        The lexical comparison is a comparison of ASCII values modified so
+        that all the letters sort earlier than all the non-letters and so that
+        a tilde sorts before anything, even the end of a part.
+        """
+        if a == b:
+            return 0
+        try:
+            for i, char in enumerate(a):
+                if char == b[i]:
+                    continue
+                # "a tilde sorts before anything, even the end of a part"
+                # (emptyness)
+                if char == "~":
+                    return -1
+                if b[i] == "~":
+                    return 1
+                # "all the letters sort earlier than all the non-letters"
+                if char.isalpha() and not b[i].isalpha():
+                    return -1
+                if not char.isalpha() and b[i].isalpha():
+                    return 1
+                # otherwise lexical sort
+                if ord(char) > ord(b[i]):
+                    return 1
+                if ord(char) < ord(b[i]):
+                    return -1
+        except IndexError:
+            # a is longer than b but otherwise equal, greater unless there are tildes
+            if char == "~":
+                return -1
+            return 1
+        # if we get here, a is shorter than b but otherwise equal, so check for tildes...
+        if b[len(a)] == "~":
+            return 1
+        return -1
+
+    def _compare_revision_strings(self, first: str, second: str):  # noqa: C901
+        """Compare two debian revision strings."""
+        if first == second:
+            return 0
+
+        # listify pads results so that we will always be comparing ints to ints
+        # and strings to strings (at least until we fall off the end of a list)
+        first_list = self._listify(first)
+        second_list = self._listify(second)
+        if first_list == second_list:
+            return 0
+        try:
+            for i, item in enumerate(first_list):
+                # explicitly raise IndexError if we've fallen off the edge of list2
+                if i >= len(second_list):
+                    raise IndexError
+                # if the items are equal, next
+                if item == second_list[i]:
+                    continue
+                # numeric comparison
+                if isinstance(item, int):
+                    if item > second_list[i]:
+                        return 1
+                    if item < second_list[i]:
+                        return -1
+                else:
+                    # string comparison
+                    return self._dstringcmp(item, second_list[i])
+        except IndexError:
+            # rev1 is longer than rev2 but otherwise equal, hence greater
+            # ...except for goddamn tildes
+            if first_list[len(second_list)][0][0] == "~":
+                return 1
+            return 1
+        # rev1 is shorter than rev2 but otherwise equal, hence lesser
+        # ...except for goddamn tildes
+        if second_list[len(first_list)][0][0] == "~":
+            return -1
+        return -1
+
+    def _compare_version(self, other) -> int:
+        if (self.number, self.epoch) == (other.number, other.epoch):
+            return 0
+
+        if self.epoch < other.epoch:
+            return -1
+        if self.epoch > other.epoch:
+            return 1
+
+        # If none of these are true, follow the algorithm
+        upstream_version, debian_version = self._get_parts(self.number)
+        other_upstream_version, other_debian_version = self._get_parts(other.number)
+
+        upstream_cmp = self._compare_revision_strings(upstream_version, other_upstream_version)
+        if upstream_cmp != 0:
+            return upstream_cmp
+
+        debian_cmp = self._compare_revision_strings(debian_version, other_debian_version)
+        if debian_cmp != 0:
+            return debian_cmp
+
+        return 0
+
+    def __lt__(self, other) -> bool:
+        """Less than magic method impl."""
+        return self._compare_version(other) < 0
+
+    def __eq__(self, other) -> bool:
+        """Equality magic method impl."""
+        return self._compare_version(other) == 0
+
+    def __gt__(self, other) -> bool:
+        """Greater than magic method impl."""
+        return self._compare_version(other) > 0
+
+    def __le__(self, other) -> bool:
+        """Less than or equal to magic method impl."""
+        return self.__eq__(other) or self.__lt__(other)
+
+    def __ge__(self, other) -> bool:
+        """Greater than or equal to magic method impl."""
+        return self.__gt__(other) or self.__eq__(other)
+
+    def __ne__(self, other) -> bool:
+        """Not equal to magic method impl."""
+        return not self.__eq__(other)
+
+
+def add_package(
+    package_names: Union[str, List[str]],
+    version: Optional[str] = "",
+    arch: Optional[str] = "",
+    update_cache: Optional[bool] = False,
+) -> Union[DebianPackage, List[DebianPackage]]:
+    """Add a package or list of packages to the system.
+
+    Args:
+        name: the name(s) of the package(s)
+        version: an (Optional) version as a string. Defaults to the latest known
+        arch: an optional architecture for the package
+        update_cache: whether or not to run `apt-get update` prior to operating
+
+    Raises:
+        TypeError if no package name is given, or explicit version is set for multiple packages
+        PackageNotFoundError if the package is not in the cache.
+        PackageError if packages fail to install
+    """
+    cache_refreshed = False
+    if update_cache:
+        update()
+        cache_refreshed = True
+
+    packages = {"success": [], "retry": [], "failed": []}
+
+    package_names = [package_names] if type(package_names) is str else package_names
+    if not package_names:
+        raise TypeError("Expected at least one package name to add, received zero!")
+
+    if len(package_names) != 1 and version:
+        raise TypeError(
+            "Explicit version should not be set if more than one package is being added!"
+        )
+
+    for p in package_names:
+        pkg, success = _add(p, version, arch)
+        if success:
+            packages["success"].append(pkg)
+        else:
+            logger.warning("failed to locate and install/update '%s'", pkg)
+            packages["retry"].append(p)
+
+    if packages["retry"] and not cache_refreshed:
+        logger.info("updating the apt-cache and retrying installation of failed packages.")
+        update()
+
+        for p in packages["retry"]:
+            pkg, success = _add(p, version, arch)
+            if success:
+                packages["success"].append(pkg)
+            else:
+                packages["failed"].append(p)
+
+    if packages["failed"]:
+        raise PackageError("Failed to install packages: {}".format(", ".join(packages["failed"])))
+
+    return packages["success"] if len(packages["success"]) > 1 else packages["success"][0]
+
+
+def _add(
+    name: str,
+    version: Optional[str] = "",
+    arch: Optional[str] = "",
+) -> Tuple[Union[DebianPackage, str], bool]:
+    """Adds a package.
+
+    Args:
+        name: the name(s) of the package(s)
+        version: an (Optional) version as a string. Defaults to the latest known
+        arch: an optional architecture for the package
+
+    Returns: a tuple of `DebianPackage` if found, or a :str: if it is not, and
+        a boolean indicating success
+    """
+    try:
+        pkg = DebianPackage.from_system(name, version, arch)
+        pkg.ensure(state=PackageState.Present)
+        return pkg, True
+    except PackageNotFoundError:
+        return name, False
+
+
+def remove_package(
+    package_names: Union[str, List[str]]
+) -> Union[DebianPackage, List[DebianPackage]]:
+    """Removes a package from the system.
+
+    Args:
+        package_names: the name of a package
+
+    Raises:
+        PackageNotFoundError if the package is not found.
+    """
+    packages = []
+
+    package_names = [package_names] if type(package_names) is str else package_names
+    if not package_names:
+        raise TypeError("Expected at least one package name to add, received zero!")
+
+    for p in package_names:
+        try:
+            pkg = DebianPackage.from_installed_package(p)
+            pkg.ensure(state=PackageState.Absent)
+            packages.append(pkg)
+        except PackageNotFoundError:
+            logger.info("package '%s' was requested for removal, but it was not installed.", p)
+
+    # the list of packages will be empty when no package is removed
+    logger.debug("packages: '%s'", packages)
+    return packages[0] if len(packages) == 1 else packages
+
+
+def update() -> None:
+    """Updates the apt cache via `apt-get update`."""
+    check_call(["apt-get", "update"], stderr=PIPE, stdout=PIPE)
+
+
+def import_key(key: str) -> str:
+    """Import an ASCII Armor key.
+
+    A Radix64 format keyid is also supported for backwards
+    compatibility. In this case Ubuntu keyserver will be
+    queried for a key via HTTPS by its keyid. This method
+    is less preferable because https proxy servers may
+    require traffic decryption which is equivalent to a
+    man-in-the-middle attack (a proxy server impersonates
+    keyserver TLS certificates and has to be explicitly
+    trusted by the system).
+
+    Args:
+        key: A GPG key in ASCII armor format, including BEGIN
+            and END markers or a keyid.
+
+    Returns:
+        The GPG key filename written.
+
+    Raises:
+        GPGKeyError if the key could not be imported
+    """
+    key = key.strip()
+    if "-" in key or "\n" in key:
+        # Send everything not obviously a keyid to GPG to import, as
+        # we trust its validation better than our own. eg. handling
+        # comments before the key.
+        logger.debug("PGP key found (looks like ASCII Armor format)")
+        if (
+            "-----BEGIN PGP PUBLIC KEY BLOCK-----" in key
+            and "-----END PGP PUBLIC KEY BLOCK-----" in key
+        ):
+            logger.debug("Writing provided PGP key in the binary format")
+            key_bytes = key.encode("utf-8")
+            key_name = DebianRepository._get_keyid_by_gpg_key(key_bytes)
+            key_gpg = DebianRepository._dearmor_gpg_key(key_bytes)
+            gpg_key_filename = "/etc/apt/trusted.gpg.d/{}.gpg".format(key_name)
+            DebianRepository._write_apt_gpg_keyfile(
+                key_name=gpg_key_filename, key_material=key_gpg
+            )
+            return gpg_key_filename
+        else:
+            raise GPGKeyError("ASCII armor markers missing from GPG key")
+    else:
+        logger.warning(
+            "PGP key found (looks like Radix64 format). "
+            "SECURELY importing PGP key from keyserver; "
+            "full key not provided."
+        )
+        # as of bionic add-apt-repository uses curl with an HTTPS keyserver URL
+        # to retrieve GPG keys. `apt-key adv` command is deprecated as is
+        # apt-key in general as noted in its manpage. See lp:1433761 for more
+        # history. Instead, /etc/apt/trusted.gpg.d is used directly to drop
+        # gpg
+        key_asc = DebianRepository._get_key_by_keyid(key)
+        # write the key in GPG format so that apt-key list shows it
+        key_gpg = DebianRepository._dearmor_gpg_key(key_asc.encode("utf-8"))
+        gpg_key_filename = "/etc/apt/trusted.gpg.d/{}.gpg".format(key)
+        DebianRepository._write_apt_gpg_keyfile(key_name=gpg_key_filename, key_material=key_gpg)
+        return gpg_key_filename
+
+
+class InvalidSourceError(Error):
+    """Exceptions for invalid source entries."""
+
+
+class GPGKeyError(Error):
+    """Exceptions for GPG keys."""
+
+
+class DebianRepository:
+    """An abstraction to represent a repository."""
+
+    def __init__(
+        self,
+        enabled: bool,
+        repotype: str,
+        uri: str,
+        release: str,
+        groups: List[str],
+        filename: Optional[str] = "",
+        gpg_key_filename: Optional[str] = "",
+        options: Optional[dict] = None,
+    ):
+        self._enabled = enabled
+        self._repotype = repotype
+        self._uri = uri
+        self._release = release
+        self._groups = groups
+        self._filename = filename
+        self._gpg_key_filename = gpg_key_filename
+        self._options = options
+
+    @property
+    def enabled(self):
+        """Return whether or not the repository is enabled."""
+        return self._enabled
+
+    @property
+    def repotype(self):
+        """Return whether it is binary or source."""
+        return self._repotype
+
+    @property
+    def uri(self):
+        """Return the URI."""
+        return self._uri
+
+    @property
+    def release(self):
+        """Return which Debian/Ubuntu releases it is valid for."""
+        return self._release
+
+    @property
+    def groups(self):
+        """Return the enabled package groups."""
+        return self._groups
+
+    @property
+    def filename(self):
+        """Returns the filename for a repository."""
+        return self._filename
+
+    @filename.setter
+    def filename(self, fname: str) -> None:
+        """Sets the filename used when a repo is written back to diskself.
+
+        Args:
+            fname: a filename to write the repository information to.
+        """
+        if not fname.endswith(".list"):
+            raise InvalidSourceError("apt source filenames should end in .list!")
+
+        self._filename = fname
+
+    @property
+    def gpg_key(self):
+        """Returns the path to the GPG key for this repository."""
+        return self._gpg_key_filename
+
+    @property
+    def options(self):
+        """Returns any additional repo options which are set."""
+        return self._options
+
+    def make_options_string(self) -> str:
+        """Generate the complete options string for a a repository.
+
+        Combining `gpg_key`, if set, and the rest of the options to find
+        a complex repo string.
+        """
+        options = self._options if self._options else {}
+        if self._gpg_key_filename:
+            options["signed-by"] = self._gpg_key_filename
+
+        return (
+            "[{}] ".format(" ".join(["{}={}".format(k, v) for k, v in options.items()]))
+            if options
+            else ""
+        )
+
+    @staticmethod
+    def prefix_from_uri(uri: str) -> str:
+        """Get a repo list prefix from the uri, depending on whether a path is set."""
+        uridetails = urlparse(uri)
+        path = (
+            uridetails.path.lstrip("/").replace("/", "-") if uridetails.path else uridetails.netloc
+        )
+        return "/etc/apt/sources.list.d/{}".format(path)
+
+    @staticmethod
+    def from_repo_line(repo_line: str, write_file: Optional[bool] = True) -> "DebianRepository":
+        """Instantiate a new `DebianRepository` a `sources.list` entry line.
+
+        Args:
+            repo_line: a string representing a repository entry
+            write_file: boolean to enable writing the new repo to disk
+        """
+        repo = RepositoryMapping._parse(repo_line, "UserInput")
+        fname = "{}-{}.list".format(
+            DebianRepository.prefix_from_uri(repo.uri), repo.release.replace("/", "-")
+        )
+        repo.filename = fname
+
+        options = repo.options if repo.options else {}
+        if repo.gpg_key:
+            options["signed-by"] = repo.gpg_key
+
+        # For Python 3.5 it's required to use sorted in the options dict in order to not have
+        # different results in the order of the options between executions.
+        options_str = (
+            "[{}] ".format(" ".join(["{}={}".format(k, v) for k, v in sorted(options.items())]))
+            if options
+            else ""
+        )
+
+        if write_file:
+            with open(fname, "wb") as f:
+                f.write(
+                    (
+                        "{}".format("#" if not repo.enabled else "")
+                        + "{} {}{} ".format(repo.repotype, options_str, repo.uri)
+                        + "{} {}\n".format(repo.release, " ".join(repo.groups))
+                    ).encode("utf-8")
+                )
+
+        return repo
+
+    def disable(self) -> None:
+        """Remove this repository from consideration.
+
+        Disable it instead of removing from the repository file.
+        """
+        searcher = "{} {}{} {}".format(
+            self.repotype, self.make_options_string(), self.uri, self.release
+        )
+        for line in fileinput.input(self._filename, inplace=True):
+            if re.match(r"^{}\s".format(re.escape(searcher)), line):
+                print("# {}".format(line), end="")
+            else:
+                print(line, end="")
+
+    def import_key(self, key: str) -> None:
+        """Import an ASCII Armor key.
+
+        A Radix64 format keyid is also supported for backwards
+        compatibility. In this case Ubuntu keyserver will be
+        queried for a key via HTTPS by its keyid. This method
+        is less preferable because https proxy servers may
+        require traffic decryption which is equivalent to a
+        man-in-the-middle attack (a proxy server impersonates
+        keyserver TLS certificates and has to be explicitly
+        trusted by the system).
+
+        Args:
+          key: A GPG key in ASCII armor format,
+                      including BEGIN and END markers or a keyid.
+
+        Raises:
+          GPGKeyError if the key could not be imported
+        """
+        self._gpg_key_filename = import_key(key)
+
+    @staticmethod
+    def _get_keyid_by_gpg_key(key_material: bytes) -> str:
+        """Get a GPG key fingerprint by GPG key material.
+
+        Gets a GPG key fingerprint (40-digit, 160-bit) by the ASCII armor-encoded
+        or binary GPG key material. Can be used, for example, to generate file
+        names for keys passed via charm options.
+        """
+        # Use the same gpg command for both Xenial and Bionic
+        cmd = ["gpg", "--with-colons", "--with-fingerprint"]
+        ps = subprocess.run(
+            cmd,
+            stdout=PIPE,
+            stderr=PIPE,
+            input=key_material,
+        )
+        out, err = ps.stdout.decode(), ps.stderr.decode()
+        if "gpg: no valid OpenPGP data found." in err:
+            raise GPGKeyError("Invalid GPG key material provided")
+        # from gnupg2 docs: fpr :: Fingerprint (fingerprint is in field 10)
+        return re.search(r"^fpr:{9}([0-9A-F]{40}):$", out, re.MULTILINE).group(1)
+
+    @staticmethod
+    def _get_key_by_keyid(keyid: str) -> str:
+        """Get a key via HTTPS from the Ubuntu keyserver.
+
+        Different key ID formats are supported by SKS keyservers (the longer ones
+        are more secure, see "dead beef attack" and https://evil32.com/). Since
+        HTTPS is used, if SSLBump-like HTTPS proxies are in place, they will
+        impersonate keyserver.ubuntu.com and generate a certificate with
+        keyserver.ubuntu.com in the CN field or in SubjAltName fields of a
+        certificate. If such proxy behavior is expected it is necessary to add the
+        CA certificate chain containing the intermediate CA of the SSLBump proxy to
+        every machine that this code runs on via ca-certs cloud-init directive (via
+        cloudinit-userdata model-config) or via other means (such as through a
+        custom charm option). Also note that DNS resolution for the hostname in a
+        URL is done at a proxy server - not at the client side.
+        8-digit (32 bit) key ID
+        https://keyserver.ubuntu.com/pks/lookup?search=0x4652B4E6
+        16-digit (64 bit) key ID
+        https://keyserver.ubuntu.com/pks/lookup?search=0x6E85A86E4652B4E6
+        40-digit key ID:
+        https://keyserver.ubuntu.com/pks/lookup?search=0x35F77D63B5CEC106C577ED856E85A86E4652B4E6
+
+        Args:
+          keyid: An 8, 16 or 40 hex digit keyid to find a key for
+
+        Returns:
+          A string contining key material for the specified GPG key id
+
+
+        Raises:
+          subprocess.CalledProcessError
+        """
+        # options=mr - machine-readable output (disables html wrappers)
+        keyserver_url = (
+            "https://keyserver.ubuntu.com" "/pks/lookup?op=get&options=mr&exact=on&search=0x{}"
+        )
+        curl_cmd = ["curl", keyserver_url.format(keyid)]
+        # use proxy server settings in order to retrieve the key
+        return check_output(curl_cmd).decode()
+
+    @staticmethod
+    def _dearmor_gpg_key(key_asc: bytes) -> bytes:
+        """Converts a GPG key in the ASCII armor format to the binary format.
+
+        Args:
+          key_asc: A GPG key in ASCII armor format.
+
+        Returns:
+          A GPG key in binary format as a string
+
+        Raises:
+          GPGKeyError
+        """
+        ps = subprocess.run(["gpg", "--dearmor"], stdout=PIPE, stderr=PIPE, input=key_asc)
+        out, err = ps.stdout, ps.stderr.decode()
+        if "gpg: no valid OpenPGP data found." in err:
+            raise GPGKeyError(
+                "Invalid GPG key material. Check your network setup"
+                " (MTU, routing, DNS) and/or proxy server settings"
+                " as well as destination keyserver status."
+            )
+        else:
+            return out
+
+    @staticmethod
+    def _write_apt_gpg_keyfile(key_name: str, key_material: bytes) -> None:
+        """Writes GPG key material into a file at a provided path.
+
+        Args:
+          key_name: A key name to use for a key file (could be a fingerprint)
+          key_material: A GPG key material (binary)
+        """
+        with open(key_name, "wb") as keyf:
+            keyf.write(key_material)
+
+
+class RepositoryMapping(Mapping):
+    """An representation of known repositories.
+
+    Instantiation of `RepositoryMapping` will iterate through the
+    filesystem, parse out repository files in `/etc/apt/...`, and create
+    `DebianRepository` objects in this list.
+
+    Typical usage:
+
+        repositories = apt.RepositoryMapping()
+        repositories.add(DebianRepository(
+            enabled=True, repotype="deb", uri="https://example.com", release="focal",
+            groups=["universe"]
+        ))
+    """
+
+    def __init__(self):
+        self._repository_map = {}
+        # Repositories that we're adding -- used to implement mode param
+        self.default_file = "/etc/apt/sources.list"
+
+        # read sources.list if it exists
+        if os.path.isfile(self.default_file):
+            self.load(self.default_file)
+
+        # read sources.list.d
+        for file in glob.iglob("/etc/apt/sources.list.d/*.list"):
+            self.load(file)
+
+    def __contains__(self, key: str) -> bool:
+        """Magic method for checking presence of repo in mapping."""
+        return key in self._repository_map
+
+    def __len__(self) -> int:
+        """Return number of repositories in map."""
+        return len(self._repository_map)
+
+    def __iter__(self) -> Iterable[DebianRepository]:
+        """Iterator magic method for RepositoryMapping."""
+        return iter(self._repository_map.values())
+
+    def __getitem__(self, repository_uri: str) -> DebianRepository:
+        """Return a given `DebianRepository`."""
+        return self._repository_map[repository_uri]
+
+    def __setitem__(self, repository_uri: str, repository: DebianRepository) -> None:
+        """Add a `DebianRepository` to the cache."""
+        self._repository_map[repository_uri] = repository
+
+    def load(self, filename: str):
+        """Load a repository source file into the cache.
+
+        Args:
+          filename: the path to the repository file
+        """
+        parsed = []
+        skipped = []
+        with open(filename, "r") as f:
+            for n, line in enumerate(f):
+                try:
+                    repo = self._parse(line, filename)
+                except InvalidSourceError:
+                    skipped.append(n)
+                else:
+                    repo_identifier = "{}-{}-{}".format(repo.repotype, repo.uri, repo.release)
+                    self._repository_map[repo_identifier] = repo
+                    parsed.append(n)
+                    logger.debug("parsed repo: '%s'", repo_identifier)
+
+        if skipped:
+            skip_list = ", ".join(str(s) for s in skipped)
+            logger.debug("skipped the following lines in file '%s': %s", filename, skip_list)
+
+        if parsed:
+            logger.info("parsed %d apt package repositories", len(parsed))
+        else:
+            raise InvalidSourceError("all repository lines in '{}' were invalid!".format(filename))
+
+    @staticmethod
+    def _parse(line: str, filename: str) -> DebianRepository:
+        """Parse a line in a sources.list file.
+
+        Args:
+          line: a single line from `load` to parse
+          filename: the filename being read
+
+        Raises:
+          InvalidSourceError if the source type is unknown
+        """
+        enabled = True
+        repotype = uri = release = gpg_key = ""
+        options = {}
+        groups = []
+
+        line = line.strip()
+        if line.startswith("#"):
+            enabled = False
+            line = line[1:]
+
+        # Check for "#" in the line and treat a part after it as a comment then strip it off.
+        i = line.find("#")
+        if i > 0:
+            line = line[:i]
+
+        # Split a source into substrings to initialize a new repo.
+        source = line.strip()
+        if source:
+            # Match any repo options, and get a dict representation.
+            for v in re.findall(OPTIONS_MATCHER, source):
+                opts = dict(o.split("=") for o in v.strip("[]").split())
+                # Extract the 'signed-by' option for the gpg_key
+                gpg_key = opts.pop("signed-by", "")
+                options = opts
+
+            # Remove any options from the source string and split the string into chunks
+            source = re.sub(OPTIONS_MATCHER, "", source)
+            chunks = source.split()
+
+            # Check we've got a valid list of chunks
+            if len(chunks) < 3 or chunks[0] not in VALID_SOURCE_TYPES:
+                raise InvalidSourceError("An invalid sources line was found in %s!", filename)
+
+            repotype = chunks[0]
+            uri = chunks[1]
+            release = chunks[2]
+            groups = chunks[3:]
+
+            return DebianRepository(
+                enabled, repotype, uri, release, groups, filename, gpg_key, options
+            )
+        else:
+            raise InvalidSourceError("An invalid sources line was found in %s!", filename)
+
+    def add(self, repo: DebianRepository, default_filename: Optional[bool] = False) -> None:
+        """Add a new repository to the system.
+
+        Args:
+          repo: a `DebianRepository` object
+          default_filename: an (Optional) filename if the default is not desirable
+        """
+        new_filename = "{}-{}.list".format(
+            DebianRepository.prefix_from_uri(repo.uri), repo.release.replace("/", "-")
+        )
+
+        fname = repo.filename or new_filename
+
+        options = repo.options if repo.options else {}
+        if repo.gpg_key:
+            options["signed-by"] = repo.gpg_key
+
+        with open(fname, "wb") as f:
+            f.write(
+                (
+                    "{}".format("#" if not repo.enabled else "")
+                    + "{} {}{} ".format(repo.repotype, repo.make_options_string(), repo.uri)
+                    + "{} {}\n".format(repo.release, " ".join(repo.groups))
+                ).encode("utf-8")
+            )
+
+        self._repository_map["{}-{}-{}".format(repo.repotype, repo.uri, repo.release)] = repo
+
+    def disable(self, repo: DebianRepository) -> None:
+        """Remove a repository. Disable by default.
+
+        Args:
+          repo: a `DebianRepository` to disable
+        """
+        searcher = "{} {}{} {}".format(
+            repo.repotype, repo.make_options_string(), repo.uri, repo.release
+        )
+
+        for line in fileinput.input(repo.filename, inplace=True):
+            if re.match(r"^{}\s".format(re.escape(searcher)), line):
+                print("# {}".format(line), end="")
+            else:
+                print(line, end="")
+
+        self._repository_map["{}-{}-{}".format(repo.repotype, repo.uri, repo.release)] = repo

--- a/tests/integration/app-charm/lib/charms/operator_libs_linux/v0/apt.py
+++ b/tests/integration/app-charm/lib/charms/operator_libs_linux/v0/apt.py
@@ -78,7 +78,6 @@ Keys are constructed as `{repo_type}-{}-{release}` in order to uniquely identify
 Repositories can be added with explicit values through a Python constructor.
 
 Example:
-
 ```python
 repositories = apt.RepositoryMapping()
 
@@ -91,7 +90,6 @@ Alternatively, any valid `sources.list` line may be used to construct a new
 `DebianRepository`.
 
 Example:
-
 ```python
 repositories = apt.RepositoryMapping()
 

--- a/tests/integration/app-charm/lib/charms/operator_libs_linux/v1/snap.py
+++ b/tests/integration/app-charm/lib/charms/operator_libs_linux/v1/snap.py
@@ -1,0 +1,1001 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Representations of the system's Snaps, and abstractions around managing them.
+
+The `snap` module provides convenience methods for listing, installing, refreshing, and removing
+Snap packages, in addition to setting and getting configuration options for them.
+
+In the `snap` module, `SnapCache` creates a dict-like mapping of `Snap` objects at when
+instantiated. Installed snaps are fully populated, and available snaps are lazily-loaded upon
+request. This module relies on an installed and running `snapd` daemon to perform operations over
+the `snapd` HTTP API.
+
+`SnapCache` objects can be used to install or modify Snap packages by name in a manner similar to
+using the `snap` command from the commandline.
+
+An example of adding Juju to the system with `SnapCache` and setting a config value:
+
+```python
+try:
+    cache = snap.SnapCache()
+    juju = cache["juju"]
+
+    if not juju.present:
+        juju.ensure(snap.SnapState.Latest, channel="beta")
+        juju.set({"some.key": "value", "some.key2": "value2"})
+except snap.SnapError as e:
+    logger.error("An exception occurred when installing charmcraft. Reason: %s", e.message)
+```
+
+In addition, the `snap` module provides "bare" methods which can act on Snap packages as
+simple function calls. :meth:`add`, :meth:`remove`, and :meth:`ensure` are provided, as
+well as :meth:`add_local` for installing directly from a local `.snap` file. These return
+`Snap` objects.
+
+As an example of installing several Snaps and checking details:
+
+```python
+try:
+    nextcloud, charmcraft = snap.add(["nextcloud", "charmcraft"])
+    if nextcloud.get("mode") != "production":
+        nextcloud.set({"mode": "production"})
+except snap.SnapError as e:
+    logger.error("An exception occurred when installing snaps. Reason: %s" % e.message)
+```
+"""
+
+import http.client
+import json
+import logging
+import os
+import re
+import socket
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from subprocess import CalledProcessError, CompletedProcess
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "05394e5893f94f2d90feb7cbe6b633cd"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 7
+
+
+# Regex to locate 7-bit C1 ANSI sequences
+ansi_filter = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def _cache_init(func):
+    def inner(*args, **kwargs):
+        if _Cache.cache is None:
+            _Cache.cache = SnapCache()
+        return func(*args, **kwargs)
+
+    return inner
+
+
+# recursive hints seems to error out pytest
+JSONType = Union[Dict[str, Any], List[Any], str, int, float]
+
+
+class SnapService:
+    """Data wrapper for snap services."""
+
+    def __init__(
+        self,
+        daemon: Optional[str] = None,
+        daemon_scope: Optional[str] = None,
+        enabled: bool = False,
+        active: bool = False,
+        activators: List[str] = [],
+        **kwargs
+    ):
+        self.daemon = daemon
+        self.daemon_scope = kwargs.get("daemon-scope", None) or daemon_scope
+        self.enabled = enabled
+        self.active = active
+        self.activators = activators
+
+    def as_dict(self) -> Dict:
+        """Returns instance representation as dict."""
+        return {
+            "daemon": self.daemon,
+            "daemon_scope": self.daemon_scope,
+            "enabled": self.enabled,
+            "active": self.active,
+            "activators": self.activators,
+        }
+
+
+class MetaCache(type):
+    """MetaCache class used for initialising the snap cache."""
+
+    @property
+    def cache(cls) -> "SnapCache":
+        """Property for returning the snap cache."""
+        return cls._cache
+
+    @cache.setter
+    def cache(cls, cache: "SnapCache") -> None:
+        """Setter for the snap cache."""
+        cls._cache = cache
+
+    def __getitem__(cls, name) -> "Snap":
+        """Snap cache getter."""
+        return cls._cache[name]
+
+
+class _Cache(object, metaclass=MetaCache):
+    _cache = None
+
+
+class Error(Exception):
+    """Base class of most errors raised by this library."""
+
+    def __repr__(self):
+        """String representation of the Error class."""
+        return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
+
+    @property
+    def name(self):
+        """Return a string representation of the model plus class."""
+        return "<{}.{}>".format(type(self).__module__, type(self).__name__)
+
+    @property
+    def message(self):
+        """Return the message passed as an argument."""
+        return self.args[0]
+
+
+class SnapAPIError(Error):
+    """Raised when an HTTP API error occurs talking to the Snapd server."""
+
+    def __init__(self, body: Dict, code: int, status: str, message: str):
+        """This shouldn't be instantiated directly."""
+        super().__init__(message)  # Makes str(e) return message
+        self.body = body
+        self.code = code
+        self.status = status
+        self._message = message
+
+    def __repr__(self):
+        """String representation of the SnapAPIError class."""
+        return "APIError({!r}, {!r}, {!r}, {!r})".format(
+            self.body, self.code, self.status, self._message
+        )
+
+
+class SnapState(Enum):
+    """The state of a snap on the system or in the cache."""
+
+    Present = "present"
+    Absent = "absent"
+    Latest = "latest"
+    Available = "available"
+
+
+class SnapError(Error):
+    """Raised when there's an error running snap control commands."""
+
+
+class SnapNotFoundError(Error):
+    """Raised when a requested snap is not known to the system."""
+
+
+class Snap(object):
+    """Represents a snap package and its properties.
+
+    `Snap` exposes the following properties about a snap:
+      - name: the name of the snap
+      - state: a `SnapState` representation of its install status
+      - channel: "stable", "candidate", "beta", and "edge" are common
+      - revision: a string representing the snap's revision
+      - confinement: "classic" or "strict"
+    """
+
+    def __init__(
+        self,
+        name,
+        state: SnapState,
+        channel: str,
+        revision: str,
+        confinement: str,
+        apps: Optional[List[Dict[str, str]]] = None,
+        cohort: Optional[str] = "",
+    ) -> None:
+        self._name = name
+        self._state = state
+        self._channel = channel
+        self._revision = revision
+        self._confinement = confinement
+        self._cohort = cohort
+        self._apps = apps or []
+        self._snap_client = SnapClient()
+
+    def __eq__(self, other) -> bool:
+        """Equality for comparison."""
+        return isinstance(other, self.__class__) and (
+            self._name,
+            self._revision,
+        ) == (other._name, other._revision)
+
+    def __hash__(self):
+        """A basic hash so this class can be used in Mappings and dicts."""
+        return hash((self._name, self._revision))
+
+    def __repr__(self):
+        """A representation of the snap."""
+        return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
+
+    def __str__(self):
+        """A human-readable representation of the snap."""
+        return "<{}: {}-{}.{} -- {}>".format(
+            self.__class__.__name__,
+            self._name,
+            self._revision,
+            self._channel,
+            str(self._state),
+        )
+
+    def _snap(self, command: str, optargs: Optional[Iterable[str]] = None) -> str:
+        """Perform a snap operation.
+
+        Args:
+          command: the snap command to execute
+          optargs: an (optional) list of additional arguments to pass,
+            commonly confinement or channel
+
+        Raises:
+          SnapError if there is a problem encountered
+        """
+        optargs = optargs or []
+        _cmd = ["snap", command, self._name, *optargs]
+        try:
+            return subprocess.check_output(_cmd, universal_newlines=True)
+        except CalledProcessError as e:
+            raise SnapError(
+                "Snap: {!r}; command {!r} failed with output = {!r}".format(
+                    self._name, _cmd, e.output
+                )
+            )
+
+    def _snap_daemons(
+        self,
+        command: List[str],
+        services: Optional[List[str]] = None,
+    ) -> CompletedProcess:
+        """Perform snap app commands.
+
+        Args:
+          command: the snap command to execute
+          services: the snap service to execute command on
+
+        Raises:
+          SnapError if there is a problem encountered
+        """
+        if services:
+            # an attempt to keep the command constrained to the snap instance's services
+            services = ["{}.{}".format(self._name, service) for service in services]
+        else:
+            services = [self._name]
+
+        _cmd = ["snap", *command, *services]
+
+        try:
+            return subprocess.run(_cmd, universal_newlines=True, check=True, capture_output=True)
+        except CalledProcessError as e:
+            raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
+
+    def get(self, key) -> str:
+        """Gets a snap configuration value.
+
+        Args:
+            key: the key to retrieve
+        """
+        return self._snap("get", [key]).strip()
+
+    def set(self, config: Dict) -> str:
+        """Sets a snap configuration value.
+
+        Args:
+           config: a dictionary containing keys and values specifying the config to set.
+        """
+        args = ['{}="{}"'.format(key, val) for key, val in config.items()]
+
+        return self._snap("set", [*args])
+
+    def unset(self, key) -> str:
+        """Unsets a snap configuration value.
+
+        Args:
+            key: the key to unset
+        """
+        return self._snap("unset", [key])
+
+    def start(self, services: Optional[List[str]] = None, enable: Optional[bool] = False) -> None:
+        """Starts a snap's services.
+
+        Args:
+            services (list): (optional) list of individual snap services to start (otherwise all)
+            enable (bool): (optional) flag to enable snap services on start. Default `false`
+        """
+        args = ["start", "--enable"] if enable else ["start"]
+        self._snap_daemons(args, services)
+
+    def stop(self, services: Optional[List[str]] = None, disable: Optional[bool] = False) -> None:
+        """Stops a snap's services.
+
+        Args:
+            services (list): (optional) list of individual snap services to stop (otherwise all)
+            disable (bool): (optional) flag to disable snap services on stop. Default `False`
+        """
+        args = ["stop", "--disable"] if disable else ["stop"]
+        self._snap_daemons(args, services)
+
+    def logs(self, services: Optional[List[str]] = None, num_lines: Optional[int] = 10) -> str:
+        """Shows a snap services' logs.
+
+        Args:
+            services (list): (optional) list of individual snap services to show logs from
+                (otherwise all)
+            num_lines (int): (optional) integer number of log lines to return. Default `10`
+        """
+        args = ["logs", "-n={}".format(num_lines)] if num_lines else ["logs"]
+        return self._snap_daemons(args, services).stdout
+
+    def connect(
+        self, plug: str, service: Optional[str] = None, slot: Optional[str] = None
+    ) -> None:
+        """Connects a plug to a slot.
+
+        Args:
+            plug (str): the plug to connect
+            service (str): (optional) the snap service name to plug into
+            slot (str): (optional) the snap service slot to plug in to
+
+        Raises:
+            SnapError if there is a problem encountered
+        """
+        command = ["connect", "{}:{}".format(self._name, plug)]
+
+        if service and slot:
+            command = command + ["{}:{}".format(service, slot)]
+        elif slot:
+            command = command + [slot]
+
+        _cmd = ["snap", *command]
+        try:
+            subprocess.run(_cmd, universal_newlines=True, check=True, capture_output=True)
+        except CalledProcessError as e:
+            raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
+
+    def restart(
+        self, services: Optional[List[str]] = None, reload: Optional[bool] = False
+    ) -> None:
+        """Restarts a snap's services.
+
+        Args:
+            services (list): (optional) list of individual snap services to show logs from.
+                (otherwise all)
+            reload (bool): (optional) flag to use the service reload command, if available.
+                Default `False`
+        """
+        args = ["restart", "--reload"] if reload else ["restart"]
+        self._snap_daemons(args, services)
+
+    def _install(self, channel: Optional[str] = "", cohort: Optional[str] = "") -> None:
+        """Add a snap to the system.
+
+        Args:
+          channel: the channel to install from
+          cohort: optional, the key of a cohort that this snap belongs to
+        """
+        cohort = cohort or self._cohort
+
+        args = []
+        if self.confinement == "classic":
+            args.append("--classic")
+        if channel:
+            args.append('--channel="{}"'.format(channel))
+        if cohort:
+            args.append('--cohort="{}"'.format(cohort))
+
+        self._snap("install", args)
+
+    def _refresh(
+        self,
+        channel: Optional[str] = "",
+        cohort: Optional[str] = "",
+        leave_cohort: Optional[bool] = False,
+    ) -> None:
+        """Refresh a snap.
+
+        Args:
+          channel: the channel to install from
+          cohort: optionally, specify a cohort.
+          leave_cohort: leave the current cohort.
+        """
+        channel = '--channel="{}"'.format(channel) if channel else ""
+        args = [channel]
+
+        if not cohort:
+            cohort = self._cohort
+
+        if leave_cohort:
+            self._cohort = ""
+            args.append("--leave-cohort")
+        elif cohort:
+            args.append('--cohort="{}"'.format(cohort))
+
+        self._snap("refresh", args)
+
+    def _remove(self) -> str:
+        """Removes a snap from the system."""
+        return self._snap("remove")
+
+    @property
+    def name(self) -> str:
+        """Returns the name of the snap."""
+        return self._name
+
+    def ensure(
+        self,
+        state: SnapState,
+        classic: Optional[bool] = False,
+        channel: Optional[str] = "",
+        cohort: Optional[str] = "",
+    ):
+        """Ensures that a snap is in a given state.
+
+        Args:
+          state: a `SnapState` to reconcile to.
+          classic: an (Optional) boolean indicating whether classic confinement should be used
+          channel: the channel to install from
+          cohort: optional. Specify the key of a snap cohort.
+
+        Raises:
+          SnapError if an error is encountered
+        """
+        self._confinement = "classic" if classic or self._confinement == "classic" else ""
+
+        if state not in (SnapState.Present, SnapState.Latest):
+            # We are attempting to remove this snap.
+            if self._state in (SnapState.Present, SnapState.Latest):
+                # The snap is installed, so we run _remove.
+                self._remove()
+            else:
+                # The snap is not installed -- no need to do anything.
+                pass
+        else:
+            # We are installing or refreshing a snap.
+            if self._state not in (SnapState.Present, SnapState.Latest):
+                # The snap is not installed, so we install it.
+                self._install(channel, cohort)
+            else:
+                # The snap is installed, but we are changing it (e.g., switching channels).
+                self._refresh(channel, cohort)
+
+        self._update_snap_apps()
+        self._state = state
+
+    def _update_snap_apps(self) -> None:
+        """Updates a snap's apps after snap changes state."""
+        try:
+            self._apps = self._snap_client.get_installed_snap_apps(self._name)
+        except SnapAPIError:
+            logger.debug("Unable to retrieve snap apps for {}".format(self._name))
+            self._apps = []
+
+    @property
+    def present(self) -> bool:
+        """Returns whether or not a snap is present."""
+        return self._state in (SnapState.Present, SnapState.Latest)
+
+    @property
+    def latest(self) -> bool:
+        """Returns whether the snap is the most recent version."""
+        return self._state is SnapState.Latest
+
+    @property
+    def state(self) -> SnapState:
+        """Returns the current snap state."""
+        return self._state
+
+    @state.setter
+    def state(self, state: SnapState) -> None:
+        """Sets the snap state to a given value.
+
+        Args:
+          state: a `SnapState` to reconcile the snap to.
+
+        Raises:
+          SnapError if an error is encountered
+        """
+        if self._state is not state:
+            self.ensure(state)
+        self._state = state
+
+    @property
+    def revision(self) -> str:
+        """Returns the revision for a snap."""
+        return self._revision
+
+    @property
+    def channel(self) -> str:
+        """Returns the channel for a snap."""
+        return self._channel
+
+    @property
+    def confinement(self) -> str:
+        """Returns the confinement for a snap."""
+        return self._confinement
+
+    @property
+    def apps(self) -> List:
+        """Returns (if any) the installed apps of the snap."""
+        self._update_snap_apps()
+        return self._apps
+
+    @property
+    def services(self) -> Dict:
+        """Returns (if any) the installed services of the snap."""
+        self._update_snap_apps()
+        services = {}
+        for app in self._apps:
+            if "daemon" in app:
+                services[app["name"]] = SnapService(**app).as_dict()
+
+        return services
+
+
+class _UnixSocketConnection(http.client.HTTPConnection):
+    """Implementation of HTTPConnection that connects to a named Unix socket."""
+
+    def __init__(self, host, timeout=None, socket_path=None):
+        if timeout is None:
+            super().__init__(host)
+        else:
+            super().__init__(host, timeout=timeout)
+        self.socket_path = socket_path
+
+    def connect(self):
+        """Override connect to use Unix socket (instead of TCP socket)."""
+        if not hasattr(socket, "AF_UNIX"):
+            raise NotImplementedError("Unix sockets not supported on {}".format(sys.platform))
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.socket_path)
+        if self.timeout is not None:
+            self.sock.settimeout(self.timeout)
+
+
+class _UnixSocketHandler(urllib.request.AbstractHTTPHandler):
+    """Implementation of HTTPHandler that uses a named Unix socket."""
+
+    def __init__(self, socket_path: str):
+        super().__init__()
+        self.socket_path = socket_path
+
+    def http_open(self, req) -> http.client.HTTPResponse:
+        """Override http_open to use a Unix socket connection (instead of TCP)."""
+        return self.do_open(_UnixSocketConnection, req, socket_path=self.socket_path)
+
+
+class SnapClient:
+    """Snapd API client to talk to HTTP over UNIX sockets.
+
+    In order to avoid shelling out and/or involving sudo in calling the snapd API,
+    use a wrapper based on the Pebble Client, trimmed down to only the utility methods
+    needed for talking to snapd.
+    """
+
+    def __init__(
+        self,
+        socket_path: str = "/run/snapd.socket",
+        opener: Optional[urllib.request.OpenerDirector] = None,
+        base_url: str = "http://localhost/v2/",
+        timeout: float = 5.0,
+    ):
+        """Initialize a client instance.
+
+        Args:
+            socket_path: a path to the socket on the filesystem. Defaults to /run/snap/snapd.socket
+            opener: specifies an opener for unix socket, if unspecified a default is used
+            base_url: base url for making requests to the snap client. Defaults to
+                http://localhost/v2/
+            timeout: timeout in seconds to use when making requests to the API. Default is 5.0s.
+        """
+        if opener is None:
+            opener = self._get_default_opener(socket_path)
+        self.opener = opener
+        self.base_url = base_url
+        self.timeout = timeout
+
+    @classmethod
+    def _get_default_opener(cls, socket_path):
+        """Build the default opener to use for requests (HTTP over Unix socket)."""
+        opener = urllib.request.OpenerDirector()
+        opener.add_handler(_UnixSocketHandler(socket_path))
+        opener.add_handler(urllib.request.HTTPDefaultErrorHandler())
+        opener.add_handler(urllib.request.HTTPRedirectHandler())
+        opener.add_handler(urllib.request.HTTPErrorProcessor())
+        return opener
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        query: Dict = None,
+        body: Dict = None,
+    ) -> JSONType:
+        """Make a JSON request to the Snapd server with the given HTTP method and path.
+
+        If query dict is provided, it is encoded and appended as a query string
+        to the URL. If body dict is provided, it is serialied as JSON and used
+        as the HTTP body (with Content-Type: "application/json"). The resulting
+        body is decoded from JSON.
+        """
+        headers = {"Accept": "application/json"}
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        response = self._request_raw(method, path, query, headers, data)
+        return json.loads(response.read().decode())["result"]
+
+    def _request_raw(
+        self,
+        method: str,
+        path: str,
+        query: Dict = None,
+        headers: Dict = None,
+        data: bytes = None,
+    ) -> http.client.HTTPResponse:
+        """Make a request to the Snapd server; return the raw HTTPResponse object."""
+        url = self.base_url + path
+        if query:
+            url = url + "?" + urllib.parse.urlencode(query)
+
+        if headers is None:
+            headers = {}
+        request = urllib.request.Request(url, method=method, data=data, headers=headers)
+
+        try:
+            response = self.opener.open(request, timeout=self.timeout)
+        except urllib.error.HTTPError as e:
+            code = e.code
+            status = e.reason
+            message = ""
+            try:
+                body = json.loads(e.read().decode())["result"]
+            except (IOError, ValueError, KeyError) as e2:
+                # Will only happen on read error or if Pebble sends invalid JSON.
+                body = {}
+                message = "{} - {}".format(type(e2).__name__, e2)
+            raise SnapAPIError(body, code, status, message)
+        except urllib.error.URLError as e:
+            raise SnapAPIError({}, 500, "Not found", e.reason)
+        return response
+
+    def get_installed_snaps(self) -> Dict:
+        """Get information about currently installed snaps."""
+        return self._request("GET", "snaps")
+
+    def get_snap_information(self, name: str) -> Dict:
+        """Query the snap server for information about single snap."""
+        return self._request("GET", "find", {"name": name})[0]
+
+    def get_installed_snap_apps(self, name: str) -> List:
+        """Query the snap server for apps belonging to a named, currently installed snap."""
+        return self._request("GET", "apps", {"names": name, "select": "service"})
+
+
+class SnapCache(Mapping):
+    """An abstraction to represent installed/available packages.
+
+    When instantiated, `SnapCache` iterates through the list of installed
+    snaps using the `snapd` HTTP API, and a list of available snaps by reading
+    the filesystem to populate the cache. Information about available snaps is lazily-loaded
+    from the `snapd` API when requested.
+    """
+
+    def __init__(self):
+        if not self.snapd_installed:
+            raise SnapError("snapd is not installed or not in /usr/bin") from None
+        self._snap_client = SnapClient()
+        self._snap_map = {}
+        if self.snapd_installed:
+            self._load_available_snaps()
+            self._load_installed_snaps()
+
+    def __contains__(self, key: str) -> bool:
+        """Magic method to ease checking if a given snap is in the cache."""
+        return key in self._snap_map
+
+    def __len__(self) -> int:
+        """Returns number of items in the snap cache."""
+        return len(self._snap_map)
+
+    def __iter__(self) -> Iterable["Snap"]:
+        """Magic method to provide an iterator for the snap cache."""
+        return iter(self._snap_map.values())
+
+    def __getitem__(self, snap_name: str) -> Snap:
+        """Return either the installed version or latest version for a given snap."""
+        snap = self._snap_map.get(snap_name, None)
+        if snap is None:
+            # The snapd cache file may not have existed when _snap_map was
+            # populated.  This is normal.
+            try:
+                self._snap_map[snap_name] = self._load_info(snap_name)
+            except SnapAPIError:
+                raise SnapNotFoundError("Snap '{}' not found!".format(snap_name))
+
+        return self._snap_map[snap_name]
+
+    @property
+    def snapd_installed(self) -> bool:
+        """Check whether snapd has been installled on the system."""
+        return os.path.isfile("/usr/bin/snap")
+
+    def _load_available_snaps(self) -> None:
+        """Load the list of available snaps from disk.
+
+        Leave them empty and lazily load later if asked for.
+        """
+        if not os.path.isfile("/var/cache/snapd/names"):
+            # The snap catalog may not be populated yet; this is normal.
+            # snapd updates the cache infrequently and the cache file may not
+            # currently exist.
+            return
+
+        with open("/var/cache/snapd/names", "r") as f:
+            for line in f:
+                if line.strip():
+                    self._snap_map[line.strip()] = None
+
+    def _load_installed_snaps(self) -> None:
+        """Load the installed snaps into the dict."""
+        installed = self._snap_client.get_installed_snaps()
+
+        for i in installed:
+            snap = Snap(
+                name=i["name"],
+                state=SnapState.Latest,
+                channel=i["channel"],
+                revision=i["revision"],
+                confinement=i["confinement"],
+                apps=i.get("apps", None),
+            )
+            self._snap_map[snap.name] = snap
+
+    def _load_info(self, name) -> Snap:
+        """Load info for snaps which are not installed if requested.
+
+        Args:
+            name: a string representing the name of the snap
+        """
+        info = self._snap_client.get_snap_information(name)
+
+        return Snap(
+            name=info["name"],
+            state=SnapState.Available,
+            channel=info["channel"],
+            revision=info["revision"],
+            confinement=info["confinement"],
+            apps=None,
+        )
+
+
+@_cache_init
+def add(
+    snap_names: Union[str, List[str]],
+    state: Union[str, SnapState] = SnapState.Latest,
+    channel: Optional[str] = "latest",
+    classic: Optional[bool] = False,
+    cohort: Optional[str] = "",
+) -> Union[Snap, List[Snap]]:
+    """Add a snap to the system.
+
+    Args:
+        snap_names: the name or names of the snaps to install
+        state: a string or `SnapState` representation of the desired state, one of
+            [`Present` or `Latest`]
+        channel: an (Optional) channel as a string. Defaults to 'latest'
+        classic: an (Optional) boolean specifying whether it should be added with classic
+            confinement. Default `False`
+
+    Raises:
+        SnapError if some snaps failed to install or were not found.
+    """
+    snap_names = [snap_names] if type(snap_names) is str else snap_names
+    if not snap_names:
+        raise TypeError("Expected at least one snap to add, received zero!")
+
+    if type(state) is str:
+        state = SnapState(state)
+
+    return _wrap_snap_operations(snap_names, state, channel, classic, cohort)
+
+
+@_cache_init
+def remove(snap_names: Union[str, List[str]]) -> Union[Snap, List[Snap]]:
+    """Removes a snap from the system.
+
+    Args:
+        snap_names: the name or names of the snaps to install
+
+    Raises:
+        SnapError if some snaps failed to install.
+    """
+    snap_names = [snap_names] if type(snap_names) is str else snap_names
+    if not snap_names:
+        raise TypeError("Expected at least one snap to add, received zero!")
+
+    return _wrap_snap_operations(snap_names, SnapState.Absent, "", False)
+
+
+@_cache_init
+def ensure(
+    snap_names: Union[str, List[str]],
+    state: str,
+    channel: Optional[str] = "latest",
+    classic: Optional[bool] = False,
+    cohort: Optional[str] = "",
+) -> Union[Snap, List[Snap]]:
+    """Ensures a snap is in a given state to the system.
+
+    Args:
+        name: the name(s) of the snaps to operate on
+        state: a string representation of the desired state, from `SnapState`
+        channel: an (Optional) channel as a string. Defaults to 'latest'
+        classic: an (Optional) boolean specifying whether it should be added with classic
+            confinement. Default `False`
+
+    Raises:
+        SnapError if the snap is not in the cache.
+    """
+    if state in ("present", "latest"):
+        return add(snap_names, SnapState(state), channel, classic, cohort)
+    else:
+        return remove(snap_names)
+
+
+def _wrap_snap_operations(
+    snap_names: List[str],
+    state: SnapState,
+    channel: str,
+    classic: bool,
+    cohort: Optional[str] = "",
+) -> Union[Snap, List[Snap]]:
+    """Wrap common operations for bare commands."""
+    snaps = {"success": [], "failed": []}
+
+    op = "remove" if state is SnapState.Absent else "install or refresh"
+
+    for s in snap_names:
+        try:
+            snap = _Cache[s]
+            if state is SnapState.Absent:
+                snap.ensure(state=SnapState.Absent)
+            else:
+                snap.ensure(state=state, classic=classic, channel=channel, cohort=cohort)
+            snaps["success"].append(snap)
+        except SnapError as e:
+            logger.warning("Failed to {} snap {}: {}!".format(op, s, e.message))
+            snaps["failed"].append(s)
+        except SnapNotFoundError:
+            logger.warning("Snap '{}' not found in cache!".format(s))
+            snaps["failed"].append(s)
+
+    if len(snaps["failed"]):
+        raise SnapError(
+            "Failed to install or refresh snap(s): {}".format(
+                ", ".join([s for s in snaps["failed"]])
+            )
+        )
+
+    return snaps["success"] if len(snaps["success"]) > 1 else snaps["success"][0]
+
+
+def install_local(
+    filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
+) -> Snap:
+    """Perform a snap operation.
+
+    Args:
+        filename: the path to a local .snap file to install
+        classic: whether to use classic confinement
+        dangerous: whether --dangerous should be passed to install snaps without a signature
+
+    Raises:
+        SnapError if there is a problem encountered
+    """
+    _cmd = [
+        "snap",
+        "install",
+        filename,
+    ]
+    if classic:
+        _cmd.append("--classic")
+    if dangerous:
+        _cmd.append("--dangerous")
+    try:
+        result = subprocess.check_output(_cmd, universal_newlines=True).splitlines()[-1]
+        snap_name, _ = result.split(" ", 1)
+        snap_name = ansi_filter.sub("", snap_name)
+
+        c = SnapCache()
+
+        try:
+            return c[snap_name]
+        except SnapAPIError as e:
+            logger.error(
+                "Could not find snap {} when querying Snapd socket: {}".format(snap_name, e.body)
+            )
+            raise SnapError("Failed to find snap {} in Snap cache".format(snap_name))
+    except CalledProcessError as e:
+        raise SnapError("Could not install snap {}: {}".format(filename, e.output))
+
+
+def _system_set(config_item: str, value: str) -> None:
+    """Helper for setting snap system config values.
+
+    Args:
+        config_item: name of snap system setting. E.g. 'refresh.hold'
+        value: value to assign
+    """
+    _cmd = ["snap", "set", "system", "{}={}".format(config_item, value)]
+    try:
+        subprocess.check_call(_cmd, universal_newlines=True)
+    except CalledProcessError:
+        raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
+
+
+def hold_refresh(days: int = 90) -> bool:
+    """Set the system-wide snap refresh hold.
+
+    Args:
+        days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
+    """
+    # Currently the snap daemon can only hold for a maximum of 90 days
+    if not isinstance(days, int) or days > 90:
+        raise ValueError("days must be an int between 1 and 90")
+    elif days == 0:
+        _system_set("refresh.hold", "")
+        logger.info("Removed system-wide snap refresh hold")
+    else:
+        # Add the number of days to current time
+        target_date = datetime.now(timezone.utc).astimezone() + timedelta(days=days)
+        # Format for the correct datetime format
+        hold_date = target_date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        # Python dumps the offset in format '+0100', we need '+01:00'
+        hold_date = "{0}:{1}".format(hold_date[:-2], hold_date[-2:])
+        # Actually set the hold date
+        _system_set("refresh.hold", hold_date)
+        logger.info("Set system-wide snap refresh hold to: %s", hold_date)

--- a/tests/integration/app-charm/lib/charms/operator_libs_linux/v1/snap.py
+++ b/tests/integration/app-charm/lib/charms/operator_libs_linux/v1/snap.py
@@ -113,7 +113,7 @@ class SnapService:
         enabled: bool = False,
         active: bool = False,
         activators: List[str] = [],
-        **kwargs
+        **kwargs,
     ):
         self.daemon = daemon
         self.daemon_scope = kwargs.get("daemon-scope", None) or daemon_scope
@@ -915,9 +915,7 @@ def _wrap_snap_operations(
 
     if len(snaps["failed"]):
         raise SnapError(
-            "Failed to install or refresh snap(s): {}".format(
-                ", ".join([s for s in snaps["failed"]])
-            )
+            "Failed to install or refresh snap(s): {}".format(", ".join(list(snaps["failed"])))
         )
 
     return snaps["success"] if len(snaps["success"]) > 1 else snaps["success"][0]

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -10,13 +10,15 @@ of the libraries in this repository.
 
 import logging
 import subprocess
+from socket import getfqdn
 
 from charms.data_platform_libs.v0.data_interfaces import KafkaRequires, TopicCreatedEvent
+from charms.operator_libs_linux.v0 import apt
+from charms.operator_libs_linux.v1 import snap
 from ops.charm import ActionEvent, CharmBase, RelationEvent
 from ops.main import main
 from ops.model import ActiveStatus
-from charms.operator_libs_linux.v0 import apt
-from charms.operator_libs_linux.v1 import snap
+
 from utils import safe_write_to_file
 
 logger = logging.getLogger(__name__)
@@ -62,7 +64,12 @@ class ApplicationCharm(CharmBase):
             self.kafka_requirer_admin.on.topic_created, self.on_topic_created_admin
         )
 
-        self.framework.observe(getattr(self.on, "create_keystores_action"), self._action)
+        self.framework.observe(
+            getattr(self.on, "create_certificate_action"), self.create_certificate
+        )
+        self.framework.observe(
+            getattr(self.on, "run_mtls_producer_action"), self.run_mtls_producer
+        )
 
     def _on_start(self, _) -> None:
         self.unit.status = ActiveStatus()
@@ -83,6 +90,7 @@ class ApplicationCharm(CharmBase):
         return
 
     def _install_packages(self):
+        logger.info("INSTALLING PACKAGES")
         apt.update()
         apt.add_package(["snapd", "openjdk-17-jre-headless"])
         cache = snap.SnapCache()
@@ -91,17 +99,9 @@ class ApplicationCharm(CharmBase):
         if not kafka.present:
             kafka.ensure(snap.SnapState.Latest, channel="latest/edge")
 
-    def _create_keystore(self, event: ActionEvent):
-        peer_relation = self.model.get_relation("cluster")
-        if not peer_relation:
-            event.fail("no peer relation")
-            return
-
-        unit_host = peer_relation.data[self.unit].get("private-address" "")
-        unit_name = self.unit.name
-
+    def _create_keystore(self, unit_name: str, unit_host: str):
         try:
-            # creating the keystore
+            logger.info("creating the keystore")
             subprocess.check_output(
                 f'keytool -keystore client.keystore.jks -alias client-key -validity 90 -genkey -keyalg RSA -noprompt -storepass password -dname "CN=client" -ext SAN=DNS:{unit_name},IP:{unit_host}',
                 stderr=subprocess.PIPE,
@@ -109,75 +109,142 @@ class ApplicationCharm(CharmBase):
                 universal_newlines=True,
             )
 
-            # creating a CA
+            logger.info("creating a ca")
             subprocess.check_output(
-                f'openssl req -new -x509 -keyout ca.key -out ca.cert -days 90 -passout pass:password -subj "/CN=client-ca"',
+                'openssl req -new -x509 -keyout ca.key -out ca.cert -days 90 -passout pass:password -subj "/CN=client-ca"',
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
             )
 
-            # signing certificate
+            logger.info("signing certificate")
             subprocess.check_output(
-                f"keytool -keystore client.keystore.jks -alias client-key -certreq -file client.csr -storepass password",
+                "keytool -keystore client.keystore.jks -alias client-key -certreq -file client.csr -storepass password",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
             )
             subprocess.check_output(
-                f"openssl x509 -req -CA ca.cert -CAkey ca.key -in client.csr -out client.cert -days 90 -CAcreateserial -passin pass:password",
-                stderr=subprocess.PIPE,
-                shell=True,
-                universal_newlines=True,
-            )
-
-            # importing certificate to keystore
-            subprocess.check_output(
-                f"keytool -keystore client.keystore.jks -alias client-cert -importcert -file client.cert -storepass password",
+                "openssl x509 -req -CA ca.cert -CAkey ca.key -in client.csr -out client.cert -days 90 -CAcreateserial -passin pass:password",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
             )
 
-            # grabbing cert content
+            logger.info("importing certificate to keystore")
+            subprocess.check_output(
+                "keytool -keystore client.keystore.jks -alias client-cert -importcert -file client.cert -storepass password -noprompt",
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
+
+            logger.info("grabbing cert content")
             certificate = subprocess.check_output(
                 "cat client.cert", stderr=subprocess.PIPE, shell=True, universal_newlines=True
+            )
+            ca = subprocess.check_output(
+                "cat ca.cert", stderr=subprocess.PIPE, shell=True, universal_newlines=True
             )
 
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
             raise e
 
-        event.set_results({"client-certificate": certificate})
+        return {"certificate": certificate, "ca": ca}
 
-    def _create_truststore(self, event: ActionEvent):
-        broker_ca = event.params["broker-ca"]
+    def _create_truststore(self, broker_ca: str):
+        logger.info("writing broker cert to unit")
+        unit_name = self.unit.name.replace("/", "-")
+        safe_write_to_file(
+            content=broker_ca, path=f"/var/lib/juju/agents/unit-{unit_name}/charm/broker.cert"
+        )
 
-        safe_write_to_file(content=broker_ca, path="broker.cert") 
-
-        try:
-            # creating truststore and importing cert files
-            for file in ["broker.cert", "ca.cert", "client.cert"]:
+        # creating truststore and importing cert files
+        for file in ["broker.cert", "ca.cert", "client.cert"]:
+            try:
+                logger.info(f"adding {file} to truststore")
                 subprocess.check_output(
-                    f"keytool -keystore client.truststore.jks -alias broker-ca -importcert -file {file} -storepass password",
+                    f"keytool -keystore client.truststore.jks -alias {file.replace('.','-')} -importcert -file {file} -storepass password -noprompt",
                     stderr=subprocess.PIPE,
                     shell=True,
                     universal_newlines=True,
                 )
+            except subprocess.CalledProcessError as e:
+                # in case this reruns and fails
+                if "already exists" in e.output:
+                    logger.warning(e.output)
+                    continue
+                raise e
+
+    def _attempt_mtls_connection(self, bootstrap_servers: str):
+        logger.info("creating data to feed to producer")
+        unit_name = self.unit.name.replace("/", "-")
+        safe_write_to_file(
+            content="a\n b\n c\n d\n e", path=f"/var/lib/juju/agents/unit-{unit_name}/charm/data"
+        )
+
+        logger.info("creating client.properties file")
+        properties = [
+            "security.protocol=SSL",
+            "ssl.truststore.location=client.truststore.jks",
+            "ssl.keystore.location=client.keystore.jks",
+            "ssl.truststore.password=password",
+            "ssl.keystore.password=password",
+            "ssl.key.password=password",
+        ]
+        safe_write_to_file(
+            content="\n".join(properties),
+            path=f"/var/lib/juju/agents/unit-{unit_name}/charm/client.properties",
+        )
+
+        logger.info("running producer application")
+        try:
+            subprocess.check_output(
+                f"/snap/charmed-kafka/current/opt/kafka/bin/kafka-console-producer.sh --broker-list {bootstrap_servers} --topic=TEST-TOPIC --producer.config client.properties < data",
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
             raise e
 
-        return
+    def create_certificate(self, event: ActionEvent):
+        peer_relation = self.model.get_relation("cluster")
+        if not peer_relation:
+            logger.error("peer relation not ready")
+            raise Exception("peer relation not ready")
 
-    def _create_data(self, _):
-        
+        self._install_packages()
 
-    def _attempt_mtls_connection(self, _):
-        subprocess.check_output(
-            "/"
+        unit_host = peer_relation.data[self.unit].get("private-address" "") or ""
+        unit_name = getfqdn()
 
+        logger.info(f"{unit_host=}")
+        logger.info(f"{unit_name=}")
+
+        response = self._create_keystore(unit_host=unit_host, unit_name=unit_name)
+
+        logger.info(f"{response=}")
+
+        event.set_results(
+            {"client-certificate": response["certificate"], "client-ca": response["ca"]}
         )
+
+    def run_mtls_producer(self, event: ActionEvent):
+        broker_ca = event.params["broker-ca"]
+        bootstrap_server = event.params["bootstrap-server"]
+
+        try:
+            self._create_truststore(broker_ca=broker_ca)
+            self._attempt_mtls_connection(bootstrap_servers=bootstrap_server)
+        except Exception as e:
+            logger.error(e)
+            event.fail()
+            return
+
+        event.set_results({"success": "TRUE"})
 
 
 if __name__ == "__main__":

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -9,11 +9,15 @@ of the libraries in this repository.
 """
 
 import logging
+import subprocess
 
 from charms.data_platform_libs.v0.data_interfaces import KafkaRequires, TopicCreatedEvent
-from ops.charm import CharmBase, RelationEvent
+from ops.charm import ActionEvent, CharmBase, RelationEvent
 from ops.main import main
 from ops.model import ActiveStatus
+from charms.operator_libs_linux.v0 import apt
+from charms.operator_libs_linux.v1 import snap
+from utils import safe_write_to_file
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +62,8 @@ class ApplicationCharm(CharmBase):
             self.kafka_requirer_admin.on.topic_created, self.on_topic_created_admin
         )
 
+        self.framework.observe(getattr(self.on, "create_keystores_action"), self._action)
+
     def _on_start(self, _) -> None:
         self.unit.status = ActiveStatus()
 
@@ -75,6 +81,103 @@ class ApplicationCharm(CharmBase):
     def on_topic_created_admin(self, event: TopicCreatedEvent):
         logger.info(f"{event.username} {event.password} {event.bootstrap_server} {event.tls}")
         return
+
+    def _install_packages(self):
+        apt.update()
+        apt.add_package(["snapd", "openjdk-17-jre-headless"])
+        cache = snap.SnapCache()
+        kafka = cache["charmed-kafka"]
+
+        if not kafka.present:
+            kafka.ensure(snap.SnapState.Latest, channel="latest/edge")
+
+    def _create_keystore(self, event: ActionEvent):
+        peer_relation = self.model.get_relation("cluster")
+        if not peer_relation:
+            event.fail("no peer relation")
+            return
+
+        unit_host = peer_relation.data[self.unit].get("private-address" "")
+        unit_name = self.unit.name
+
+        try:
+            # creating the keystore
+            subprocess.check_output(
+                f'keytool -keystore client.keystore.jks -alias client-key -validity 90 -genkey -keyalg RSA -noprompt -storepass password -dname "CN=client" -ext SAN=DNS:{unit_name},IP:{unit_host}',
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
+
+            # creating a CA
+            subprocess.check_output(
+                f'openssl req -new -x509 -keyout ca.key -out ca.cert -days 90 -passout pass:password -subj "/CN=client-ca"',
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
+
+            # signing certificate
+            subprocess.check_output(
+                f"keytool -keystore client.keystore.jks -alias client-key -certreq -file client.csr -storepass password",
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
+            subprocess.check_output(
+                f"openssl x509 -req -CA ca.cert -CAkey ca.key -in client.csr -out client.cert -days 90 -CAcreateserial -passin pass:password",
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
+
+            # importing certificate to keystore
+            subprocess.check_output(
+                f"keytool -keystore client.keystore.jks -alias client-cert -importcert -file client.cert -storepass password",
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
+
+            # grabbing cert content
+            certificate = subprocess.check_output(
+                "cat client.cert", stderr=subprocess.PIPE, shell=True, universal_newlines=True
+            )
+
+        except subprocess.CalledProcessError as e:
+            logger.error(e.output)
+            raise e
+
+        event.set_results({"client-certificate": certificate})
+
+    def _create_truststore(self, event: ActionEvent):
+        broker_ca = event.params["broker-ca"]
+
+        safe_write_to_file(content=broker_ca, path="broker.cert") 
+
+        try:
+            # creating truststore and importing cert files
+            for file in ["broker.cert", "ca.cert", "client.cert"]:
+                subprocess.check_output(
+                    f"keytool -keystore client.truststore.jks -alias broker-ca -importcert -file {file} -storepass password",
+                    stderr=subprocess.PIPE,
+                    shell=True,
+                    universal_newlines=True,
+                )
+        except subprocess.CalledProcessError as e:
+            logger.error(e.output)
+            raise e
+
+        return
+
+    def _create_data(self, _):
+        
+
+    def _attempt_mtls_connection(self, _):
+        subprocess.check_output(
+            "/"
+
+        )
 
 
 if __name__ == "__main__":

--- a/tests/integration/app-charm/src/utils.py
+++ b/tests/integration/app-charm/src/utils.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import base64
+import logging
+import os
+import re
+import secrets
+import string
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+def safe_get_file(filepath: str) -> Optional[List[str]]:
+    """Load file contents from charm workload.
+
+    Args:
+        filepath: the filepath to load data from
+
+    Returns:
+        List of file content lines
+        None if file does not exist
+    """
+    if not os.path.exists(filepath):
+        return None
+    else:
+        with open(filepath) as f:
+            content = f.read().split("\n")
+
+    return content
+
+
+def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
+    """Ensures destination filepath exists before writing.
+
+    Args:
+        content: the content to be written to a file
+        path: the full destination filepath
+        mode: the write mode. Usually "w" for write, or "a" for append. Default "w"
+    """
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, mode) as f:
+        f.write(content)
+
+    return
+
+
+def generate_password() -> str:
+    """Creates randomized string for use as app passwords.
+
+    Returns:
+        String of 32 randomized letter+digit characters
+    """
+    return "".join([secrets.choice(string.ascii_letters + string.digits) for _ in range(32)])
+
+
+def parse_tls_file(raw_content: str) -> str:
+    """Parse TLS files from both plain text or base64 format."""
+    if re.match(r"(-+(BEGIN|END) [A-Z ]+-+)", raw_content):
+        return raw_content
+    return base64.b64decode(raw_content).decode("utf-8")

--- a/tests/integration/app-charm/src/utils.py
+++ b/tests/integration/app-charm/src/utils.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
+
 def safe_get_file(filepath: str) -> Optional[List[str]]:
     """Load file contents from charm workload.
 

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -28,6 +28,7 @@ TLS_NAME = "tls-certificates-operator"
 REL_NAME_CONSUMER = "kafka-client-consumer"
 REL_NAME_PRODUCER = "kafka-client-producer"
 REL_NAME_ADMIN = "kafka-client-admin"
+REL_NAME_CERTIFICATES = "certificates"
 
 
 @pytest.mark.abort_on_fail
@@ -231,7 +232,7 @@ async def test_connection_updated_on_tls_enabled(ops_test: OpsTest, app_charm):
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, ZK, TLS_NAME, DUMMY_NAME_1], timeout=1000, idle_period=40
     )
-    await ops_test.model.add_relation(TLS_NAME, APP_NAME)
+    await ops_test.model.add_relation(TLS_NAME, f"{APP_NAME}:{REL_NAME_CERTIFICATES}")
 
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, ZK, TLS_NAME, DUMMY_NAME_1], timeout=1000, idle_period=40

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -28,6 +28,7 @@ from .test_charm import DUMMY_NAME
 logger = logging.getLogger(__name__)
 
 TLS_NAME = "tls-certificates-operator"
+REL_NAME_CERTIFICATES = "certificates"
 
 
 @pytest.mark.abort_on_fail
@@ -79,7 +80,7 @@ async def test_kafka_tls(ops_test: OpsTest, app_charm):
         show_unit(f"{APP_NAME}/{num_unit}", model_full_name=ops_test.model_full_name), unit=0
     )
 
-    await ops_test.model.add_relation(APP_NAME, TLS_NAME)
+    await ops_test.model.add_relation(f"{APP_NAME}:{REL_NAME_CERTIFICATES}", TLS_NAME)
     logger.info("Relate Kafka to TLS")
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, ZK_NAME, TLS_NAME], idle_period=60, timeout=1000

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -3,23 +3,31 @@
 # See LICENSE file for licensing details.
 
 import asyncio
+import base64
 import logging
 
 import pytest
 from charms.tls_certificates_interface.v1.tls_certificates import generate_private_key
 from pytest_operator.plugin import OpsTest
 
-from literals import REL_NAME, SECURITY_PROTOCOL_PORTS
+from literals import (
+    CHARM_KEY,
+    REL_NAME,
+    SECURITY_PROTOCOL_PORTS,
+    TLS_RELATION,
+    TRUSTED_CERTIFICATE_RELATION,
+    ZK,
+)
 from utils import get_active_brokers
 
 from .helpers import (
-    APP_NAME,
     REL_NAME_ADMIN,
-    ZK_NAME,
     check_tls,
+    extract_ca,
     extract_private_key,
     get_address,
     get_kafka_zk_relation_data,
+    set_mtls_client_acls,
     set_tls_private_key,
     show_unit,
 )
@@ -28,7 +36,7 @@ from .test_charm import DUMMY_NAME
 logger = logging.getLogger(__name__)
 
 TLS_NAME = "tls-certificates-operator"
-REL_NAME_CERTIFICATES = "certificates"
+MTLS_NAME = "mtls"
 
 
 @pytest.mark.abort_on_fail
@@ -38,23 +46,25 @@ async def test_deploy_tls(ops_test: OpsTest, kafka_charm):
 
     await asyncio.gather(
         ops_test.model.deploy(TLS_NAME, channel="beta", config=tls_config, series="jammy"),
-        ops_test.model.deploy(ZK_NAME, channel="edge", num_units=3, series="jammy"),
-        ops_test.model.deploy(kafka_charm, application_name=APP_NAME, series="jammy"),
+        ops_test.model.deploy(ZK, channel="edge", series="jammy", application_name=ZK),
+        ops_test.model.deploy(kafka_charm, application_name=CHARM_KEY, series="jammy"),
     )
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME, TLS_NAME], timeout=1800)
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK].units) == 1)
+    await ops_test.model.wait_for_idle(
+        apps=[CHARM_KEY, ZK, TLS_NAME], idle_period=15, timeout=1800
+    )
 
-    assert ops_test.model.applications[APP_NAME].status == "waiting"
-    assert ops_test.model.applications[ZK_NAME].status == "active"
+    assert ops_test.model.applications[CHARM_KEY].status == "waiting"
+    assert ops_test.model.applications[ZK].status == "active"
     assert ops_test.model.applications[TLS_NAME].status == "active"
 
     # Relate Zookeeper to TLS
-    await ops_test.model.add_relation(TLS_NAME, ZK_NAME)
-    logger.info("Relate Zookeeper to TLS")
-    await ops_test.model.wait_for_idle(apps=[TLS_NAME, ZK_NAME], idle_period=40)
+    async with ops_test.fast_forward():
+        await ops_test.model.add_relation(TLS_NAME, ZK)
+        await ops_test.model.wait_for_idle(apps=[TLS_NAME, ZK], idle_period=15)
 
-    assert ops_test.model.applications[TLS_NAME].status == "active"
-    assert ops_test.model.applications[ZK_NAME].status == "active"
+        assert ops_test.model.applications[TLS_NAME].status == "active"
+        assert ops_test.model.applications[ZK].status == "active"
 
 
 @pytest.mark.abort_on_fail
@@ -65,10 +75,10 @@ async def test_kafka_tls(ops_test: OpsTest, app_charm):
     Afterwards, relate Kafka to TLS operator, which unblocks the application.
     """
     # Relate Zookeeper[TLS] to Kafka[Non-TLS]
-    await ops_test.model.add_relation(ZK_NAME, APP_NAME)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME], idle_period=60, timeout=1000)
-
-    assert ops_test.model.applications[APP_NAME].status == "blocked"
+    async with ops_test.fast_forward():
+        await ops_test.model.add_relation(ZK, CHARM_KEY)
+        await ops_test.model.wait_for_idle(apps=[ZK], idle_period=15, timeout=1000)
+        assert ops_test.model.applications[CHARM_KEY].status == "blocked"
 
     # Set a custom private key, by running set-tls-private-key action with no parameters,
     # as this will generate a random one
@@ -77,31 +87,39 @@ async def test_kafka_tls(ops_test: OpsTest, app_charm):
 
     # Extract the key
     private_key = extract_private_key(
-        show_unit(f"{APP_NAME}/{num_unit}", model_full_name=ops_test.model_full_name), unit=0
+        show_unit(f"{CHARM_KEY}/{num_unit}", model_full_name=ops_test.model_full_name), unit=0
     )
 
-    await ops_test.model.add_relation(f"{APP_NAME}:{REL_NAME_CERTIFICATES}", TLS_NAME)
-    logger.info("Relate Kafka to TLS")
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, ZK_NAME, TLS_NAME], idle_period=60, timeout=1000
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.add_relation(f"{CHARM_KEY}:{TLS_RELATION}", TLS_NAME)
+        logger.info("Relate Kafka to TLS")
+        await ops_test.model.wait_for_idle(
+            apps=[CHARM_KEY, ZK, TLS_NAME], idle_period=15, timeout=1000
+        )
 
-    assert ops_test.model.applications[APP_NAME].status == "active"
-    assert ops_test.model.applications[ZK_NAME].status == "active"
+    assert ops_test.model.applications[CHARM_KEY].status == "active"
+    assert ops_test.model.applications[ZK].status == "active"
 
-    kafka_address = await get_address(ops_test=ops_test, app_name=APP_NAME)
-    logger.info("Check for Kafka TLS")
+    kafka_address = await get_address(ops_test=ops_test, app_name=CHARM_KEY)
     assert not check_tls(ip=kafka_address, port=SECURITY_PROTOCOL_PORTS["SASL_SSL"].client)
-    await asyncio.gather(
-        ops_test.model.deploy(app_charm, application_name=DUMMY_NAME, num_units=1, series="jammy"),
-    )
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_NAME, ZK_NAME])
-    await ops_test.model.add_relation(APP_NAME, f"{DUMMY_NAME}:{REL_NAME_ADMIN}")
-    assert ops_test.model.applications[APP_NAME].status == "active"
-    assert ops_test.model.applications[DUMMY_NAME].status == "active"
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME, DUMMY_NAME])
 
-    logger.info("Check for Kafka TLS")
+    async with ops_test.fast_forward():
+        await asyncio.gather(
+            ops_test.model.deploy(
+                app_charm, application_name=DUMMY_NAME, num_units=1, series="jammy"
+            ),
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[CHARM_KEY, DUMMY_NAME], timeout=1000, idle_period=15
+        )
+        await ops_test.model.add_relation(CHARM_KEY, f"{DUMMY_NAME}:{REL_NAME_ADMIN}")
+        await ops_test.model.wait_for_idle(
+            apps=[CHARM_KEY, DUMMY_NAME], timeout=1000, idle_period=15
+        )
+
+        assert ops_test.model.applications[CHARM_KEY].status == "active"
+        assert ops_test.model.applications[DUMMY_NAME].status == "active"
+
     assert check_tls(ip=kafka_address, port=SECURITY_PROTOCOL_PORTS["SASL_SSL"].client)
 
     # Rotate credentials
@@ -111,30 +129,96 @@ async def test_kafka_tls(ops_test: OpsTest, app_charm):
 
     # Extract the key
     private_key_2 = extract_private_key(
-        show_unit(f"{APP_NAME}/{num_unit}", model_full_name=ops_test.model_full_name), unit=0
+        show_unit(f"{CHARM_KEY}/{num_unit}", model_full_name=ops_test.model_full_name), unit=0
     )
 
     assert private_key != private_key_2
     assert private_key_2 == new_private_key
 
 
+async def test_mtls(ops_test: OpsTest):
+    # creating the signed external cert on the unit
+    logger.info("RUNNING ACTION - CREATE CERTIFICATE")
+    action = await ops_test.model.units.get(f"{DUMMY_NAME}/0").run_action("create-certificate")
+    response = await action.wait()
+    logger.info(f"{response=}")
+    client_certificate = response.results["client-certificate"]
+    client_ca = response.results["client-ca"]
+
+    logger.info(f"{client_certificate=}")
+    logger.info(f"{client_ca=}")
+
+    encoded_client_certificate = base64.b64encode(client_certificate.encode("utf-8")).decode(
+        "utf-8"
+    )
+    encoded_client_ca = base64.b64encode(client_ca.encode("utf-8")).decode("utf-8")
+
+    logger.info(f"{encoded_client_certificate=}")
+    logger.info(f"{encoded_client_ca=}")
+
+    # deploying mtls operator with certs
+    logger.info("DEPLOYING - MTLS")
+    tls_config = {
+        "generate-self-signed-certificates": "false",
+        "certificate": encoded_client_certificate,
+        "ca-certificate": encoded_client_ca,
+    }
+    await ops_test.model.deploy(
+        TLS_NAME, channel="beta", config=tls_config, series="jammy", application_name=MTLS_NAME
+    )
+    await ops_test.model.wait_for_idle(apps=[MTLS_NAME], timeout=1000, idle_period=15)
+    async with ops_test.fast_forward():
+        logger.info("RELATING - MTLS + KAFKA")
+        await ops_test.model.add_relation(
+            f"{CHARM_KEY}:{TRUSTED_CERTIFICATE_RELATION}", f"{MTLS_NAME}:{TLS_RELATION}"
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[CHARM_KEY, MTLS_NAME], idle_period=15, timeout=1000
+        )
+
+    # getting kafka ca and address
+    logger.info("EXTRACTING CA FROM KAFKA")
+    broker_ca = extract_ca(show_unit(f"{CHARM_KEY}/0", model_full_name=ops_test.model_full_name))
+    logger.info(f"{broker_ca=}")
+    address = await get_address(ops_test, app_name=CHARM_KEY)
+    ssl_port = SECURITY_PROTOCOL_PORTS["SSL"].client
+    sasl_port = SECURITY_PROTOCOL_PORTS["SASL_SSL"].client
+    ssl_bootstrap_server = f"{address}:{ssl_port}"
+    sasl_bootstrap_server = f"{address}:{sasl_port}"
+
+    # setting ACLs using normal sasl port
+    await set_mtls_client_acls(ops_test, bootstrap_server=sasl_bootstrap_server)
+
+    # running mtls producer
+    logger.info("RUNNING ACTION - MTLS PRODUCER")
+    action = await ops_test.model.units.get(f"{DUMMY_NAME}/0").run_action(
+        "run-mtls-producer", **{"bootstrap-server": ssl_bootstrap_server, "broker-ca": broker_ca}
+    )
+
+    response = await action.wait()
+
+    logger.info(f"{response=}")
+
+    assert response.results.get("success", None) == "TRUE"
+
+
 async def test_kafka_tls_scaling(ops_test: OpsTest):
     """Scale the application while using TLS to check that new units will configure correctly."""
-    await ops_test.model.applications[APP_NAME].add_units(count=2)
+    await ops_test.model.applications[CHARM_KEY].add_units(count=2)
     logger.info("Scaling Kafka to 3 units")
     await ops_test.model.block_until(
-        lambda: len(ops_test.model.applications[APP_NAME].units) == 3, timeout=1000
+        lambda: len(ops_test.model.applications[CHARM_KEY].units) == 3, timeout=1000
     )
     # Wait for model to settle
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
+        apps=[CHARM_KEY],
         status="active",
         idle_period=40,
         timeout=1000,
     )
 
     kafka_zk_relation_data = get_kafka_zk_relation_data(
-        unit_name=f"{APP_NAME}/2", model_full_name=ops_test.model_full_name
+        unit_name=f"{CHARM_KEY}/2", model_full_name=ops_test.model_full_name
     )
     active_brokers = get_active_brokers(zookeeper_config=kafka_zk_relation_data)
     chroot = kafka_zk_relation_data.get("chroot", "")
@@ -142,15 +226,12 @@ async def test_kafka_tls_scaling(ops_test: OpsTest):
     assert f"{chroot}/brokers/ids/1" in active_brokers
     assert f"{chroot}/brokers/ids/2" in active_brokers
 
-    kafka_address = await get_address(ops_test=ops_test, app_name=APP_NAME, unit_num=2)
+    kafka_address = await get_address(ops_test=ops_test, app_name=CHARM_KEY, unit_num=2)
     assert check_tls(ip=kafka_address, port=SECURITY_PROTOCOL_PORTS["SASL_SSL"].client)
 
     # remove relation and check connection again
-    await ops_test.model.applications[APP_NAME].remove_relation(
-        f"{APP_NAME}:{REL_NAME}", f"{DUMMY_NAME}:{REL_NAME_ADMIN}"
+    await ops_test.model.applications[CHARM_KEY].remove_relation(
+        f"{CHARM_KEY}:{REL_NAME}", f"{DUMMY_NAME}:{REL_NAME_ADMIN}"
     )
-    await ops_test.model.wait_for_idle(apps=[APP_NAME])
+    await ops_test.model.wait_for_idle(apps=[CHARM_KEY])
     assert not check_tls(ip=kafka_address, port=SECURITY_PROTOCOL_PORTS["SASL_SSL"].client)
-
-async def test_mtls(ops_test: OpsTest)
-      

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -151,3 +151,6 @@ async def test_kafka_tls_scaling(ops_test: OpsTest):
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME])
     assert not check_tls(ip=kafka_address, port=SECURITY_PROTOCOL_PORTS["SASL_SSL"].client)
+
+async def test_mtls(ops_test: OpsTest)
+      

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -112,6 +112,50 @@ def test_listeners_in_server_properties(harness):
         assert expected_advertised_listeners in harness.charm.kafka_config.server_properties
 
 
+def test_ssl_listeners_in_server_properties(harness):
+    """Checks that listeners are added after TLS relation are created."""
+    zk_relation_id = harness.add_relation(ZK, CHARM_KEY)
+    # Simulate data-integrator relation
+    client_relation_id = harness.add_relation("kafka-client", "app")
+    harness.update_relation_data(client_relation_id, "app", {"extra-user-roles": "admin,producer"})
+    client_relation_id = harness.add_relation("kafka-client", "appii")
+    harness.update_relation_data(
+        client_relation_id, "appii", {"extra-user-roles": "admin,consumer"}
+    )
+
+    harness.update_relation_data(
+        zk_relation_id,
+        harness.charm.app.name,
+        {
+            "chroot": "/kafka",
+            "username": "moria",
+            "password": "mellon",
+            "endpoints": "1.1.1.1,2.2.2.2",
+            "uris": "1.1.1.1:2181/kafka,2.2.2.2:2181/kafka",
+            "tls": "enabled",
+        },
+    )
+    peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_relation_id, "kafka/1")
+    harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
+    harness.update_relation_data(peer_relation_id, "kafka", {"tls": "enabled", "mtls": "enabled"})
+
+    expected_listeners = (
+        "listeners=INTERNAL_SASL_SSL://:19093,CLIENT_SASL_SSL://:9093,CLIENT_SSL://:9094"
+    )
+    expected_advertised_listeners = "advertised.listeners=INTERNAL_SASL_SSL://treebeard:19093,CLIENT_SASL_SSL://treebeard:9093,CLIENT_SSL://treebeard:9094"
+
+    with (
+        patch(
+            "config.KafkaConfig.internal_user_credentials",
+            new_callable=PropertyMock,
+            return_value={INTER_BROKER_USER: "fangorn", ADMIN_USER: "forest"},
+        ),
+    ):
+        assert expected_listeners in harness.charm.kafka_config.server_properties
+        assert expected_advertised_listeners in harness.charm.kafka_config.server_properties
+
+
 def test_zookeeper_config_succeeds_fails_config(harness):
     """Checks that no ZK config is returned if missing field."""
     zk_relation_id = harness.add_relation(ZK, CHARM_KEY)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -55,14 +55,14 @@ def harness():
     return harness
 
 
-def test_blocked_if_trusted_certificates_added_before_tls_relation(harness: Harness):
+def test_blocked_if_trusted_certificate_added_before_tls_relation(harness: Harness):
     # Create peer relation
     peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_relation_id, "kafka/1")
     harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
 
     harness.set_leader(True)
-    harness.add_relation("trusted-certificates", "tls-one")
+    harness.add_relation("trusted-certificate", "tls-one")
 
     assert isinstance(harness.charm.app.status, BlockedStatus)
 
@@ -75,7 +75,7 @@ def test_mtls_flag_added(harness: Harness):
     harness.update_relation_data(peer_relation_id, "kafka", {"tls": "enabled"})
 
     harness.set_leader(True)
-    harness.add_relation("trusted-certificates", "tls-one")
+    harness.add_relation("trusted-certificate", "tls-one")
 
     peer_relation_data = harness.get_relation_data(peer_relation_id, "kafka")
     assert peer_relation_data.get("mtls", "disabled") == "enabled"

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+
+import pytest
+import yaml
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
+
+from charm import KafkaCharm
+from literals import CHARM_KEY, PEER, ZK
+
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
+
+
+@pytest.fixture
+def harness():
+    harness = Harness(KafkaCharm, meta=METADATA)
+    harness.add_relation("restart", CHARM_KEY)
+    harness._update_config(
+        {
+            "log_retention_ms": "-1",
+            "compression_type": "producer",
+        }
+    )
+    harness.begin()
+
+    # Relate to ZK with tls enabled
+    zk_relation_id = harness.add_relation(ZK, CHARM_KEY)
+    harness.update_relation_data(
+        zk_relation_id,
+        harness.charm.app.name,
+        {
+            "chroot": "/kafka",
+            "username": "moria",
+            "password": "mellon",
+            "endpoints": "1.1.1.1,2.2.2.2",
+            "uris": "1.1.1.1:2181/kafka,2.2.2.2:2181/kafka",
+            "tls": "enabled",
+        },
+    )
+
+    # Simulate data-integrator relation
+    client_relation_id = harness.add_relation("kafka-client", "app")
+    harness.update_relation_data(client_relation_id, "app", {"extra-user-roles": "admin,producer"})
+    client_relation_id = harness.add_relation("kafka-client", "appii")
+    harness.update_relation_data(
+        client_relation_id, "appii", {"extra-user-roles": "admin,consumer"}
+    )
+
+    return harness
+
+
+def test_blocked_if_trusted_certificates_added_before_tls_relation(harness: Harness):
+    # Create peer relation
+    peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_relation_id, "kafka/1")
+    harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
+
+    harness.set_leader(True)
+    harness.add_relation("trusted-certificates", "tls-one")
+
+    assert isinstance(harness.charm.app.status, BlockedStatus)
+
+
+def test_mtls_flag_added(harness: Harness):
+    # Create peer relation
+    peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_relation_id, "kafka/1")
+    harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
+    harness.update_relation_data(peer_relation_id, "kafka", {"tls": "enabled"})
+
+    harness.set_leader(True)
+    harness.add_relation("trusted-certificates", "tls-one")
+
+    peer_relation_data = harness.get_relation_data(peer_relation_id, "kafka")
+    assert peer_relation_data.get("mtls", "disabled") == "enabled"
+    assert isinstance(harness.charm.app.status, ActiveStatus)

--- a/tox.ini
+++ b/tox.ini
@@ -131,4 +131,6 @@ pass_env =
     CI_PACKED_CHARMS
 commands =
     poetry install --with integration
+    sudo apt install openjdk-17-jre-headless
+    sudo snap install charmed-kafka --channel latest/edge
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_tls.py

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ commands =
         --skip {tox_root}/.tox \
         --skip {tox_root}/build \
         --skip {tox_root}/lib \
+        --skip {tox_root}/tests/integration/*/lib \
         --skip {tox_root}/venv \
         --skip {tox_root}/.mypy_cache \
         --skip {tox_root}/icon.svg
@@ -131,6 +132,4 @@ pass_env =
     CI_PACKED_CHARMS
 commands =
     poetry install --with integration
-    sudo apt install openjdk-17-jre-headless
-    sudo snap install charmed-kafka --channel latest/edge
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_tls.py


### PR DESCRIPTION
Addresses [DPE-1339](https://warthogs.atlassian.net/browse/DPE-1339).

Two relation names have been added:
- `trusted-certificates`
- `trusted-ca`

They implement the _requirer_ side of tls-certificates-interface. These relations will hold one certificate, that will be imported into the truststore of each broker. When a relation is removed, the certificate is deleted from the truststores.

A new listener is added when the relations are in use: `CLIENT_SSL` on port `9094`

[DPE-1339]: https://warthogs.atlassian.net/browse/DPE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ