### PR TITLE
fix: various flakey CI tests, error handling and logging warnings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -60,7 +60,9 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         self.restart = RollingOpsManager(self, relation="restart", callback=self._restart)
         self.grafana_dashboards = GrafanaDashboardProvider(self)
         self.metrics_endpoint = MetricsEndpointProvider(
-            self, jobs=[{"static_configs": [{"targets": ["*:9100", "*:9101"]}]}]
+            self,
+            refresh_event=self.on.start,
+            jobs=[{"static_configs": [{"targets": ["*:9100", "*:9101"]}]}],
         )
 
         self.framework.observe(getattr(self.on, "start"), self._on_start)

--- a/src/tls.py
+++ b/src/tls.py
@@ -299,7 +299,7 @@ class KafkaTLS(Object):
         """Cleans up all keys/certs/stores on a unit."""
         try:
             subprocess.check_output(
-                "rm -r *.pem *.key *.p12 *.jks",
+                "rm -rf *.pem *.key *.p12 *.jks",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -44,13 +44,17 @@ async def test_deploy_charms_relate_active(
             app_charm, application_name=DUMMY_NAME_1, num_units=1, series="jammy"
         ),
     )
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_NAME_1, ZK])
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, DUMMY_NAME_1, ZK], timeout=1800, idle_period=30
+    )
     await ops_test.model.add_relation(APP_NAME, ZK)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK])
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, ZK], status="active", idle_period=30, timeout=1800
+    )
     await ops_test.model.add_relation(APP_NAME, f"{DUMMY_NAME_1}:{REL_NAME_CONSUMER}")
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_NAME_1])
-    assert ops_test.model.applications[APP_NAME].status == "active"
-    assert ops_test.model.applications[DUMMY_NAME_1].status == "active"
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, DUMMY_NAME_1], status="active", idle_period=30, timeout=1800
+    )
 
     # implicitly tests setting of kafka app data
     returned_usernames, zookeeper_uri = get_zookeeper_connection(
@@ -78,7 +82,7 @@ async def test_deploy_multiple_charms_same_topic_relate_active(
     ops_test: OpsTest, app_charm, usernames: Set[str]
 ):
     """Test relation with multiple applications."""
-    await ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_2, num_units=1),
+    await ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_2, num_units=1)
     await ops_test.model.wait_for_idle(apps=[DUMMY_NAME_2])
     await ops_test.model.add_relation(APP_NAME, f"{DUMMY_NAME_2}:{REL_NAME_CONSUMER}")
     await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_NAME_2])
@@ -213,7 +217,7 @@ async def test_admin_removed_from_super_users(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_connection_updated_on_tls_enabled(ops_test: OpsTest, app_charm):
     """Test relation when TLS is enabled."""
-    await ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_1, num_units=1),
+    await ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_1, num_units=1)
     await ops_test.model.wait_for_idle(apps=[DUMMY_NAME_1])
     await ops_test.model.add_relation(APP_NAME, f"{DUMMY_NAME_1}:{REL_NAME_CONSUMER}")
     await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_NAME_1])

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -31,15 +31,17 @@ async def test_kafka_simple_scale_up(ops_test: OpsTest, kafka_charm):
         ),
         ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="jammy"),
     )
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK])
+    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK], idle_period=30, timeout=1800)
     await ops_test.model.add_relation(APP_NAME, ZK)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK])
+    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK], idle_period=30, timeout=600)
     assert ops_test.model.applications[ZK].status == "active"
     assert ops_test.model.applications[APP_NAME].status == "active"
 
     await ops_test.model.applications[APP_NAME].add_units(count=2)
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", timeout=1000, idle_period=30
+    )
 
     kafka_zk_relation_data = get_kafka_zk_relation_data(
         unit_name="kafka/2", model_full_name=ops_test.model_full_name
@@ -53,10 +55,11 @@ async def test_kafka_simple_scale_up(ops_test: OpsTest, kafka_charm):
 
 @pytest.mark.abort_on_fail
 async def test_kafka_simple_scale_down(ops_test: OpsTest):
-
     await ops_test.model.applications[APP_NAME].destroy_units(f"{APP_NAME}/1")
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 2)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", timeout=1000, idle_period=30
+    )
 
     time.sleep(30)
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -41,7 +41,7 @@ async def test_deploy_tls(ops_test: OpsTest, kafka_charm):
         ops_test.model.deploy(kafka_charm, application_name=APP_NAME, series="jammy"),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME, TLS_NAME], timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME, TLS_NAME], timeout=1800)
 
     assert ops_test.model.applications[APP_NAME].status == "waiting"
     assert ops_test.model.applications[ZK_NAME].status == "active"


### PR DESCRIPTION
## Changes Made
##### `fix: avoid noisy warnings from cos`
- Without this change, `juju debug-log` was inundated with `0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.`
##### `fix: add force flag for rm missing tls files`
- In case no files exist to `rm`, add `-f` flag to avoid error
- Addresses https://github.com/canonical/kafka-operator/issues/66
##### `fix: add longer timeouts + idleperiods for int-tests on CI`
- Getting model timeout errors for slow CI deploy. Longer timeouts helps this
- Changes made in https://github.com/canonical/zookeeper-operator/pull/47 means that Kafka will `idle` until the next `update-status` triggers ZK to complete the relation. Longer idle periods helps this
- Addresses https://github.com/canonical/kafka-operator/issues/73