### PR TITLE
[DPE-1905] Add rack awareness integration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -192,11 +192,11 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         # Load current properties set in the charm workload and check
         # if rack.properties file exists
         properties = safe_get_file(self.kafka_config.server_properties_filepath)
-        if properties:
-            if self.kafka_config.rack_properties != [] and (
-                set(self.kafka_config.server_properties) ^ set(properties)
-            ):
-                self._on_config_changed(event)
+        if properties and (
+            self.kafka_config.rack_properties != []
+            and (set(self.kafka_config.server_properties) ^ set(properties))
+        ):
+            self._on_config_changed(event)
 
         if not broker_active(
             unit=self.unit,

--- a/src/config.py
+++ b/src/config.py
@@ -21,7 +21,7 @@ from literals import (
     AuthMechanism,
     Scope,
 )
-from utils import map_env, safe_write_to_file, update_env
+from utils import map_env, safe_get_file, safe_write_to_file, update_env
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
@@ -413,6 +413,17 @@ class KafkaConfig:
         )
 
     @property
+    def rack_properties(self) -> List[str]:
+        """Builds all properties related to rack awareness configuration.
+
+        Returns:
+            List of properties to be set
+        """
+        # TODO: not sure if we should make this an instance attribute like the other paths
+        rack_path = f"{self.charm.snap.CONF_PATH}/rack.properties"
+        return safe_get_file(rack_path) or []
+
+    @property
     def client_properties(self) -> List[str]:
         """Builds all properties necessary for running an admin Kafka client.
 
@@ -465,6 +476,7 @@ class KafkaConfig:
             + self.scram_properties
             + self.default_replication_properties
             + self.auth_properties
+            + self.rack_properties
             + DEFAULT_CONFIG_OPTIONS.split("\n")
         )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -358,6 +358,33 @@ def test_auth_properties(harness):
     )
 
 
+def test_rack_properties(harness: Harness):
+    """Checks that rack properties are added to server properties."""
+    harness.add_relation(PEER, CHARM_KEY)
+    zk_relation_id = harness.add_relation(ZK, CHARM_KEY)
+    harness.update_relation_data(
+        zk_relation_id,
+        harness.charm.app.name,
+        {
+            "chroot": "/kafka",
+            "username": "moria",
+            "password": "mellon",
+            "endpoints": "1.1.1.1,2.2.2.2",
+            "uris": "1.1.1.1:2181/kafka,2.2.2.2:2181/kafka",
+            "tls": "disabled",
+        },
+    )
+
+    with (
+        patch(
+            "config.KafkaConfig.rack_properties",
+            new_callable=PropertyMock,
+            return_value=["broker.rack=gondor-west"],
+        )
+    ):
+        assert "broker.rack=gondor-west" in harness.charm.kafka_config.server_properties
+
+
 def test_super_users(harness):
     """Checks super-users property is updated for new admin clients."""
     peer_relation_id = harness.add_relation(PEER, CHARM_KEY)


### PR DESCRIPTION
The charm will figure out if `rack.properties` file exists. If it does, its contents will be added to `server.properties`.

Since there are no relations being triggered, `update_status` has been used to also check if the file was created after everything went `active | idle`. An alternative approach could be to add an action to manually trigger the check.

There are no integration tests yet, since the rack awareness charm hasn't been released.

