### PR TITLE
fix: rework mtls checks

### DIFF
--- a/src/tls.py
+++ b/src/tls.py
@@ -149,11 +149,11 @@ class KafkaTLS(Object):
             event.defer()
             return
 
-        alias = self.generate_alias(app_name=event.app.name, relation_id=event.relation.id)
+        alias = self.generate_alias(app_name=event.app.name, relation_id=event.relation.id)  # type: ignore
         csr = (
             generate_csr(
                 add_unique_id_to_subject_name=bool(alias),
-                private_key=self.private_key.encode("utf-8"),
+                private_key=self.private_key.encode("utf-8"),  # type: ignore
                 subject=self.charm.unit_peer_data.get("private-address", ""),
                 **self._sans,
             )
@@ -171,7 +171,7 @@ class KafkaTLS(Object):
             event.defer()
             return
 
-        relation_data = _load_relation_data(dict(event.relation.data[event.relation.app]))
+        relation_data = _load_relation_data(dict(event.relation.data[event.relation.app]))  # type: ignore
         provider_certificates = relation_data.get("certificates", [])
 
         if not provider_certificates:
@@ -179,7 +179,7 @@ class KafkaTLS(Object):
             event.defer()
             return
 
-        alias = self.generate_alias(event.relation.app.name, event.relation.id)
+        alias = self.generate_alias(event.relation.app.name, event.relation.id)  # type: ignore
         # NOTE: Relation should only be used with one set of certificates,
         # hence using just the first item on the list.
         content = (
@@ -195,7 +195,7 @@ class KafkaTLS(Object):
         """Handle relation broken for a trusted certificate/ca relation."""
         # All units will need to remove the cert from their truststore
         alias = self.generate_alias(
-            app_name=event.relation.app.name, relation_id=event.relation.id
+            app_name=event.relation.app.name, relation_id=event.relation.id  # type: ignore
         )
         self.remove_cert(alias=alias)
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -144,16 +144,17 @@ class KafkaTLS(Object):
 
     def _trusted_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Generate a CSR so the tls-certificates operator works as expected."""
-        if not self.enabled:
+        # Once the certificates have been added, TLS setup has finished
+        if not self.certificate:
             logger.debug("Missing TLS relation, deferring")
             event.defer()
             return
 
-        alias = self.generate_alias(app_name=event.app.name, relation_id=event.relation.id)  # type: ignore
+        alias = self.generate_alias(app_name=event.app.name, relation_id=event.relation.id)  # type: ignore[reportOptionalMemberAccess]
         csr = (
             generate_csr(
                 add_unique_id_to_subject_name=bool(alias),
-                private_key=self.private_key.encode("utf-8"),  # type: ignore
+                private_key=self.private_key.encode("utf-8"),  # type: ignore[reportOptionalMemberAccess]
                 subject=self.charm.unit_peer_data.get("private-address", ""),
                 **self._sans,
             )
@@ -166,12 +167,13 @@ class KafkaTLS(Object):
 
     def _trusted_relation_changed(self, event: RelationChangedEvent) -> None:
         """Overrides the requirer logic of TLSInterface."""
-        if not self.enabled:
+        # Once the certificates have been added, TLS setup has finished
+        if not self.certificate:
             logger.debug("Missing TLS relation, deferring")
             event.defer()
             return
 
-        relation_data = _load_relation_data(dict(event.relation.data[event.relation.app]))  # type: ignore
+        relation_data = _load_relation_data(dict(event.relation.data[event.relation.app]))  # type: ignore[reportOptionalMemberAccess]
         provider_certificates = relation_data.get("certificates", [])
 
         if not provider_certificates:
@@ -179,7 +181,7 @@ class KafkaTLS(Object):
             event.defer()
             return
 
-        alias = self.generate_alias(event.relation.app.name, event.relation.id)  # type: ignore
+        alias = self.generate_alias(event.relation.app.name, event.relation.id)  # type: ignore[reportOptionalMemberAccess]
         # NOTE: Relation should only be used with one set of certificates,
         # hence using just the first item on the list.
         content = (
@@ -195,7 +197,7 @@ class KafkaTLS(Object):
         """Handle relation broken for a trusted certificate/ca relation."""
         # All units will need to remove the cert from their truststore
         alias = self.generate_alias(
-            app_name=event.relation.app.name, relation_id=event.relation.id  # type: ignore
+            app_name=event.relation.app.name, relation_id=event.relation.id  # type: ignore[reportOptionalMemberAccess]
         )
         self.remove_cert(alias=alias)
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -150,11 +150,16 @@ class KafkaTLS(Object):
             event.defer()
             return
 
-        alias = self.generate_alias(app_name=event.app.name, relation_id=event.relation.id)  # type: ignore[reportOptionalMemberAccess]
+        alias = self.generate_alias(
+            app_name=event.app.name,  # pyright: ignore[reportOptionalMemberAccess]
+            relation_id=event.relation.id,
+        )
         csr = (
             generate_csr(
                 add_unique_id_to_subject_name=bool(alias),
-                private_key=self.private_key.encode("utf-8"),  # type: ignore[reportOptionalMemberAccess]
+                private_key=self.private_key.encode(  # pyright: ignore[reportOptionalMemberAccess]
+                    "utf-8"
+                ),
                 subject=self.charm.unit_peer_data.get("private-address", ""),
                 **self._sans,
             )
@@ -181,7 +186,10 @@ class KafkaTLS(Object):
             event.defer()
             return
 
-        alias = self.generate_alias(event.relation.app.name, event.relation.id)  # type: ignore[reportOptionalMemberAccess]
+        alias = self.generate_alias(
+            event.relation.app.name,  # pyright: ignore[reportOptionalMemberAccess]
+            event.relation.id,
+        )
         # NOTE: Relation should only be used with one set of certificates,
         # hence using just the first item on the list.
         content = (
@@ -197,7 +205,8 @@ class KafkaTLS(Object):
         """Handle relation broken for a trusted certificate/ca relation."""
         # All units will need to remove the cert from their truststore
         alias = self.generate_alias(
-            app_name=event.relation.app.name, relation_id=event.relation.id  # type: ignore[reportOptionalMemberAccess]
+            app_name=event.relation.app.name,  # pyright: ignore[reportOptionalMemberAccess]
+            relation_id=event.relation.id,
         )
         self.remove_cert(alias=alias)
 

--- a/tests/integration/app-charm/actions.yaml
+++ b/tests/integration/app-charm/actions.yaml
@@ -13,3 +13,13 @@ run-mtls-producer:
     broker-ca:
       type: string
       description: The CA used for broker identity from certificates relation
+    num-messages:
+      type: integer
+      description: The number of messages to be sent for testing
+
+get-offsets:
+  description: Retrieve offset for test topic
+  params:
+    bootstrap-server:
+      type: string
+      description: The address for mtls Kafka

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -8,6 +8,7 @@ This charm is meant to be used only for testing
 of the libraries in this repository.
 """
 
+import base64
 import logging
 import shutil
 import subprocess
@@ -23,7 +24,6 @@ from ops.model import ActiveStatus
 from utils import safe_write_to_file
 
 logger = logging.getLogger(__name__)
-
 
 CHARM_KEY = "app"
 PEER = "cluster"
@@ -71,6 +71,7 @@ class ApplicationCharm(CharmBase):
         self.framework.observe(
             getattr(self.on, "run_mtls_producer_action"), self.run_mtls_producer
         )
+        self.framework.observe(getattr(self.on, "get_offsets_action"), self.get_offsets)
 
     def _on_start(self, _) -> None:
         self.unit.status = ActiveStatus()
@@ -164,6 +165,7 @@ class ApplicationCharm(CharmBase):
     def _create_truststore(self, broker_ca: str):
         logger.info("writing broker cert to unit")
         unit_name = self.unit.name.replace("/", "-")
+
         safe_write_to_file(
             content=broker_ca, path=f"/var/lib/juju/agents/unit-{unit_name}/charm/broker.cert"
         )
@@ -173,7 +175,7 @@ class ApplicationCharm(CharmBase):
             try:
                 logger.info(f"adding {file} to truststore")
                 subprocess.check_output(
-                    f"keytool -keystore client.truststore.jks -alias {file.replace('.','-')} -importcert -file {file} -storepass password -noprompt",
+                    f"keytool -keystore client.truststore.jks -alias {file.replace('.', '-')} -importcert -file {file} -storepass password -noprompt",
                     stderr=subprocess.PIPE,
                     shell=True,
                     universal_newlines=True,
@@ -185,13 +187,6 @@ class ApplicationCharm(CharmBase):
                     logger.warning(e.output)
                     continue
                 raise e
-
-    def _attempt_mtls_connection(self, bootstrap_servers: str):
-        logger.info("creating data to feed to producer")
-        unit_name = self.unit.name.replace("/", "-")
-        safe_write_to_file(
-            content="a\n b\n c\n d\n e", path=f"/var/lib/juju/agents/unit-{unit_name}/charm/data"
-        )
 
         logger.info("creating client.properties file")
         properties = [
@@ -207,10 +202,31 @@ class ApplicationCharm(CharmBase):
             path=f"/var/lib/juju/agents/unit-{unit_name}/charm/client.properties",
         )
 
+    def _attempt_mtls_connection(self, bootstrap_servers: str, num_messages: int):
+        logger.info("creating data to feed to producer")
+        unit_name = self.unit.name.replace("/", "-")
+        content = "\n".join(f"message: {ith}" for ith in range(num_messages))
+
+        safe_write_to_file(
+            content=content, path=f"/var/lib/juju/agents/unit-{unit_name}/charm/data"
+        )
+
+        logger.info("Creating topic")
+        try:
+            subprocess.check_output(
+                f"/snap/charmed-kafka/current/bin/kafka-topics.sh --bootstrap-server {bootstrap_servers} --topic=TEST-TOPIC --create --command-config client.properties",
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(e.output)
+            raise e
+
         logger.info("running producer application")
         try:
             subprocess.check_output(
-                f"/snap/charmed-kafka/current/bin/kafka-console-producer.sh --broker-list {bootstrap_servers} --topic=TEST-TOPIC --producer.config client.properties < data",
+                f"/snap/charmed-kafka/current/bin/kafka-console-producer.sh --bootstrap-server {bootstrap_servers} --topic=TEST-TOPIC --producer.config client.properties < data",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
@@ -244,16 +260,39 @@ class ApplicationCharm(CharmBase):
     def run_mtls_producer(self, event: ActionEvent):
         broker_ca = event.params["broker-ca"]
         bootstrap_server = event.params["bootstrap-server"]
+        num_messages = int(event.params["num-messages"])
+
+        decode_cert = base64.b64decode(broker_ca).decode("utf-8").strip()
 
         try:
-            self._create_truststore(broker_ca=broker_ca)
-            self._attempt_mtls_connection(bootstrap_servers=bootstrap_server)
+            self._create_truststore(broker_ca=decode_cert)
+            self._attempt_mtls_connection(
+                bootstrap_servers=bootstrap_server, num_messages=num_messages
+            )
         except Exception as e:
             logger.error(e)
             event.fail()
             return
 
         event.set_results({"success": "TRUE"})
+
+    def get_offsets(self, event: ActionEvent):
+        bootstrap_server = event.params["bootstrap-server"]
+
+        logger.info("fetching offsets")
+        try:
+            output = subprocess.check_output(
+                f"/snap/charmed-kafka/current/bin/kafka-get-offsets.sh --bootstrap-server {bootstrap_server} --topic=TEST-TOPIC --command-config client.properties",
+                stderr=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
+            event.set_results({"output": output})
+        except subprocess.CalledProcessError as e:
+            logger.error(e.output)
+            event.fail()
+
+        return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The issue is the logic of this check, that will return instead of continuing (needs more `not`):
```
if not self.private_key or self.keystore_password or self.truststore_password:
```

All these extra checks are forced because of pyright. But some of them are not really needed, as things that _seem_ to be `None` in `operator` are actually initialized later on.

Rationale for the changes:
- Checking that the private keys and password exists doesn't really provide any information, the same can be achieved by just checking that the `tls` flag exists (`self.enabled`) 
- I don't know of a situation where `event` doesn't have an `event.relation` attached to it. It is initialized on all relation events: https://github.com/canonical/operator/blob/main/ops/charm.py#L435-L446