### PR TITLE
fix: ensure ca cert is removed on expiry

### DIFF
--- a/src/tls.py
+++ b/src/tls.py
@@ -437,9 +437,12 @@ class KafkaTLS(Object):
             set_snap_ownership(path=f"{self.charm.snap.CONF_PATH}/truststore.jks")
             set_snap_mode_bits(path=f"{self.charm.snap.CONF_PATH}/truststore.jks")
         except subprocess.CalledProcessError as e:
-            # in case this reruns and fails
+            # when this reruns and fails, attempt refresh of ca
             if "already exists" in e.output:
+                self.remove_cert(alias="ca")
+                self.set_truststore()
                 return
+
             logger.error(e.output)
             raise e
 


### PR DESCRIPTION
## Changes Made
##### `fix: make sure during ca refresh new cert gets added to truststore`
- We weren't calling `remove_cert` on the truststore during expiry events
- This would mean that on new `certificate-available` events, we would get a clash on the `ca` alias, raise `CalledProcessError`, handle, and then return without updating the cert
- Now we call `remove_cert` to remove the `ca` alias, then recursively re-call `set_truststore()` to add the new one