### PR TITLE
Fix expressions on dashboard

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -32,6 +32,8 @@ from literals import (
     CHARM_KEY,
     INTERNAL_USERS,
     JMX_EXPORTER_PORT,
+    LOGS_RULES_DIR,
+    METRICS_RULES_DIR,
     PEER,
     REL_NAME,
     ZK,
@@ -94,9 +96,9 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
                 # See https://github.com/canonical/charmed-kafka-snap for details
                 {"path": "/metrics", "port": f"{JMX_EXPORTER_PORT}"},
             ],
-            metrics_rules_dir="./src/alert_rules/prometheus",
-            logs_rules_dir="./src/alert_rules/loki",
-            log_slots=["charmed-kafka:logs"],
+            metrics_rules_dir=METRICS_RULES_DIR,
+            logs_rules_dir=LOGS_RULES_DIR,
+            log_slots=[f"{self.snap.SNAP_NAME}:{self.snap.LOG_SLOT}"],
         )
 
     @property

--- a/src/grafana_dashboards/kafka-metrics.json
+++ b/src/grafana_dashboards/kafka-metrics.json
@@ -805,7 +805,7 @@
       "pluginVersion": "7.3.4",
       "targets": [
         {
-          "expr": "sum(rate(kafka_server_brokertopicmetrics_messagesin_total{job=\"$job\",topic=\"\"}[1m]))",
+          "expr": "sum(kafka_server_brokertopicmetrics_messagesinpersec{job=\"$job\",topic=\"\"})",
           "interval": "",
           "legendFormat": "Total messages in per sec ",
           "refId": "A"
@@ -1010,7 +1010,7 @@
             "mode": "thresholds"
           },
           "custom": {},
-          "displayName": "Messages In Per Sec",
+          "displayName": "Messages In Per Sec (timerange)",
           "mappings": [],
           "noValue": "0",
           "thresholds": {
@@ -1050,7 +1050,7 @@
       "pluginVersion": "7.3.4",
       "targets": [
         {
-          "expr": "sum(increase(kafka_server_brokertopicmetrics_messagesin_total{job=\"$job\",topic=\"\"}[$__range]))",
+          "expr": "sum(increase(kafka_server_brokertopicmetrics_messagesinpersec{job=\"$job\",topic=\"\"}[$__range]))",
           "interval": "",
           "legendFormat": "Total messages from ${__from:date:MM-DD hA} to ${__to:date:MM-DD hA}",
           "refId": "A"
@@ -1226,7 +1226,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "100 - rate(kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_count{job=\"$job\",instance=~\"$broker\"}[1m]) / 10000000",
+          "expr": "kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_total{job=\"$job\",instance=~\"$broker\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1862,7 +1862,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sort(sum(rate(kafka_server_brokertopicmetrics_messagesin_total{job=\"$job\",instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"}[1m]))by(topic))",
+          "expr": "sort(sum(kafka_server_brokertopicmetrics_messagesinpersec{job=\"$job\",instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"})by(topic))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1970,7 +1970,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(kafka_server_brokertopicmetrics_bytesin_total{job=\"$job\",topic!=\"\",instance=~\"$broker\",topic=~\"$topic\"}[1m]))by(topic)",
+          "expr": "sum (kafka_server_brokertopicmetrics_bytesinpersec{job=\"$job\",topic!=\"\",instance=~\"$broker\",topic=~\"$topic\"})by(topic)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2084,7 +2084,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(kafka_server_brokertopicmetrics_totalproducerequests_total{job=\"$job\",instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"}[1m]))by(topic)",
+          "expr": "sum (kafka_server_brokertopicmetrics_totalproducerequestspersec{job=\"$job\",instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"}))by(topic)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2194,7 +2194,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(kafka_server_brokertopicmetrics_bytesout_total{job=\"$job\",instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"}[1m]))by(topic)",
+          "expr": "sum (kafka_server_brokertopicmetrics_bytesoutpersec{job=\"$job\",instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"})by(topic)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2300,7 +2300,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(kafka_network_requestmetrics_requests_total{request=~\"Produce\",job=\"$job\",instance=~\"$broker\"}[1m]))by(instance)",
+          "expr": "sum(kafka_network_requestmetrics_requestspersec{request=~\"Produce\",job=\"$job\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2414,7 +2414,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(kafka_server_brokertopicmetrics_bytesout_total{job=\"$job\",instance=~\"$broker\",topic!=\"\"}[1m]))by(instance)",
+          "expr": "sum (kafka_server_brokertopicmetrics_bytesoutpersec{job=\"$job\",instance=~\"$broker\",topic!=\"\"})by(instance)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2423,7 +2423,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum (rate(kafka_server_brokertopicmetrics_bytesin_total{job=\"$job\",instance=~\"$broker\",topic!=\"\"}[1m]))by(instance)",
+          "expr": "sum (kafka_server_brokertopicmetrics_bytesinpersec{job=\"$job\",instance=~\"$broker\",topic!=\"\"})by(instance)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2544,7 +2544,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_failedproducerequests_total{job=~\"$job\",instance=~\"$broker\"}[1m]))by(instance)",
+          "expr": "sum(kafka_server_brokertopicmetrics_failedproducerequestspersec{job=~\"$job\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2649,7 +2649,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_failedfetchrequests_total{job=~\"$job\",instance=~\"$broker\"}[1m]))by(instance)",
+          "expr": "sum(kafka_server_brokertopicmetrics_failedfetchrequestspersec{job=~\"$job\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2754,7 +2754,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_failedproducerequests_total{job=~\"$job\",topic!=\"\",instance=~\"$broker\",topic=~\"$topic\"}[1m]))by(topic)",
+          "expr": "sum(kafka_server_brokertopicmetrics_failedproducerequestspersec{job=~\"$job\",topic!=\"\",instance=~\"$broker\",topic=~\"$topic\"})by(topic)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2859,7 +2859,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(kafka_server_brokertopicmetrics_failedfetchrequests_total{job=~\"$job\",topic!=\"\",instance=~\"$broker\",topic=~\"$topic\"}[1m]))by(topic)",
+          "expr": "sum(kafka_server_brokertopicmetrics_failedfetchrequestspersec{job=~\"$job\",topic!=\"\",instance=~\"$broker\",topic=~\"$topic\"})by(topic)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2966,7 +2966,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (irate(kafka_server_sessionexpirelistener_zookeeperdisconnects_total{job=\"$job\",instance=~\"$broker\"}[1m]))by(instance)",
+          "expr": "sum (kafka_server_sessionexpirelistener_zookeeperdisconnectspersec{job=\"$job\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3070,7 +3070,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (irate(kafka_server_sessionexpirelistener_zookeeperexpires_total{job=\"$job\",instance=~\"$broker\"}[1m]))by(instance)",
+          "expr": "sum (kafka_server_sessionexpirelistener_zookeeperexpirespersec{job=\"$job\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3287,7 +3287,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (irate(kafka_server_replicamanager_isrshrinks_total{job=\"$job\",instance=~\"$broker\"}[1m]))",
+          "expr": "sum (kafka_server_replicamanager_isrshrinkspersec{job=\"$job\",instance=~\"$broker\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3295,7 +3295,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum (irate(kafka_server_replicamanager_isrexpands_total{job=\"$job\",instance=~\"$broker\"}[1m]))",
+          "expr": "sum (kafka_server_replicamanager_isrexpandspersec{job=\"$job\",instance=~\"$broker\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3399,7 +3399,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(kafka_network_requestmetrics_requests_total{request=~\"FetchFollower\",job=\"$job\",instance=~\"$broker\"}[1m]))by(instance)",
+          "expr": "sum(kafka_network_requestmetrics_requestspersec{request=~\"FetchFollower\",job=\"$job\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3505,7 +3505,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(kafka_network_requestmetrics_requests_total{request=\"FetchConsumer\",job=\"$job\",instance=~\"$broker\"}[5m]))by(instance)",
+          "expr": "sum(kafka_network_requestmetrics_requestspersec{request=\"FetchConsumer\",job=\"$job\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3719,7 +3719,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (irate(kafka_server_brokertopicmetrics_totalfetchrequests_total{job=\"$job\",instance=~\"$broker\",topic!=\"\"}[1m]))by(instance)",
+          "expr": "sum (kafka_server_brokertopicmetrics_totalfetchrequestspersec{job=\"$job\",instance=~\"$broker\",topic!=\"\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -4036,7 +4036,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (irate(kafka_controller_controllerstats_leaderelectionrateandtimems_count{job=\"$job\",instance=~\"$broker\"}[1m]))by(instance)",
+          "expr": "sum (kafka_controller_controllerstats_leaderelectionrateandtimems{job=\"$job\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/src/grafana_dashboards/kafka-metrics.json
+++ b/src/grafana_dashboards/kafka-metrics.json
@@ -2084,7 +2084,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (kafka_server_brokertopicmetrics_totalproducerequestspersec{job=\"$job\",instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"}))by(topic)",
+          "expr": "sum (kafka_server_brokertopicmetrics_totalproducerequestspersec{job=\"$job\",instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"})by(topic)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/src/literals.py
+++ b/src/literals.py
@@ -23,6 +23,8 @@ TRUSTED_CERTIFICATE_RELATION = "trusted-certificate"
 TRUSTED_CA_RELATION = "trusted-ca"
 INTERNAL_USERS = [INTER_BROKER_USER, ADMIN_USER]
 JMX_EXPORTER_PORT = 9101
+METRICS_RULES_DIR = "./src/alert_rules/prometheus"
+LOGS_RULES_DIR = "./src/alert_rules/loki"
 
 AuthMechanism = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]
 Scope = Literal["INTERNAL", "CLIENT"]

--- a/src/snap.py
+++ b/src/snap.py
@@ -27,6 +27,7 @@ class KafkaSnap:
     SNAP_NAME = "charmed-kafka"
     COMPONENT = "kafka"
     SNAP_SERVICE = "daemon"
+    LOG_SLOT = "logs"
 
     CONF_PATH = f"/var/snap/{SNAP_NAME}/current/etc/{COMPONENT}"
     LOGS_PATH = f"/var/snap/{SNAP_NAME}/common/var/log/{COMPONENT}"


### PR DESCRIPTION
Addresses [DPE-1432](https://warthogs.atlassian.net/browse/DPE-1432)

Fixes some of the expressions from the dashboard to use up-to-date metrics from the JMX exporter. Most of them switch from calculating the per second value by using `rate()[1m]` on total counters to just use `persec` metric directly.

[DPE-1432]: https://warthogs.atlassian.net/browse/DPE-1432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ