### PR TITLE
feat: enable hostname_verification for ZooKeeper, handle noPIDfound

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -10,6 +10,7 @@ from typing import MutableMapping, Optional
 
 from charms.data_platform_libs.v0.data_models import TypedCharmBase
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+from charms.operator_libs_linux.v1.snap import SnapError
 from charms.rolling_ops.v0.rollingops import RollingOpsManager, RunWithLock
 from ops.charm import (
     ActionEvent,
@@ -189,8 +190,12 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
             self._set_status(Status.ZK_NOT_CONNECTED)
             return
 
-        if not self.health.machine_configured():
-            self._set_status(Status.SYSCONF_NOT_OPTIMAL)
+        try:
+            if not self.health.machine_configured():
+                self._set_status(Status.SYSCONF_NOT_OPTIMAL)
+                return
+        except SnapError:
+            self._set_status(Status.SNAP_NOT_RUNNING)
             return
 
         self._set_status(Status.ACTIVE)

--- a/src/config.py
+++ b/src/config.py
@@ -289,7 +289,6 @@ class KafkaConfig:
             f"zookeeper.ssl.truststore.location={self.truststore_filepath}",
             f"zookeeper.ssl.truststore.password={self.charm.tls.truststore_password}",
             "zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty",
-            "zookeeper.ssl.endpoint.identification.algorithm=",
         ]
 
     @property

--- a/src/snap.py
+++ b/src/snap.py
@@ -139,14 +139,13 @@ class KafkaSnap:
             Integer of pid
 
         Raises:
-            KeyError if no pid string found in most recent log
-            SnapError if error occurs
+            SnapError if error occurs or if no pid string found in most recent log
         """
         last_log = self.kafka.logs(services=[self.SNAP_SERVICE], num_lines=1)
         pid_string = re.search(rf"{SNAP_NAME}.{self.SNAP_SERVICE}\[([0-9]+)\]", last_log)
 
         if not pid_string:
-            raise KeyError("pid not found in snap logs")
+            raise snap.SnapError("pid not found in snap logs")
 
         return int(pid_string[1])
 

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -6,6 +6,7 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
+from charms.operator_libs_linux.v1.snap import SnapError
 
 from snap import KafkaSnap
 
@@ -24,3 +25,15 @@ def test_run_bin_command_args():
         assert "charmed-kafka.configs" in patched.call_args.args[0].split()
         assert "-Djava" == patched.call_args.args[0].split()[0]
         assert "--list" == patched.call_args.args[0].split()[-1]
+
+
+def test_get_service_pid_raises():
+    """Checks get_service_pid raises if PID cannot be found."""
+    with (
+        patch(
+            "snap.snap.Snap.logs",
+            return_value="2023-04-13T13:11:43+01:00 juju.fetch-oci[840]: /usr/bin/timeout",
+        ),
+        pytest.raises(SnapError),
+    ):
+        KafkaSnap().get_service_pid()


### PR DESCRIPTION
## Changes Made
##### `feat: enable hosnameverification for ZK TLS certs`
- This wasn't enabled before due to bug in TLS lib
- Should work out the box now
##### `chore: handle when no snap service pid found, block charm`
- Issue would happen when charm didn't set up fast enough before `update-status` fired, raising unhandled `KeyError` 