### PR TITLE
[MISC] Fix integration tests

### DIFF
--- a/tests/integration/app-charm/actions.yaml
+++ b/tests/integration/app-charm/actions.yaml
@@ -13,3 +13,13 @@ run-mtls-producer:
     broker-ca:
       type: string
       description: The CA used for broker identity from certificates relation
+    num-messages:
+      type: integer
+      description: The number of messages to be sent for testing
+
+get-offsets:
+  description: Retrieve offset for test topic
+  params:
+    bootstrap-server:
+      type: string
+      description: The address for mtls Kafka

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -71,9 +71,7 @@ class ApplicationCharm(CharmBase):
         self.framework.observe(
             getattr(self.on, "run_mtls_producer_action"), self.run_mtls_producer
         )
-        self.framework.observe(
-            getattr(self.on, "get_offsets_action"), self.get_offsets
-        )
+        self.framework.observe(getattr(self.on, "get_offsets_action"), self.get_offsets)
 
     def _on_start(self, _) -> None:
         self.unit.status = ActiveStatus()

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -306,3 +306,4 @@ async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
     )
 
     return result
+

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -306,4 +306,3 @@ async def set_mtls_client_acls(ops_test: OpsTest, bootstrap_server: str) -> str:
     )
 
     return result
-

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -215,8 +215,8 @@ async def test_mtls(ops_test: OpsTest):
     topic_name, min_offset, max_offset = response.results["output"].strip().split(":")
 
     assert topic_name == "TEST-TOPIC"
-    assert min_offset == 0
-    assert max_offset == 10
+    assert min_offset == "0"
+    assert max_offset == "10"
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -48,8 +48,12 @@ async def test_deploy_tls(ops_test: OpsTest, kafka_charm):
         ops_test.model.deploy(TLS_NAME, channel="beta", config=tls_config, series="jammy"),
         ops_test.model.deploy(ZK, channel="edge", series="jammy", application_name=ZK),
         ops_test.model.deploy(
-            kafka_charm, application_name=CHARM_KEY, series="jammy",
-            config={"ssl_principal_mapping_rules": "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT"},
+            kafka_charm,
+            application_name=CHARM_KEY,
+            series="jammy",
+            config={
+                "ssl_principal_mapping_rules": "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT"
+            },
         ),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK].units) == 1)
@@ -187,11 +191,12 @@ async def test_mtls(ops_test: OpsTest):
 
     # running mtls producer
     action = await ops_test.model.units.get(f"{DUMMY_NAME}/0").run_action(
-        "run-mtls-producer", **{
+        "run-mtls-producer",
+        **{
             "bootstrap-server": ssl_bootstrap_server,
             "broker-ca": base64.b64encode(broker_ca.encode("utf-8")).decode("utf-8"),
             "num-messages": num_messages,
-        }
+        },
     )
 
     response = await action.wait()
@@ -199,9 +204,10 @@ async def test_mtls(ops_test: OpsTest):
     assert response.results.get("success", None) == "TRUE"
 
     offsets_action = await ops_test.model.units.get(f"{DUMMY_NAME}/0").run_action(
-        "get-offsets", **{
+        "get-offsets",
+        **{
             "bootstrap-server": ssl_bootstrap_server,
-        }
+        },
     )
 
     response = await offsets_action.wait()

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -216,7 +216,7 @@ async def test_mtls(ops_test: OpsTest):
 
     assert topic_name == "TEST-TOPIC"
     assert min_offset == "0"
-    assert max_offset == "10"
+    assert max_offset == str(num_messages)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -47,7 +47,10 @@ async def test_deploy_tls(ops_test: OpsTest, kafka_charm):
     await asyncio.gather(
         ops_test.model.deploy(TLS_NAME, channel="beta", config=tls_config, series="jammy"),
         ops_test.model.deploy(ZK, channel="edge", series="jammy", application_name=ZK),
-        ops_test.model.deploy(kafka_charm, application_name=CHARM_KEY, series="jammy"),
+        ops_test.model.deploy(
+            kafka_charm, application_name=CHARM_KEY, series="jammy",
+            config={"ssl_principal_mapping_rules": "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT"},
+        ),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK].units) == 1)
     await ops_test.model.wait_for_idle(
@@ -180,14 +183,34 @@ async def test_mtls(ops_test: OpsTest):
     # setting ACLs using normal sasl port
     await set_mtls_client_acls(ops_test, bootstrap_server=sasl_bootstrap_server)
 
+    num_messages = 10
+
     # running mtls producer
     action = await ops_test.model.units.get(f"{DUMMY_NAME}/0").run_action(
-        "run-mtls-producer", **{"bootstrap-server": ssl_bootstrap_server, "broker-ca": broker_ca}
+        "run-mtls-producer", **{
+            "bootstrap-server": ssl_bootstrap_server,
+            "broker-ca": base64.b64encode(broker_ca.encode("utf-8")).decode("utf-8"),
+            "num-messages": num_messages,
+        }
     )
 
     response = await action.wait()
 
     assert response.results.get("success", None) == "TRUE"
+
+    offsets_action = await ops_test.model.units.get(f"{DUMMY_NAME}/0").run_action(
+        "get-offsets", **{
+            "bootstrap-server": ssl_bootstrap_server,
+        }
+    )
+
+    response = await offsets_action.wait()
+
+    topic_name, min_offset, max_offset = response.results["output"].strip().split(":")
+
+    assert topic_name == "TEST-TOPIC"
+    assert min_offset == 0
+    assert max_offset == 10
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
I believe the integration tests on mTLS SHOULD not have passed as there were multiple problems I encountered when running step-by-step:

* ssl_principal_mapping_rules was not set, therefore the producer should not have had permission to write
* in order to rightfully produce message to the topic, the topic should have been created before
* broker-ca parameter is best to be first base64 encoded before being passed to the action, and then decoded in the action (similarly to what is done in the tls-certificate-operator)

I have also added an action to retrieve the offsets on the test topic, to be used in order to make sure that messages were indeed produced and pushed to Kafka. The condition for passing now should be way more stringent. 

I believe it would also be good to test that clients can connect when we use the `trusted-ca` interface, instead of `trusted-certificate`. Or is this tested elsewhere?