### PR TITLE
Add regex rules config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,7 +67,7 @@ options:
     type: string
     default: ""
   ssl_principal_mapping_rules:
-    description: A list of rules for mapping from distinguished name from the client certificate to short name.
+    description: A list of rules for mapping from distinguished name from the client certificate to short name. Each rule starts with "RULE:" and contains an expression as the following. "RULE:pattern/replacement/[LU]". A valid set of rules could look something like this "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT"
     type: string
     default: "DEFAULT"
   replication_quota_window_num:

--- a/config.yaml
+++ b/config.yaml
@@ -66,6 +66,10 @@ options:
     description: A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. By default all the available cipher suites are supported.
     type: string
     default: ""
+  ssl_principal_mapping_rules:
+    description: A list of rules for mapping from distinguished name from the client certificate to short name.
+    type: string
+    default: "DEFAULT"
   replication_quota_window_num:
     description: The number of samples to retain in memory for replication quotas.
     type: int
@@ -74,4 +78,3 @@ options:
     description: Specifies the enabled cipher suites to be used in ZooKeeper TLS negotiation (csv). Overrides any explicit value set via the zookeeper.ssl.ciphersuites system property (note the single word "ciphersuites"). The default value of null means the list of enabled cipher suites is determined by the Java runtime being used.
     type: string
     default: ""
-  

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -117,6 +117,7 @@ class CharmConfig(BaseConfigModel):
     def ssl_principal_mapping_rules_validator(cls, value: str) -> Optional[str]:
         """Check that the list is formed by valid regex values."""
         # get all regex up until replacement position "/"
+        # TODO: check that there is a replacement as well, not: RULE:regex/
         pat = re.compile(r"RULE:([^/]+)(?:,RULE:[^/]+)*(?:DEFAULT){0,1}")
         matches = re.findall(pat, value)
         for match in matches:

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -57,6 +57,7 @@ class CharmConfig(BaseConfigModel):
     log_cleanup_policy: str
     log_message_timestamp_type: str
     ssl_cipher_suites: Optional[str]
+    ssl_principal_mapping_rules: Optional[str]
     replication_quota_window_num: int
     zookeeper_ssl_cipher_suites: Optional[str]
 

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -124,6 +124,7 @@ class CharmConfig(BaseConfigModel):
                 re.compile(match)
             except re.error:
                 raise ValueError("Non valid regex pattern")
+        return value
 
     @validator("transaction_state_log_num_partitions", "offsets_topic_num_partitions")
     @classmethod

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -219,9 +219,9 @@ def test_ssl_principal_mapping_rules(harness: Harness):
             return_value={INTER_BROKER_USER: "fangorn", ADMIN_USER: "forest"},
         )
     ):
-        harness.update_config({"ssl_principal_mapping_rules": "erebor,DEFAULT"})
+        harness.update_config({"ssl_principal_mapping_rules": "RULE:^(erebor)$/$1,DEFAULT"})
         assert (
-            "ssl.principal.mapping.rules=erebor,DEFAULT"
+            "ssl.principal.mapping.rules=RULE:^(erebor)$/$1,DEFAULT"
             in harness.charm.kafka_config.server_properties
         )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -220,7 +220,10 @@ def test_ssl_principal_mapping_rules(harness: Harness):
         )
     ):
         harness.update_config({"ssl_principal_mapping_rules": "erebor,DEFAULT"})
-        assert "ssl.principal.mapping.rules=erebor,DEFAULT" in harness.charm.kafka_config.server_properties
+        assert (
+            "ssl.principal.mapping.rules=erebor,DEFAULT"
+            in harness.charm.kafka_config.server_properties
+        )
 
 
 def test_auth_properties(harness):


### PR DESCRIPTION
Addresses [DPE-1340](https://warthogs.atlassian.net/browse/DPE-1340)

Adds [`ssl.principal.mapping.rules`](https://kafka.apache.org/documentation/#brokerconfigs_ssl.principal.mapping.rules) config option to charm.

[DPE-1340]: https://warthogs.atlassian.net/browse/DPE-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ