### PR TITLE
feat: add `profile` configured JVM heap args

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -79,6 +79,6 @@ options:
     type: string
     default: ""
   profile:
-     description: 'profile representing the scope of deployment, and used to be able to enable high-level customisation of sysconfigs, resource checks/allocation, warning levels, etc. Allowed values are: “production”, “staging” and “testing”'
+     description: 'Profile representing the scope of deployment, and used to enable high-level customisation of sysconfigs, resource checks/allocation, warning levels, etc. Allowed values are: “production”, “staging” and “testing”'
      type: string
      default: production

--- a/config.yaml
+++ b/config.yaml
@@ -78,3 +78,7 @@ options:
     description: Specifies the enabled cipher suites to be used in ZooKeeper TLS negotiation (csv). Overrides any explicit value set via the zookeeper.ssl.ciphersuites system property (note the single word "ciphersuites"). The default value of null means the list of enabled cipher suites is determined by the Java runtime being used.
     type: string
     default: ""
+  profile:
+     description: 'profile representing the scope of deployment, and used to be able to enable high-level customisation of sysconfigs, resource checks/allocation, warning levels, etc. Allowed values are: “production”, “staging” and “testing”'
+     type: string
+     default: production

--- a/src/config.py
+++ b/src/config.py
@@ -202,7 +202,7 @@ class KafkaConfig:
         """
         opts = [f"-Dlog4j.configuration=file:{self.log4j_properties_filepath}"]
 
-        return f"KAFKA_LOG4J_OPTS={' '.join(opts)}"
+        return f"KAFKA_LOG4J_OPTS='{' '.join(opts)}'"
 
     @property
     def jmx_opts(self) -> str:
@@ -216,7 +216,7 @@ class KafkaConfig:
             f"-javaagent:{self.jmx_prometheus_javaagent_filepath}={JMX_EXPORTER_PORT}:{self.jmx_prometheus_config_filepath}",
         ]
 
-        return f"KAFKA_JMX_OPTS={' '.join(opts)}"
+        return f"KAFKA_JMX_OPTS='{' '.join(opts)}'"
 
     @property
     def jvm_performance_opts(self) -> str:
@@ -235,7 +235,7 @@ class KafkaConfig:
             "-XX:MaxMetaspaceFreeRatio=80",
         ]
 
-        return f"KAFKA_JVM_PERFORMANCE_OPTS={' '.join(opts)}"
+        return f"KAFKA_JVM_PERFORMANCE_OPTS='{' '.join(opts)}'"
 
     @property
     def heap_opts(self) -> str:
@@ -252,7 +252,7 @@ class KafkaConfig:
             f"-Xmx{target_memory}G",
         ]
 
-        return f"KAFKA_HEAP_OPTS={' '.join(opts)}"
+        return f"KAFKA_HEAP_OPTS='{' '.join(opts)}'"
 
     @property
     def kafka_opts(self) -> str:
@@ -266,7 +266,7 @@ class KafkaConfig:
             "-Djavax.net.debug=ssl:handshake:verbose:session:keymanager:trustmanager",
         ]
 
-        return f"KAFKA_OPTS={' '.join(opts)}"
+        return f"KAFKA_OPTS='{' '.join(opts)}'"
 
     @property
     def bootstrap_server(self) -> List[str]:

--- a/src/config.py
+++ b/src/config.py
@@ -214,14 +214,17 @@ class KafkaConfig:
         opts = [
             "-Dcom.sun.management.jmxremote",
             f"-javaagent:{self.jmx_prometheus_javaagent_filepath}={JMX_EXPORTER_PORT}:{self.jmx_prometheus_config_filepath}",
-            "-Djavax.net.debug=ssl:handshake:verbose:session:keymanager:trustmanager",
         ]
 
         return f"KAFKA_JMX_OPTS={' '.join(opts)}"
 
     @property
     def jvm_performance_opts(self) -> str:
-        """The JVM config options for tuning performance settings."""
+        """The JVM config options for tuning performance settings.
+
+        Returns:
+            String of JVM performance options
+        """
         opts = [
             "-XX:MetaspaceSize=96m",
             "-XX:+UseG1GC",
@@ -236,7 +239,11 @@ class KafkaConfig:
 
     @property
     def heap_opts(self) -> str:
-        """The JVM config options for setting heap limits."""
+        """The JVM config options for setting heap limits.
+
+        Returns:
+            String of JVM heap memory options
+        """
         target_memory = (
             JVM_MEM_MIN_GB if self.charm.config["profile"] == "testing" else JVM_MEM_MAX_GB
         )
@@ -254,7 +261,10 @@ class KafkaConfig:
         Returns:
             String of Java config options
         """
-        opts = [f"-Djava.security.auth.login.config={self.zk_jaas_filepath}"]
+        opts = [
+            f"-Djava.security.auth.login.config={self.zk_jaas_filepath}",
+            "-Djavax.net.debug=ssl:handshake:verbose:session:keymanager:trustmanager",
+        ]
 
         return f"KAFKA_OPTS={' '.join(opts)}"
 

--- a/src/config.py
+++ b/src/config.py
@@ -245,7 +245,7 @@ class KafkaConfig:
             String of JVM heap memory options
         """
         target_memory = (
-            JVM_MEM_MIN_GB if self.charm.config["profile"] == "testing" else JVM_MEM_MAX_GB
+            JVM_MEM_MIN_GB if self.charm.config.profile == "testing" else JVM_MEM_MAX_GB
         )
         opts = [
             f"-Xms{target_memory}G",

--- a/src/health.py
+++ b/src/health.py
@@ -172,7 +172,9 @@ class KafkaHealth(Object):
             JVM_MEM_MIN_GB if self.charm.config["profile"] == "testing" else JVM_MEM_MAX_GB
         )
 
-        if target_memory_gb >= total_memory_gb:  # reserving 2GB for non-JVM
+        # TODO: with memory barely above JVM heap, there will be no room for OS page cache, degrading perf
+        # need to figure out a better way of ensuring sufficiently beefy machines
+        if target_memory_gb >= total_memory_gb:
             logger.error(
                 f"Insufficient total memory '{round(total_memory_gb, 2)}' for desired performance profile '{self.charm.config['profile']}' - redeploy with greater than {target_memory_gb}GB available memory"
             )

--- a/src/health.py
+++ b/src/health.py
@@ -136,7 +136,7 @@ class KafkaHealth(Object):
             return True
 
         total_partitions, average_partition_size = self._get_partitions_size()
-        segment_size = int(self.charm.config["log_segment_bytes"])
+        segment_size = self.charm.config.log_segment_bytes
 
         minimum_fd_limit = total_partitions * (average_partition_size / segment_size)
         current_max_files = self._get_current_max_files()
@@ -169,14 +169,14 @@ class KafkaHealth(Object):
 
         total_memory_gb = int(meminfo[0].split()[1]) / 1000000
         target_memory_gb = (
-            JVM_MEM_MIN_GB if self.charm.config["profile"] == "testing" else JVM_MEM_MAX_GB
+            JVM_MEM_MIN_GB if self.charm.config.profile == "testing" else JVM_MEM_MAX_GB
         )
 
         # TODO: with memory barely above JVM heap, there will be no room for OS page cache, degrading perf
         # need to figure out a better way of ensuring sufficiently beefy machines
         if target_memory_gb >= total_memory_gb:
             logger.error(
-                f"Insufficient total memory '{round(total_memory_gb, 2)}' for desired performance profile '{self.charm.config['profile']}' - redeploy with greater than {target_memory_gb}GB available memory"
+                f"Insufficient total memory '{round(total_memory_gb, 2)}' for desired performance profile '{self.charm.config.profile}' - redeploy with greater than {target_memory_gb}GB available memory"
             )
             return False
 

--- a/src/health.py
+++ b/src/health.py
@@ -11,9 +11,9 @@ from statistics import mean
 from typing import TYPE_CHECKING, Tuple
 
 from ops.framework import Object
-from src.utils import safe_get_file
 
 from literals import JVM_MEM_MAX_GB, JVM_MEM_MIN_GB
+from utils import safe_get_file
 
 if TYPE_CHECKING:
     from charm import KafkaCharm

--- a/src/literals.py
+++ b/src/literals.py
@@ -32,6 +32,9 @@ AuthMechanism = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]
 Scope = Literal["INTERNAL", "CLIENT"]
 DebugLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
 
+JVM_MEM_MIN_GB = 1
+JVM_MEM_MAX_GB = 6
+
 
 @dataclass
 class Ports:

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -61,6 +61,7 @@ class CharmConfig(BaseConfigModel):
     ssl_principal_mapping_rules: str
     replication_quota_window_num: int
     zookeeper_ssl_cipher_suites: Optional[str]
+    profile: str
 
     @validator("*", pre=True)
     @classmethod
@@ -203,3 +204,12 @@ class CharmConfig(BaseConfigModel):
         if int_value >= -9223372036854775807 and int_value <= 9223372036854775808:
             return int_value
         raise ValueError("Value is not a long")
+
+    @validator("profile")
+    @classmethod
+    def profile_values(cls, value: str) -> Optional[str]:
+        """Check profile config option is one of `testing`, `staging` or `production`."""
+        if value not in ["testing", "staging", "production"]:
+            raise ValueError("Value not one of 'testing', 'staging' or 'production'")
+
+        return value

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -234,7 +234,7 @@ def test_kafka_opts(harness):
 
 @pytest.mark.parametrize(
     "profile,expected",
-    [("testing", JVM_MEM_MIN_GB), ("other", JVM_MEM_MIN_GB), ("production", JVM_MEM_MAX_GB)],
+    [("testing", JVM_MEM_MIN_GB), ("production", JVM_MEM_MAX_GB)],
 )
 def test_heap_opts(harness, profile, expected):
     """Checks necessary args for KAFKA_HEAP_OPTS."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,6 +16,8 @@ from literals import (
     INTER_BROKER_USER,
     INTERNAL_USERS,
     JMX_EXPORTER_PORT,
+    JVM_MEM_MAX_GB,
+    JVM_MEM_MIN_GB,
     PEER,
     ZK,
 )
@@ -230,6 +232,19 @@ def test_kafka_opts(harness):
     assert "KAFKA_OPTS" in args
 
 
+@pytest.mark.parametrize(
+    "profile,expected",
+    [("testing", JVM_MEM_MIN_GB), ("other", JVM_MEM_MIN_GB), ("production", JVM_MEM_MAX_GB)],
+)
+def test_heap_opts(harness, profile, expected):
+    """Checks necessary args for KAFKA_HEAP_OPTS."""
+    harness._update_config({"profile": profile})
+    args = harness.charm.kafka_config.heap_opts
+    assert f"Xms{expected}G" in args
+    assert f"Xmx{expected}G" in args
+    assert "KAFKA_HEAP_OPTS" in args
+
+
 def test_log4j_opts(harness):
     """Checks necessary args for KAFKA_LOG4J_OPTS."""
     args = harness.charm.kafka_config.log4j_opts
@@ -260,6 +275,8 @@ def test_set_environment(harness):
             assert "KAFKA_OPTS" in call.kwargs.get("content", "")
             assert "KAFKA_LOG4J_OPTS" in call.kwargs.get("content", "")
             assert "KAFKA_JMX_OPTS" in call.kwargs.get("content", "")
+            assert "KAFKA_HEAP_OPTS" in call.kwargs.get("content", "")
+            assert "KAFKA_JVM_PERFORMANCE_OPTS" in call.kwargs.get("content", "")
             assert "/etc/environment" == call.kwargs.get("path", "")
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -230,6 +230,7 @@ def test_kafka_opts(harness):
     args = harness.charm.kafka_config.kafka_opts
     assert "-Djava.security.auth.login.config" in args
     assert "KAFKA_OPTS" in args
+    assert "-Djavax.net.debug=ssl" in args
 
 
 @pytest.mark.parametrize(
@@ -258,7 +259,6 @@ def test_jmx_opts(harness):
     assert "-javaagent:" in args
     assert args.split(":")[1].split("=")[-1] == str(JMX_EXPORTER_PORT)
     assert "KAFKA_JMX_OPTS" in args
-    assert "-Djavax.net.debug=ssl" in args
 
 
 def test_set_environment(harness):


### PR DESCRIPTION
## Changes Made
##### `feat: increase JVM heap for main Kafka service on large machines`
- Set to 6GB using default `profile=production` config option. Otherwise 1GB.
- Health check looks for available memory, informing user if insufficient for desired profile