### PR TITLE
[MISC] Fix typo in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     name: Release to CharmHub
     needs:
       - lib-check
-      - ci-test
+      - ci-tests
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
I have noticed that our release pipelines was erroring out because of a typo, and therefore we did not publish new charm recently because of this :(

Unfortunately to test if this would work we need to merge this PR