### PR TITLE
fix: point charmhub buttons to this repo

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,15 +1,17 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: kafka
-display-name: Kafka
 description: |
   Kafka is an event streaming platform. This charm deploys and operates Kafka.
-summary: The Charmed Kafka Operator
+display-name: Kafka
+issues: https://github.com/canonical/kafka-operator/issues/new
 maintainers:
   - Marc Oppenheimer <marc.oppenheimer@canonical.com>
+name: kafka
 series:
   - jammy
+source: https://github.com/canonical/kafka-operator
+summary: The Charmed Kafka Operator
 
 peers:
   cluster:


### PR DESCRIPTION
## Changes Made
##### `fix: point charmhub buttons to this repo`
- Updating the `charmcraft.yaml` to include `issues:` **should** fix this iirc
- If not, still a good change