### PR TITLE
fix: ensure config changed called on trusted-changed

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,7 +67,7 @@ options:
     type: string
     default: ""
   ssl_principal_mapping_rules:
-    description: A list of rules for mapping from distinguished name from the client certificate to short name. Each rule starts with "RULE:" and contains an expression as the following. "RULE:pattern/replacement/[LU]". A valid set of rules could look something like this "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT"
+    description: A list of rules for mapping from distinguished name from the client certificate to short name. Each rule starts with "RULE:" and contains an expression as the following. "RULE:pattern/replacement/[LU]". A valid set of rules could look something like this 'RULE:^.*[Cc][Nn]=([a-zA-Z0-9.-_@]*).*$/$1/L,DEFAULT'
     type: string
     default: "DEFAULT"
   replication_quota_window_num:

--- a/config.yaml
+++ b/config.yaml
@@ -67,7 +67,7 @@ options:
     type: string
     default: ""
   ssl_principal_mapping_rules:
-    description: A list of rules for mapping from distinguished name from the client certificate to short name. Each rule starts with "RULE:" and contains an expression as the following. "RULE:pattern/replacement/[LU]". A valid set of rules could look something like this 'RULE:^.*[Cc][Nn]=([a-zA-Z0-9.-_@]*).*$/$1/L,DEFAULT'
+    description: "A list of rules for mapping from distinguished name from the client certificate to short name. Each rule starts with 'RULE:' and contains an expression as the following. 'RULE:pattern/replacement/[LU]'. A valid set of rules could look something like this 'RULE:^.*[Cc][Nn]=([a-zA-Z0-9.-_@]*).*$/$1/L,DEFAULT'"
     type: string
     default: "DEFAULT"
   replication_quota_window_num:

--- a/src/config.py
+++ b/src/config.py
@@ -212,6 +212,7 @@ class KafkaConfig:
         opts = [
             "-Dcom.sun.management.jmxremote",
             f"-javaagent:{self.jmx_prometheus_javaagent_filepath}={JMX_EXPORTER_PORT}:{self.jmx_prometheus_config_filepath}",
+            "-Djavax.net.debug=ssl:handshake:verbose:session:keymanager:trustmanager",
         ]
 
         return f"KAFKA_JMX_OPTS={' '.join(opts)}"

--- a/src/tls.py
+++ b/src/tls.py
@@ -202,7 +202,7 @@ class KafkaTLS(Object):
         self.import_cert(alias=f"{alias}", filename=filename)
 
         # ensuring new config gets applied
-        self.charm._on_config_changed(event)
+        self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
 
     def _trusted_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handle relation broken for a trusted certificate/ca relation."""

--- a/src/tls.py
+++ b/src/tls.py
@@ -201,8 +201,17 @@ class KafkaTLS(Object):
         safe_write_to_file(content=content, path=f"{self.charm.snap.CONF_PATH}/{filename}")
         self.import_cert(alias=f"{alias}", filename=filename)
 
+        # ensuring new config gets applied
+        self.charm._on_config_changed(event)
+
     def _trusted_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handle relation broken for a trusted certificate/ca relation."""
+        # Once the certificates have been added, TLS setup has finished
+        if not self.certificate:
+            logger.debug("Missing TLS relation, deferring")
+            event.defer()
+            return
+
         # All units will need to remove the cert from their truststore
         alias = self.generate_alias(
             app_name=event.relation.app.name,  # pyright: ignore[reportOptionalMemberAccess]
@@ -463,7 +472,7 @@ class KafkaTLS(Object):
         except subprocess.CalledProcessError as e:
             # in case this reruns and fails
             if "already exists" in e.output:
-                logger.warning(e.output)
+                logger.debug(e.output)
                 return
             logger.error(e.output)
             raise e

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -241,9 +241,9 @@ def test_jmx_opts(harness):
     """Checks necessary args for KAFKA_JMX_OPTS."""
     args = harness.charm.kafka_config.jmx_opts
     assert "-javaagent:" in args
-    assert len(args.split(":")) == 3
     assert args.split(":")[1].split("=")[-1] == str(JMX_EXPORTER_PORT)
     assert "KAFKA_JMX_OPTS" in args
+    assert "-Djavax.net.debug=ssl" in args
 
 
 def test_set_environment(harness):


### PR DESCRIPTION
## Changes Made
##### `feat: ensure config-changed updates properties during trusted-relation-changed events`
- https://warthogs.atlassian.net/browse/DPE-1985
##### `docs: add additional characters and correct quoting to ssl_principal_mapping_rules example`
- https://warthogs.atlassian.net/browse/DPE-1987
##### `feat: enable ssl jmx debug server logs by default`
- https://warthogs.atlassian.net/browse/DPE-1986
