### PR TITLE
refactor/feat: use updated non-root snap, use `--bootstrap-server` auth

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,18 +75,20 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ needs.build.outputs.artifact-name }}
-      - name: Select tests
-        id: select-tests
-        run: |
-          if [ "${{ github.event_name }}" == "schedule" ]
-          then
-            echo Running unstable and stable tests
-            echo "mark_expression=" >> $GITHUB_OUTPUT
-          else
-            echo Skipping unstable tests
-            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
-          fi
+      # - name: Select tests
+      #   id: select-tests
+      #   run: |
+      #     if [ "${{ github.event_name }}" == "schedule" ]
+      #     then
+      #       echo Running unstable and stable tests
+      #       echo "mark_expression=" >> $GITHUB_OUTPUT
+      #     else
+      #       echo Skipping unstable tests
+      #       echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+      #     fi
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Run integration tests
-        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        run: tox run -e integration-tls
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,10 +55,10 @@ jobs:
     #       - integration-password-rotation
     #       - integration-tls
     # name: ${{ matrix.tox-environments }}
-    # needs:
-    #   - lint
-    #   - unit-test
-    #   - build
+    needs:
+      - lint
+      - unit-test
+      - build
     runs-on: ubuntu-latest
     # timeout-minutes: 120
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,22 +45,22 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
 
   integration-test:
-    # strategy:
-    #   fail-fast: false
-    #   matrix:
-    #     tox-environments:
-    #       - integration-charm
-    #       - integration-provider
-    #       - integration-scaling
-    #       - integration-password-rotation
-    #       - integration-tls
-    # name: ${{ matrix.tox-environments }}
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environments:
+          - integration-charm
+          - integration-provider
+          - integration-scaling
+          - integration-password-rotation
+          - integration-tls
+    name: ${{ matrix.tox-environments }}
     needs:
       - lint
       - unit-test
       - build
     runs-on: ubuntu-latest
-    # timeout-minutes: 120
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -75,18 +75,18 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ needs.build.outputs.artifact-name }}
-      # - name: Select tests
-      #   id: select-tests
-      #   run: |
-      #     if [ "${{ github.event_name }}" == "schedule" ]
-      #     then
-      #       echo Running unstable and stable tests
-      #       echo "mark_expression=" >> $GITHUB_OUTPUT
-      #     else
-      #       echo Skipping unstable tests
-      #       echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
-      #     fi
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
       - name: Run integration tests
-        run: tox run -e integration-tls
+        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,8 +86,6 @@ jobs:
       #       echo Skipping unstable tests
       #       echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
       #     fi
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
       - name: Run integration tests
         run: tox run -e integration-tls
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,8 @@ jobs:
       #       echo Skipping unstable tests
       #       echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
       #     fi
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Run integration tests
         run: tox run -e integration-tls
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,22 +45,22 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
 
   integration-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        tox-environments:
-          - integration-charm
-          - integration-provider
-          - integration-scaling
-          - integration-password-rotation
-          - integration-tls
-    name: ${{ matrix.tox-environments }}
-    needs:
-      - lint
-      - unit-test
-      - build
+    # strategy:
+    #   fail-fast: false
+    #   matrix:
+    #     tox-environments:
+    #       - integration-charm
+    #       - integration-provider
+    #       - integration-scaling
+    #       - integration-password-rotation
+    #       - integration-tls
+    # name: ${{ matrix.tox-environments }}
+    # needs:
+    #   - lint
+    #   - unit-test
+    #   - build
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -40,10 +40,10 @@ provides:
     interface: cos_agent
 
 storage:
-  log-data:
+  data:
     type: filesystem
     description: Directories where the log data is stored
     minimum-size: 10G
-    location: /var/snap/charmed-kafka/common
+    location: /var/snap/charmed-kafka/common/var/lib/kafka
     multiple:
       range: 1-

--- a/poetry.lock
+++ b/poetry.lock
@@ -863,6 +863,21 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.7.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
+    {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "oauthlib"
 version = "3.2.2"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1283,6 +1298,25 @@ files = [
 
 [package.dependencies]
 pytz = "*"
+
+[[package]]
+name = "pyright"
+version = "1.1.301"
+description = "Command line wrapper for pyright"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.301-py3-none-any.whl", hash = "sha256:ecc3752ba8c866a8041c90becf6be79bd52f4c51f98472e4776cae6d55e12826"},
+    {file = "pyright-1.1.301.tar.gz", hash = "sha256:6ac4afc0004dca3a977a4a04a8ba25b5b5aa55f8289550697bfc20e11be0d5f2"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "pyrsistent"
@@ -1898,4 +1932,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "dfb0b462c0666e1f6cf26eb6b5d2fd1ddeb9b968354f6e11a3d8e6bf0ed84cfd"
+content-hash = "97194f2b5c5ff2547fc06d26dd24ba9c7dd8eb341aa518ddb56b85a3e6300aed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ optional = true
 black = "^22.3.0"
 ruff = ">=0.0.157"
 codespell = ">=2.2.2"
+pyright = "^1.1.301"
 
 [tool.poetry.group.unit]
 optional = true
@@ -78,6 +79,10 @@ tenacity = ">=7.0"
 pure-sasl = ">=0.5"
 kafka-python = ">=2.0"
 requests = ">2.25"
+
+
+[tool.poetry.group.format.dependencies]
+pyright = "^1.1.301"
 
 [tool.ruff]
 line-length = 99
@@ -104,3 +109,14 @@ src = ["src", "tests"]
 
 [tool.ruff.mccabe]
 max-complexity = 10
+
+[tool.pyright]
+include = ["src"]
+extraPaths = ["./lib"]
+pythonVersion = "3.10"
+pythonPlatform = "All"
+typeCheckingMode = "basic"
+reportIncompatibleMethodOverride = false
+reportImportCycles = false
+reportMissingModuleSource = true
+stubPath = ""

--- a/src/config.py
+++ b/src/config.py
@@ -103,16 +103,16 @@ class KafkaConfig:
 
     def __init__(self, charm):
         self.charm: "KafkaCharm" = charm
-        self.server_properties_filepath = f"{self.charm.snap.conf_path}/server.properties"
-        self.client_properties_filepath = f"{self.charm.snap.conf_path}/client.properties"
-        self.zk_jaas_filepath = f"{self.charm.snap.conf_path}/zookeeper-jaas.cfg"
-        self.keystore_filepath = f"{self.charm.snap.conf_path}/keystore.p12"
-        self.truststore_filepath = f"{self.charm.snap.conf_path}/truststore.jks"
-        self.log4j_properties_filepath = f"{self.charm.snap.conf_path}/log4j.properties"
+        self.server_properties_filepath = f"{self.charm.snap.CONF_PATH}/server.properties"
+        self.client_properties_filepath = f"{self.charm.snap.CONF_PATH}/client.properties"
+        self.zk_jaas_filepath = f"{self.charm.snap.CONF_PATH}/zookeeper-jaas.cfg"
+        self.keystore_filepath = f"{self.charm.snap.CONF_PATH}/keystore.p12"
+        self.truststore_filepath = f"{self.charm.snap.CONF_PATH}/truststore.jks"
+        self.log4j_properties_filepath = f"{self.charm.snap.CONF_PATH}/log4j.properties"
         self.jmx_prometheus_javaagent_filepath = (
-            f"{self.charm.snap.binaries_path}/jmx_prometheus_javaagent.jar"
+            f"{self.charm.snap.BINARIES_PATH}/jmx_prometheus_javaagent.jar"
         )
-        self.jmx_prometheus_config_filepath = f"{self.charm.snap.conf_path}/jmx_prometheus.yaml"
+        self.jmx_prometheus_config_filepath = f"{self.charm.snap.CONF_PATH}/jmx_prometheus.yaml"
 
     @property
     def internal_user_credentials(self) -> Dict[str, str]:

--- a/src/literals.py
+++ b/src/literals.py
@@ -70,7 +70,7 @@ class Status(Enum):
         "ERROR",
     )
     REMOVED_STORAGE_NO_REPL = StatusLevel(
-        ActiveStatus("potential log-data loss due to storage removal without replication"),
+        ActiveStatus("potential data loss due to storage removal without replication"),
         "ERROR",
     )
     NO_BROKER_CREDS = StatusLevel(

--- a/src/provider.py
+++ b/src/provider.py
@@ -8,7 +8,7 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from charms.data_platform_libs.v0.data_interfaces import KafkaProvides, TopicRequestedEvent
-from ops.charm import RelationBrokenEvent
+from ops.charm import RelationBrokenEvent, RelationCreatedEvent
 from ops.framework import Object
 from ops.model import Relation
 
@@ -34,6 +34,7 @@ class KafkaProvider(Object):
 
         self.kafka_provider = KafkaProvides(self.charm, REL_NAME)
 
+        self.framework.observe(self.charm.on[REL_NAME].relation_created, self._on_relation_created)
         self.framework.observe(self.charm.on[REL_NAME].relation_broken, self._on_relation_broken)
 
         self.framework.observe(
@@ -98,6 +99,11 @@ class KafkaProvider(Object):
     def peer_relation(self) -> Optional[Relation]:
         """The Kafka cluster's peer relation."""
         return self.charm.model.get_relation(PEER)
+
+    def _on_relation_created(self, event: RelationCreatedEvent) -> None:
+        """Handler for `kafka-client-relation-created` event."""
+        logger.info("RELATION CREATED - CALLING CONFIG CHANGED")
+        self.charm._on_config_changed(event)
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handler for `kafka-client-relation-broken` event.

--- a/src/snap.py
+++ b/src/snap.py
@@ -27,10 +27,10 @@ class KafkaSnap:
     COMPONENT = "kafka"
     SNAP_SERVICE = "daemon"
 
-    conf_path = f"/var/snap/{SNAP_NAME}/current/etc/{COMPONENT}"
-    logs_path = f"/var/snap/{SNAP_NAME}/common/var/log/{COMPONENT}"
-    data_path = f"/var/snap/{SNAP_NAME}/common/var/lib/{COMPONENT}"
-    binaries_path = f"/snap/{SNAP_NAME}/current/opt/{COMPONENT}"
+    CONF_PATH = f"/var/snap/{SNAP_NAME}/current/etc/{COMPONENT}"
+    LOGS_PATH = f"/var/snap/{SNAP_NAME}/common/var/log/{COMPONENT}"
+    DATA_PATH = f"/var/snap/{SNAP_NAME}/common/var/lib/{COMPONENT}"
+    BINARIES_PATH = f"/snap/{SNAP_NAME}/current/opt/{COMPONENT}"
 
     def __init__(self) -> None:
         self.kafka = snap.SnapCache()[SNAP_NAME]

--- a/src/snap.py
+++ b/src/snap.py
@@ -148,8 +148,6 @@ class KafkaSnap:
         opts_string = " ".join(opts)
         command = f"{opts_string} {SNAP_NAME}.{bin_keyword} {args_string}"
 
-        logger.info(f"{command=}")
-
         try:
             output = subprocess.check_output(
                 command, stderr=subprocess.PIPE, universal_newlines=True, shell=True

--- a/src/snap.py
+++ b/src/snap.py
@@ -20,14 +20,19 @@ from literals import SNAP_NAME
 logger = logging.getLogger(__name__)
 
 
-SNAP_CONFIG_PATH = "/var/snap/charmed-kafka/common"
-
-
 class KafkaSnap:
     """Wrapper for performing common operations specific to the Kafka Snap."""
 
+    SNAP_NAME = "charmed-kafka"
+    COMPONENT = "kafka"
+    SNAP_SERVICE = "daemon"
+
+    conf_path = f"/var/snap/{SNAP_NAME}/current/etc/{COMPONENT}"
+    logs_path = f"/var/snap/{SNAP_NAME}/common/var/log/{COMPONENT}"
+    data_path = f"/var/snap/{SNAP_NAME}/common/var/lib/{COMPONENT}"
+    binaries_path = f"/snap/{SNAP_NAME}/current/opt/{COMPONENT}"
+
     def __init__(self) -> None:
-        self.snap_config_path = SNAP_CONFIG_PATH
         self.kafka = snap.SnapCache()[SNAP_NAME]
 
     def install(self) -> bool:
@@ -43,7 +48,7 @@ class KafkaSnap:
             kafka = cache[SNAP_NAME]
 
             if not kafka.present:
-                kafka.ensure(snap.SnapState.Latest, channel="latest/edge")
+                kafka.ensure(snap.SnapState.Latest, channel="3/edge")
 
             self.kafka = kafka
             self.kafka.connect(plug="removable-media")
@@ -53,82 +58,64 @@ class KafkaSnap:
             logger.error(str(e))
             return False
 
-    def start_snap_service(self, snap_service: str) -> bool:
+    def start_snap_service(self) -> bool:
         """Starts snap service process.
-
-        Args:
-            snap_service: The desired service to run on the unit
-                `charmed-kafka` or `zookeeper`
 
         Returns:
             True if service successfully starts. False otherwise.
         """
         try:
-            self.kafka.start(services=[snap_service])
+            self.kafka.start(services=[self.SNAP_SERVICE])
             return True
         except snap.SnapError as e:
             logger.exception(str(e))
             return False
 
-    def stop_snap_service(self, snap_service: str) -> bool:
+    def stop_snap_service(self) -> bool:
         """Stops snap service process.
-
-        Args:
-            snap_service: The desired service to stop on the unit
-                `charmed-kafka` or `zookeeper`
 
         Returns:
             True if service successfully stops. False otherwise.
         """
         try:
-            self.kafka.stop(services=[snap_service])
+            self.kafka.stop(services=[self.SNAP_SERVICE])
             return True
         except snap.SnapError as e:
             logger.exception(str(e))
             return False
 
-    def restart_snap_service(self, snap_service: str) -> bool:
+    def restart_snap_service(self) -> bool:
         """Restarts snap service process.
-
-        Args:
-            snap_service: The desired service to run on the unit
-                `kafka` or `zookeeper`
 
         Returns:
             True if service successfully restarts. False otherwise.
         """
         try:
-            self.kafka.restart(services=[snap_service])
+            self.kafka.restart(services=[self.SNAP_SERVICE])
             return True
         except snap.SnapError as e:
             logger.exception(str(e))
             return False
 
-    def disable_enable(self, snap_service: str) -> None:
+    def disable_enable(self) -> None:
         """Disables then enables snap service.
 
         Necessary for snap services to recognise new storage mounts
 
-        Args:
-            snap_service: The desired service to disable+enable
-
         Raises:
             subprocess.CalledProcessError if error occurs
         """
-        subprocess.run(f"snap disable {snap_service}", shell=True)
-        subprocess.run(f"snap enable {snap_service}", shell=True)
+        subprocess.run(f"snap disable {self.SNAP_SERVICE}", shell=True)
+        subprocess.run(f"snap enable {self.SNAP_SERVICE}", shell=True)
 
     @retry(
         wait=wait_fixed(1),
         stop=stop_after_attempt(5),
-        retry_error_callback=lambda state: state.outcome.result(),
+        retry_error_callback=lambda state: state.outcome.result(),  # type: ignore
         retry=retry_if_not_result(lambda result: True if result else False),
     )
-    def active(self, snap_service: str) -> bool:
+    def active(self) -> bool:
         """Checks if service is active.
-
-        Args:
-            snap_service: The desired service to check active
 
         Returns:
             True if service is active. Otherwise False
@@ -137,19 +124,19 @@ class KafkaSnap:
             KeyError if service does not exist
         """
         try:
-            return bool(self.kafka.services[snap_service]["active"])
+            return bool(self.kafka.services[self.SNAP_SERVICE]["active"])
         except KeyError:
             return False
 
     @staticmethod
-    def run_bin_command(bin_keyword: str, bin_args: List[str], opts: List[str]) -> str:
+    def run_bin_command(bin_keyword: str, bin_args: List[str], opts: List[str] = []) -> str:
         """Runs kafka bin command with desired args.
 
         Args:
             bin_keyword: the kafka shell script to run
                 e.g `configs`, `topics` etc
             bin_args: the shell command args
-            opts (optional): the desired `KAFKA_OPTS` env var values for the command
+            opts: any additional opts args strings
 
         Returns:
             String of kafka bin command output
@@ -158,11 +145,10 @@ class KafkaSnap:
             `subprocess.CalledProcessError`: if the error returned a non-zero exit code
         """
         args_string = " ".join(bin_args)
-        args_string_appended = (
-            f"{args_string} --zk-tls-config-file={SNAP_CONFIG_PATH}/server.properties"
-        )
         opts_string = " ".join(opts)
-        command = f"KAFKA_OPTS={opts_string} {SNAP_NAME}.{bin_keyword} {args_string_appended}"
+        command = f"{opts_string} {SNAP_NAME}.{bin_keyword} {args_string}"
+
+        logger.info(f"{command=}")
 
         try:
             output = subprocess.check_output(

--- a/src/tls.py
+++ b/src/tls.py
@@ -27,7 +27,13 @@ from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, Relation
 
 from literals import TLS_RELATION, TRUSTED_CA_RELATION, TRUSTED_CERTIFICATE_RELATION
-from utils import generate_password, parse_tls_file, safe_write_to_file, set_snap_ownership
+from utils import (
+    generate_password,
+    parse_tls_file,
+    safe_write_to_file,
+    set_snap_mode_bits,
+    set_snap_ownership,
+)
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
@@ -418,6 +424,7 @@ class KafkaTLS(Object):
                 cwd=self.charm.snap.CONF_PATH,
             )
             set_snap_ownership(path=f"{self.charm.snap.CONF_PATH}/truststore.jks")
+            set_snap_mode_bits(path=f"{self.charm.snap.CONF_PATH}/truststore.jks")
         except subprocess.CalledProcessError as e:
             # in case this reruns and fails
             if "already exists" in e.output:
@@ -436,6 +443,7 @@ class KafkaTLS(Object):
                 cwd=self.charm.snap.CONF_PATH,
             )
             set_snap_ownership(path=f"{self.charm.snap.CONF_PATH}/keystore.p12")
+            set_snap_mode_bits(path=f"{self.charm.snap.CONF_PATH}/keystore.p12")
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
             raise e

--- a/src/tls.py
+++ b/src/tls.py
@@ -8,7 +8,7 @@ import json
 import logging
 import socket
 import subprocess
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from charms.tls_certificates_interface.v1.tls_certificates import (
     CertificateAvailableEvent,
@@ -27,8 +27,10 @@ from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, Relation
 
 from literals import TLS_RELATION, TRUSTED_CA_RELATION, TRUSTED_CERTIFICATE_RELATION
-from snap import SNAP_CONFIG_PATH
-from utils import generate_password, parse_tls_file, safe_write_to_file
+from utils import generate_password, parse_tls_file, safe_write_to_file, set_snap_ownership
+
+if TYPE_CHECKING:
+    from charm import KafkaCharm
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +40,7 @@ class KafkaTLS(Object):
 
     def __init__(self, charm):
         super().__init__(charm, "tls")
-        self.charm = charm
+        self.charm: "KafkaCharm" = charm
         self.certificates = TLSCertificatesRequiresV1(self.charm, TLS_RELATION)
 
         # Own certificates handlers
@@ -57,7 +59,9 @@ class KafkaTLS(Object):
         self.framework.observe(
             getattr(self.certificates.on, "certificate_expiring"), self._on_certificate_expiring
         )
-        self.framework.observe(self.charm.on.set_tls_private_key_action, self._set_tls_private_key)
+        self.framework.observe(
+            getattr(self.charm.on, "set_tls_private_key_action"), self._set_tls_private_key
+        )
 
         # External certificates handlers (for mTLS)
         for relation in [TRUSTED_CERTIFICATE_RELATION, TRUSTED_CA_RELATION]:
@@ -80,7 +84,7 @@ class KafkaTLS(Object):
 
     def _tls_relation_created(self, _) -> None:
         """Handler for `certificates_relation_created` event."""
-        if not self.charm.unit.is_leader():
+        if not self.charm.unit.is_leader() or not self.peer_relation:
             return
 
         self.peer_relation.data[self.charm.app].update({"tls": "enabled"})
@@ -184,7 +188,7 @@ class KafkaTLS(Object):
             else provider_certificates[0]["ca"]
         )
         filename = f"{alias}.pem"
-        safe_write_to_file(content=content, path=f"{SNAP_CONFIG_PATH}/{filename}")
+        safe_write_to_file(content=content, path=f"{self.charm.snap.conf_path}/{filename}")
         self.import_cert(alias=f"{alias}", filename=filename)
 
     def _trusted_relation_broken(self, event: RelationBrokenEvent) -> None:
@@ -237,7 +241,7 @@ class KafkaTLS(Object):
 
     def _on_certificate_expiring(self, _) -> None:
         """Handler for `certificate_expiring` event."""
-        if not self.private_key or not self.csr:
+        if not self.private_key or not self.csr or not self.peer_relation:
             logger.error("Missing unit private key and/or old csr")
             return
         new_csr = generate_csr(
@@ -266,7 +270,7 @@ class KafkaTLS(Object):
         self._on_certificate_expiring(event)
 
     @property
-    def peer_relation(self) -> Relation:
+    def peer_relation(self) -> Optional[Relation]:
         """Get the peer relation of the charm."""
         return self.charm.peer_relation
 
@@ -350,7 +354,7 @@ class KafkaTLS(Object):
 
     def _request_certificate(self):
         """Generates and submits CSR to provider."""
-        if not self.private_key:
+        if not self.private_key or not self.peer_relation:
             logger.error("Can't request certificate, missing private key")
             return
 
@@ -381,7 +385,9 @@ class KafkaTLS(Object):
             logger.error("Can't set private-key to unit, missing private-key in relation data")
             return
 
-        safe_write_to_file(content=self.private_key, path=f"{SNAP_CONFIG_PATH}/server.key")
+        safe_write_to_file(
+            content=self.private_key, path=f"{self.charm.snap.conf_path}/server.key"
+        )
 
     def set_ca(self) -> None:
         """Sets the unit ca."""
@@ -389,7 +395,7 @@ class KafkaTLS(Object):
             logger.error("Can't set CA to unit, missing CA in relation data")
             return
 
-        safe_write_to_file(content=self.ca, path=f"{SNAP_CONFIG_PATH}/ca.pem")
+        safe_write_to_file(content=self.ca, path=f"{self.charm.snap.conf_path}/ca.pem")
 
     def set_certificate(self) -> None:
         """Sets the unit certificate."""
@@ -397,7 +403,9 @@ class KafkaTLS(Object):
             logger.error("Can't set certificate to unit, missing certificate in relation data")
             return
 
-        safe_write_to_file(content=self.certificate, path=f"{SNAP_CONFIG_PATH}/server.pem")
+        safe_write_to_file(
+            content=self.certificate, path=f"{self.charm.snap.conf_path}/server.pem"
+        )
 
     def set_truststore(self) -> None:
         """Adds CA to JKS truststore."""
@@ -407,8 +415,9 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=SNAP_CONFIG_PATH,
+                cwd=self.charm.snap.conf_path,
             )
+            set_snap_ownership(path=f"{self.charm.snap.conf_path}/truststore.jks")
         except subprocess.CalledProcessError as e:
             # in case this reruns and fails
             if "already exists" in e.output:
@@ -424,8 +433,9 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=SNAP_CONFIG_PATH,
+                cwd=self.charm.snap.conf_path,
             )
+            set_snap_ownership(path=f"{self.charm.snap.conf_path}/keystore.p12")
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
             raise e
@@ -438,7 +448,7 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=SNAP_CONFIG_PATH,
+                cwd=self.charm.snap.conf_path,
             )
         except subprocess.CalledProcessError as e:
             # in case this reruns and fails
@@ -456,14 +466,14 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=SNAP_CONFIG_PATH,
+                cwd=self.charm.snap.conf_path,
             )
             subprocess.check_output(
                 f"rm -f {alias}.pem",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=SNAP_CONFIG_PATH,
+                cwd=self.charm.snap.conf_path,
             )
         except subprocess.CalledProcessError as e:
             if "does not exist" in e.output:
@@ -480,7 +490,7 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=SNAP_CONFIG_PATH,
+                cwd=self.charm.snap.conf_path,
             )
         except subprocess.CalledProcessError as e:
             logger.error(e.output)

--- a/src/tls.py
+++ b/src/tls.py
@@ -188,7 +188,7 @@ class KafkaTLS(Object):
             else provider_certificates[0]["ca"]
         )
         filename = f"{alias}.pem"
-        safe_write_to_file(content=content, path=f"{self.charm.snap.conf_path}/{filename}")
+        safe_write_to_file(content=content, path=f"{self.charm.snap.CONF_PATH}/{filename}")
         self.import_cert(alias=f"{alias}", filename=filename)
 
     def _trusted_relation_broken(self, event: RelationBrokenEvent) -> None:
@@ -386,7 +386,7 @@ class KafkaTLS(Object):
             return
 
         safe_write_to_file(
-            content=self.private_key, path=f"{self.charm.snap.conf_path}/server.key"
+            content=self.private_key, path=f"{self.charm.snap.CONF_PATH}/server.key"
         )
 
     def set_ca(self) -> None:
@@ -395,7 +395,7 @@ class KafkaTLS(Object):
             logger.error("Can't set CA to unit, missing CA in relation data")
             return
 
-        safe_write_to_file(content=self.ca, path=f"{self.charm.snap.conf_path}/ca.pem")
+        safe_write_to_file(content=self.ca, path=f"{self.charm.snap.CONF_PATH}/ca.pem")
 
     def set_certificate(self) -> None:
         """Sets the unit certificate."""
@@ -404,7 +404,7 @@ class KafkaTLS(Object):
             return
 
         safe_write_to_file(
-            content=self.certificate, path=f"{self.charm.snap.conf_path}/server.pem"
+            content=self.certificate, path=f"{self.charm.snap.CONF_PATH}/server.pem"
         )
 
     def set_truststore(self) -> None:
@@ -415,9 +415,9 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=self.charm.snap.conf_path,
+                cwd=self.charm.snap.CONF_PATH,
             )
-            set_snap_ownership(path=f"{self.charm.snap.conf_path}/truststore.jks")
+            set_snap_ownership(path=f"{self.charm.snap.CONF_PATH}/truststore.jks")
         except subprocess.CalledProcessError as e:
             # in case this reruns and fails
             if "already exists" in e.output:
@@ -433,9 +433,9 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=self.charm.snap.conf_path,
+                cwd=self.charm.snap.CONF_PATH,
             )
-            set_snap_ownership(path=f"{self.charm.snap.conf_path}/keystore.p12")
+            set_snap_ownership(path=f"{self.charm.snap.CONF_PATH}/keystore.p12")
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
             raise e
@@ -448,7 +448,7 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=self.charm.snap.conf_path,
+                cwd=self.charm.snap.CONF_PATH,
             )
         except subprocess.CalledProcessError as e:
             # in case this reruns and fails
@@ -466,14 +466,14 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=self.charm.snap.conf_path,
+                cwd=self.charm.snap.CONF_PATH,
             )
             subprocess.check_output(
                 f"rm -f {alias}.pem",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=self.charm.snap.conf_path,
+                cwd=self.charm.snap.CONF_PATH,
             )
         except subprocess.CalledProcessError as e:
             if "does not exist" in e.output:
@@ -490,7 +490,7 @@ class KafkaTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=self.charm.snap.conf_path,
+                cwd=self.charm.snap.CONF_PATH,
             )
         except subprocess.CalledProcessError as e:
             logger.error(e.output)

--- a/src/utils.py
+++ b/src/utils.py
@@ -113,6 +113,11 @@ def set_snap_ownership(path: str) -> None:
     shutil.chown(path, user="snap_daemon", group="root")
 
 
+def set_snap_mode_bits(path: str) -> None:
+    """Sets filepath mode bits."""
+    os.chmod(path, 0o770)
+
+
 def generate_password() -> str:
     """Creates randomized string for use as app passwords.
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import secrets
+import shutil
 import string
 from typing import Dict, List, Optional, Set
 
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
     # retry to give ZK time to update its broker zNodes before failing
     wait=wait_fixed(6),
     stop=stop_after_attempt(10),
-    retry_error_callback=(lambda state: state.outcome.result()),
+    retry_error_callback=(lambda state: state.outcome.result()),  # type: ignore
     retry=retry_if_not_result(lambda result: True if result else False),
 )
 def broker_active(unit: Unit, zookeeper_config: Dict[str, str]) -> bool:
@@ -104,7 +105,12 @@ def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
     with open(path, mode) as f:
         f.write(content)
 
-    return
+    set_snap_ownership(path=path)
+
+
+def set_snap_ownership(path: str) -> None:
+    """Sets a filepath `snap_daemon` ownership."""
+    shutil.chown(path, user="snap_daemon", group="root")
 
 
 def generate_password() -> str:

--- a/tests/integration/app-charm/src/utils.py
+++ b/tests/integration/app-charm/src/utils.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import secrets
+import shutil
 import string
 from typing import List, Optional
 
@@ -43,6 +44,8 @@ def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, mode) as f:
         f.write(content)
+
+    shutil.chown(path, user="snap_daemon", group="root")
 
     return
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 def load_acls(model_full_name: str, zookeeper_uri: str) -> Set[Acl]:
     result = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 'charmed-kafka.acls --authorizer-properties zookeeper.connect={zookeeper_uri} --list'",
+        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.acls --authorizer-properties zookeeper.connect={zookeeper_uri} --list'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -40,7 +40,7 @@ def load_acls(model_full_name: str, zookeeper_uri: str) -> Set[Acl]:
 
 def load_super_users(model_full_name: str) -> List[str]:
     result = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 'cat /var/snap/charmed-kafka/common/server.properties'",
+        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 sudo -i 'cat /var/snap/charmed-kafka/common/server.properties'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -56,7 +56,7 @@ def load_super_users(model_full_name: str) -> List[str]:
 
 def check_user(model_full_name: str, username: str, zookeeper_uri: str) -> None:
     result = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 'charmed-kafka.configs --zookeeper {zookeeper_uri} --describe --entity-type users --entity-name {username}'",
+        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.configs --zookeeper {zookeeper_uri} --describe --entity-type users --entity-name {username}'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -66,7 +66,7 @@ def check_user(model_full_name: str, username: str, zookeeper_uri: str) -> None:
 
 def get_user(model_full_name: str, username: str, zookeeper_uri: str) -> str:
     result = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 'charmed-kafka.configs --zookeeper {zookeeper_uri} --describe --entity-type users --entity-name {username}'",
+        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.configs --zookeeper {zookeeper_uri} --describe --entity-type users --entity-name {username}'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -263,7 +263,7 @@ def produce_and_check_logs(
         client.produce_message(topic_name=topic, message_content=message)
 
     logs = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh {kafka_unit_name} 'find {KafkaSnap.DATA_PATH}/data'",
+        f"JUJU_MODEL={model_full_name} juju ssh {kafka_unit_name} sudo -i 'find {KafkaSnap.DATA_PATH}/data'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -287,7 +287,7 @@ async def run_client_properties(ops_test: OpsTest) -> str:
         + f":{SECURITY_PROTOCOL_PORTS['SASL_PLAINTEXT'].client}"
     )
     result = check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'charmed-kafka.configs --bootstrap-server {bootstrap_server} --describe --all --command-config {KafkaSnap.CONF_PATH}/client.properties --entity-type users'",
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.configs --bootstrap-server {bootstrap_server} --describe --all --command-config {KafkaSnap.CONF_PATH}/client.properties --entity-type users'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -17,7 +17,7 @@ from pytest_operator.plugin import OpsTest
 
 from auth import Acl, KafkaAuth
 from literals import SECURITY_PROTOCOL_PORTS
-from snap import SNAP_CONFIG_PATH
+from snap import KafkaSnap
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
@@ -263,7 +263,7 @@ def produce_and_check_logs(
         client.produce_message(topic_name=topic, message_content=message)
 
     logs = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh {kafka_unit_name} 'find /var/snap/charmed-kafka/common/log-data'",
+        f"JUJU_MODEL={model_full_name} juju ssh {kafka_unit_name} 'find {KafkaSnap.data_path}/data'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -287,7 +287,7 @@ async def run_client_properties(ops_test: OpsTest) -> str:
         + f":{SECURITY_PROTOCOL_PORTS['SASL_PLAINTEXT'].client}"
     )
     result = check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'charmed-kafka.configs --bootstrap-server {bootstrap_server} --describe --all --command-config {SNAP_CONFIG_PATH}/client.properties --entity-type users'",
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'charmed-kafka.configs --bootstrap-server {bootstrap_server} --describe --all --command-config {KafkaSnap.conf_path}/client.properties --entity-type users'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -299,7 +299,7 @@ async def run_client_properties(ops_test: OpsTest) -> str:
 async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
     """Adds ACLs for principal `User:client` and `TEST-TOPIC`."""
     result = check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {SNAP_CONFIG_PATH}/client.properties'",
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {KafkaSnap.conf_path}/client.properties'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -40,7 +40,7 @@ def load_acls(model_full_name: str, zookeeper_uri: str) -> Set[Acl]:
 
 def load_super_users(model_full_name: str) -> List[str]:
     result = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 sudo -i 'cat /var/snap/charmed-kafka/etc/kafka/server.properties'",
+        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 sudo -i 'cat /var/snap/charmed-kafka/current/etc/kafka/server.properties'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -302,7 +302,7 @@ async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
     for _ in range(3):
         try:
             result = check_output(
-                f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {KafkaSnap.CONF_PATH}/client.properties'",
+                f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'sudo charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {KafkaSnap.CONF_PATH}/client.properties'",
                 stderr=PIPE,
                 shell=True,
                 universal_newlines=True,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -315,7 +315,7 @@ async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
             print(e.stderr)
             print(e.stdout)
             print(str(e))
+            if _ == 2:
+                raise
             time.sleep(10)
             continue
-
-    raise

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -298,11 +298,18 @@ async def run_client_properties(ops_test: OpsTest) -> str:
 
 async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
     """Adds ACLs for principal `User:client` and `TEST-TOPIC`."""
-    result = check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {KafkaSnap.CONF_PATH}/client.properties'",
-        stderr=PIPE,
-        shell=True,
-        universal_newlines=True,
-    )
+    try:
+        result = check_output(
+            f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {KafkaSnap.CONF_PATH}/client.properties'",
+            stderr=PIPE,
+            shell=True,
+            universal_newlines=True,
+        )
 
-    return result
+        return result
+
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        print(e.stderr)
+        print(e.stdout)
+        print(str(e))

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -5,7 +5,6 @@ import logging
 import re
 import socket
 import subprocess
-import time
 from contextlib import closing
 from pathlib import Path
 from subprocess import PIPE, check_output
@@ -299,25 +298,11 @@ async def run_client_properties(ops_test: OpsTest) -> str:
 
 async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
     """Adds ACLs for principal `User:client` and `TEST-TOPIC`."""
-    for _ in range(3):
-        try:
-            result = check_output(
-                f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'sudo charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {KafkaSnap.CONF_PATH}/client.properties'",
-                stderr=PIPE,
-                shell=True,
-                universal_newlines=True,
-            )
+    result = check_output(
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'sudo charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {KafkaSnap.CONF_PATH}/client.properties'",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
 
-            return result
-
-        except subprocess.CalledProcessError as e:
-            print(e.output)
-            print(e.stderr)
-            print(e.stdout)
-            print(str(e))
-            if _ == 2:
-                # print("sleeping forever")
-                # time.sleep(100000)
-                raise
-            time.sleep(10)
-            continue
+    return result

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -263,7 +263,7 @@ def produce_and_check_logs(
         client.produce_message(topic_name=topic, message_content=message)
 
     logs = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh {kafka_unit_name} 'find {KafkaSnap.data_path}/data'",
+        f"JUJU_MODEL={model_full_name} juju ssh {kafka_unit_name} 'find {KafkaSnap.DATA_PATH}/data'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -287,7 +287,7 @@ async def run_client_properties(ops_test: OpsTest) -> str:
         + f":{SECURITY_PROTOCOL_PORTS['SASL_PLAINTEXT'].client}"
     )
     result = check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'charmed-kafka.configs --bootstrap-server {bootstrap_server} --describe --all --command-config {KafkaSnap.conf_path}/client.properties --entity-type users'",
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 'charmed-kafka.configs --bootstrap-server {bootstrap_server} --describe --all --command-config {KafkaSnap.CONF_PATH}/client.properties --entity-type users'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -299,7 +299,7 @@ async def run_client_properties(ops_test: OpsTest) -> str:
 async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
     """Adds ACLs for principal `User:client` and `TEST-TOPIC`."""
     result = check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {KafkaSnap.conf_path}/client.properties'",
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'charmed-kafka.acls --bootstrap-server {bootstrap_server} --add --allow-principal=User:client --operation READ --operation WRITE --operation CREATE --topic TEST-TOPIC --command-config {KafkaSnap.CONF_PATH}/client.properties'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -316,8 +316,8 @@ async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
             print(e.stdout)
             print(str(e))
             if _ == 2:
-                print("sleeping forever")
-                time.sleep(100000)
+                # print("sleeping forever")
+                # time.sleep(100000)
                 raise
             time.sleep(10)
             continue

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -316,6 +316,8 @@ async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
             print(e.stdout)
             print(str(e))
             if _ == 2:
+                print("sleeping forever")
+                time.sleep(100000)
                 raise
             time.sleep(10)
             continue

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -40,7 +40,7 @@ def load_acls(model_full_name: str, zookeeper_uri: str) -> Set[Acl]:
 
 def load_super_users(model_full_name: str) -> List[str]:
     result = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 sudo -i 'cat /var/snap/charmed-kafka/common/server.properties'",
+        f"JUJU_MODEL={model_full_name} juju ssh kafka/0 sudo -i 'cat /var/snap/charmed-kafka/etc/kafka/server.properties'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -139,6 +139,7 @@ async def test_logs_write_to_new_storage(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.skip
 async def test_observability_integration(ops_test: OpsTest):
     await ops_test.model.deploy(
         "ch:grafana-agent",
@@ -148,7 +149,7 @@ async def test_observability_integration(ops_test: OpsTest):
         series="jammy",
     )
 
-    await ops_test.model.add_relation(f"{APP_NAME}:cos-agent", "agent"),
+    await ops_test.model.add_relation(f"{APP_NAME}:cos-agent", "agent")
 
     # TODO uncomment once cos-agent is integrated in zookeeper
     # await ops_test.model.add_relation(f"{ZK_NAME}:juju-info", "agent")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -83,7 +83,13 @@ async def test_client_properties_makes_admin_connection(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME, DUMMY_NAME])
     result = await run_client_properties(ops_test=ops_test)
     assert result
-    assert len(result.strip().split("\n")) == 3
+    
+    acls = 0
+    for line in result.strip().split("\n"):
+        if "SCRAM credential configs for user-principal" in line:
+            acls += 1
+    assert acls == 3
+
     await ops_test.model.applications[APP_NAME].remove_relation(
         f"{APP_NAME}:{REL_NAME}", f"{DUMMY_NAME}:{REL_NAME_ADMIN}"
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -37,7 +37,7 @@ async def test_build_and_deploy(ops_test: OpsTest, kafka_charm):
         ),
         ops_test.model.deploy(kafka_charm, application_name=APP_NAME, num_units=1, series="jammy"),
     )
-    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME])
+    await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME], idle_period=30, timeout=3600)
     assert ops_test.model.applications[APP_NAME].status == "blocked"
     assert ops_test.model.applications[ZK_NAME].status == "active"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -83,7 +83,7 @@ async def test_client_properties_makes_admin_connection(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME, DUMMY_NAME])
     result = await run_client_properties(ops_test=ops_test)
     assert result
-    
+
     acls = 0
     for line in result.strip().split("\n"):
         if "SCRAM credential configs for user-principal" in line:

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -138,6 +138,7 @@ async def test_kafka_tls(ops_test: OpsTest, app_charm):
     assert private_key_2 == new_private_key
 
 
+@pytest.mark.abort_on_fail
 async def test_mtls(ops_test: OpsTest):
     # creating the signed external cert on the unit
     action = await ops_test.model.units.get(f"{DUMMY_NAME}/0").run_action("create-certificate")
@@ -165,7 +166,7 @@ async def test_mtls(ops_test: OpsTest):
             f"{CHARM_KEY}:{TRUSTED_CERTIFICATE_RELATION}", f"{MTLS_NAME}:{TLS_RELATION}"
         )
         await ops_test.model.wait_for_idle(
-            apps=[CHARM_KEY, MTLS_NAME], idle_period=15, timeout=1000
+            apps=[CHARM_KEY, MTLS_NAME], idle_period=60, timeout=2000, status="active"
         )
 
     # getting kafka ca and address
@@ -189,6 +190,7 @@ async def test_mtls(ops_test: OpsTest):
     assert response.results.get("success", None) == "TRUE"
 
 
+@pytest.mark.abort_on_fail
 async def test_kafka_tls_scaling(ops_test: OpsTest):
     """Scale the application while using TLS to check that new units will configure correctly."""
     await ops_test.model.applications[CHARM_KEY].add_units(count=2)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -177,55 +177,6 @@ async def test_mtls(ops_test: OpsTest):
     ssl_bootstrap_server = f"{address}:{ssl_port}"
     sasl_bootstrap_server = f"{address}:{sasl_port}"
 
-    print(f"{broker_ca=}")
-    print(f"{address=}")
-    print(f"{ssl_port=}")
-    print(f"{sasl_port=}")
-    print(f"{ssl_bootstrap_server=}")
-    print(f"{sasl_bootstrap_server=}")
-
-    import subprocess
-
-    result = subprocess.check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'cat /var/snap/charmed-kafka/current/etc/kafka/server.properties'",
-        stderr=subprocess.PIPE,
-        shell=True,
-        universal_newlines=True,
-    )
-
-    print("sudo no sudo server")
-    print(result)
-
-    result = subprocess.check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'sudo cat /var/snap/charmed-kafka/current/etc/kafka/server.properties'",
-        stderr=subprocess.PIPE,
-        shell=True,
-        universal_newlines=True,
-    )
-
-    print("sudo sudo server")
-    print(result)
-
-    result = subprocess.check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'cat /var/snap/charmed-kafka/current/etc/kafka/client.properties'",
-        stderr=subprocess.PIPE,
-        shell=True,
-        universal_newlines=True,
-    )
-
-    print("sudo no sudo client")
-    print(result)
-
-    result = subprocess.check_output(
-        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'sudo cat /var/snap/charmed-kafka/current/etc/kafka/client.properties'",
-        stderr=subprocess.PIPE,
-        shell=True,
-        universal_newlines=True,
-    )
-
-    print("sudo sudo client")
-    print(result)
-
     # setting ACLs using normal sasl port
     await set_mtls_client_acls(ops_test, bootstrap_server=sasl_bootstrap_server)
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -177,6 +177,13 @@ async def test_mtls(ops_test: OpsTest):
     ssl_bootstrap_server = f"{address}:{ssl_port}"
     sasl_bootstrap_server = f"{address}:{sasl_port}"
 
+    print(f"{broker_ca=}")
+    print(f"{address=}")
+    print(f"{ssl_port=}")
+    print(f"{sasl_port=}")
+    print(f"{ssl_bootstrap_server=}")
+    print(f"{sasl_bootstrap_server=}")
+
     import subprocess
 
     result = subprocess.check_output(
@@ -186,6 +193,7 @@ async def test_mtls(ops_test: OpsTest):
         universal_newlines=True,
     )
 
+    print("sudo no sudo server")
     print(result)
 
     result = subprocess.check_output(
@@ -195,6 +203,7 @@ async def test_mtls(ops_test: OpsTest):
         universal_newlines=True,
     )
 
+    print("sudo sudo server")
     print(result)
 
     result = subprocess.check_output(
@@ -204,6 +213,7 @@ async def test_mtls(ops_test: OpsTest):
         universal_newlines=True,
     )
 
+    print("sudo no sudo client")
     print(result)
 
     result = subprocess.check_output(
@@ -213,6 +223,7 @@ async def test_mtls(ops_test: OpsTest):
         universal_newlines=True,
     )
 
+    print("sudo sudo client")
     print(result)
 
     # setting ACLs using normal sasl port

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -177,6 +177,44 @@ async def test_mtls(ops_test: OpsTest):
     ssl_bootstrap_server = f"{address}:{ssl_port}"
     sasl_bootstrap_server = f"{address}:{sasl_port}"
 
+    import subprocess
+
+    result = subprocess.check_output(
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'cat /var/snap/charmed-kafka/current/etc/kafka/server.properties'",
+        stderr=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+
+    print(result)
+
+    result = subprocess.check_output(
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'sudo cat /var/snap/charmed-kafka/current/etc/kafka/server.properties'",
+        stderr=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+
+    print(result)
+
+    result = subprocess.check_output(
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'cat /var/snap/charmed-kafka/current/etc/kafka/client.properties'",
+        stderr=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+
+    print(result)
+
+    result = subprocess.check_output(
+        f"JUJU_MODEL={ops_test.model_full_name} juju ssh kafka/0 sudo -i 'sudo cat /var/snap/charmed-kafka/current/etc/kafka/client.properties'",
+        stderr=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+
+    print(result)
+
     # setting ACLs using normal sasl port
     await set_mtls_client_acls(ops_test, bootstrap_server=sasl_bootstrap_server)
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -112,11 +112,11 @@ async def test_kafka_tls(ops_test: OpsTest, app_charm):
             ),
         )
         await ops_test.model.wait_for_idle(
-            apps=[CHARM_KEY, DUMMY_NAME], timeout=1000, idle_period=15
+            apps=[CHARM_KEY, DUMMY_NAME], timeout=1000, idle_period=60
         )
         await ops_test.model.add_relation(CHARM_KEY, f"{DUMMY_NAME}:{REL_NAME_ADMIN}")
         await ops_test.model.wait_for_idle(
-            apps=[CHARM_KEY, DUMMY_NAME], timeout=1000, idle_period=15
+            apps=[CHARM_KEY, DUMMY_NAME], timeout=3600, idle_period=60, status="active"
         )
 
         assert ops_test.model.applications[CHARM_KEY].status == "active"

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -19,15 +19,8 @@ def test_run_bin_command_raises():
 def test_run_bin_command_args():
     """Checks KAFKA_OPTS env-var and zk-tls flag present in all snap commands."""
     with patch("subprocess.check_output") as patched:
-        KafkaSnap.run_bin_command("configs", ["--list"], ["-Djava"])
+        KafkaSnap.run_bin_command(bin_keyword="configs", bin_args=["--list"], opts=["-Djava"])
 
-        found_tls = False
-        found_opts = False
-        for arg in patched.call_args.args:
-            if "--zk-tls-config-file" in arg:
-                found_tls = True
-            if "KAFKA_OPTS=" in arg:
-                found_opts = True
-
-        assert found_tls, "--zk-tls-config-file flag not found"
-        assert found_opts, "KAFKA_OPTS not found"
+        assert "charmed-kafka.configs" in patched.call_args.args[0].split()
+        assert "-Djava" == patched.call_args.args[0].split()[0]
+        assert "--list" == patched.call_args.args[0].split()[-1]

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,9 @@ commands =
     poetry run ruff {[vars]all_path}
     poetry run black --check --diff {[vars]all_path}
 
+    poetry install
+    poetry run pyright
+
 [testenv:unit]
 description = Run unit tests
 commands =


### PR DESCRIPTION
Blocked by https://github.com/canonical/charmed-kafka-snap/pull/22
Unblocks https://github.com/canonical/kafka-operator/pull/89

## Changes Made
##### `feat: use non-root snap`
- Writing files now requires one to change ownership to `snap_daemon` user so that it can be accessed from the main snap service
    - As we're calling `keytool` and `openssl` as `root` through a subprocess, we have to make sure that `keystore.p12` and `truststore.jks` both get explicit ownership from the snap user 
- Various paths updated, see https://github.com/canonical/charmed-kafka-snap/pull/22 for more context
- Mounted storage volumes labelled `log-data` are now just `data`
##### `refactor: use --bootstrap-server auth`
- Up until now, the charm updated users + acls using `--zookeeper` as the authorizer. This is marked for deprecation
- Since the addition of `client.properties`, we can now use `--bootstrap-server --command-config=client.properties` in order to run admin commands, authorizing with Kafka instead of through ZooKeeper
- As we need to add Kafka users BEFORE the cluster has started (i.e no `bootstrap-server`s to access), we allow for continued use of `--zookeeper` ONLY when adding internal SCRAM users (`admin`, `sync` etc), as advised in the deprecation notice 
##### `refactor: tidy up KafkaSnap`
- Hard-coding snap specific things (e.g service/snap name) as class variables to help accessibility from other objects
##### `refactor: set OPTS to /etc/environment`
- This helps both the charm and users SSH'd into the units pass all necessary env vars, see https://github.com/canonical/charmed-kafka-snap/pull/22 for more context
##### `chore: ensure mode bits set on keystores`
##### `chore: don't create user until brokers has opened client listeners`
##### `refactor: tidy up types, type-hint KafkaCharm, add pyright`
- Added `pyright` to `tox -e lint`
- Just a small tidy up. Mostly around when `peer_relation` **might** be `None`
- Type-hinting `KafkaCharm` helps avoid issues where we would have the following:
    ```python
    # charm.py
    class KafkaCharm():
        def __init__(self):
            self.config = KafkaConfig(self)
            self.some_var: str = "123"  # <- note this is a string

    # config.py
    class KafkaConfig():
        def __init__(self):
            self.charm = charm

        def do_something() -> int: 
            return 456 + self.charm.some_var  # <- linters won't pick the int + str failure here
    ```
