### PR TITLE
[DPE-1921] Handle delete_user exception

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -6,9 +6,11 @@
 
 import logging
 import re
+import subprocess
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Optional, Set
 
+from literals import REL_NAME
 from snap import KafkaSnap
 
 if TYPE_CHECKING:
@@ -37,8 +39,13 @@ class KafkaAuth:
         self.client_properties = self.charm.kafka_config.client_properties_filepath
         self.server_properties = self.charm.kafka_config.server_properties_filepath
 
-        self.current_acls: Set[Acl] = set()
         self.new_user_acls: Set[Acl] = set()
+
+    @property
+    def current_acls(self) -> Set[Acl]:
+        """Sets the current cluster ACLs."""
+        acls = self._get_acls_from_cluster()
+        return self._parse_acls(acls=acls)
 
     def _get_acls_from_cluster(self) -> str:
         """Loads the currently active ACLs from the Kafka cluster."""
@@ -86,18 +93,6 @@ class KafkaAuth:
                 )
 
         return current_acls
-
-    def load_current_acls(self) -> None:
-        """Sets the current cluster ACLs to the instance state.
-
-        State is set to `KafkaAuth.current_acls`.
-
-        Raises:
-            `subprocess.CalledProcessError`: if the error returned a non-zero exit code
-        """
-        acls = self._get_acls_from_cluster()
-
-        self.current_acls = self._parse_acls(acls=acls)
 
     @staticmethod
     def _generate_producer_acls(topic: str, username: str, **_) -> Set[Acl]:
@@ -196,7 +191,13 @@ class KafkaAuth:
             f"--entity-name={username}",
             "--delete-config=SCRAM-SHA-512",
         ]
-        KafkaSnap.run_bin_command(bin_keyword="configs", bin_args=command)
+        try:
+            KafkaSnap.run_bin_command(bin_keyword="configs", bin_args=command)
+        except subprocess.CalledProcessError as e:
+            if "delete a user credential that does not exist" in e.stderr:
+                logger.info(f"User: {username} can't be deleted, it does not exist")
+                return
+            raise
 
     def add_acl(
         self, username: str, operation: str, resource_type: str, resource_name: str
@@ -322,3 +323,20 @@ class KafkaAuth:
         acls_to_remove = current_user_acls - self.new_user_acls
         for acl in acls_to_remove:
             self.remove_acl(**asdict(acl))
+
+    def clear_users(self) -> None:
+        """Check existing relations and remove deleted users."""
+        current_usernames = [acl.username for acl in self.current_acls]
+        relation_usernames = [
+            f"relation-{relation.id}" for relation in self.charm.model.relations[REL_NAME]
+        ]
+        to_remove = [
+            username for username in current_usernames if username not in relation_usernames
+        ]
+
+        for username in to_remove:
+            self.remove_all_user_acls(username=username)
+            self.delete_user(username=username)
+            # non-leader units need cluster_config_changed event to update their super.users
+            # update on the peer relation data will trigger an update of server properties on all unit
+            self.charm.app_peer_data.update({username: ""})

--- a/src/auth.py
+++ b/src/auth.py
@@ -195,7 +195,7 @@ class KafkaAuth:
             KafkaSnap.run_bin_command(bin_keyword="configs", bin_args=command)
         except subprocess.CalledProcessError as e:
             if "delete a user credential that does not exist" in e.stderr:
-                logger.info(f"User: {username} can't be deleted, it does not exist")
+                logger.warning(f"User: {username} can't be deleted, it does not exist")
                 return
             raise
 

--- a/src/provider.py
+++ b/src/provider.py
@@ -80,8 +80,6 @@ class KafkaProvider(Object):
         # non-leader units need cluster_config_changed event to update their super.users
         self.charm.app_peer_data.update({username: password})
 
-        # self.kafka_auth.load_current_acls()
-
         self.kafka_auth.update_user_acls(
             username=username,
             topic=topic,


### PR DESCRIPTION
Addresses #104

- Change `current_acls` in `auth.py` to a property
- Added a method to iterate over relations to remove users. Not used, where to invoke? `update_status`?
- Change access to peer databag on `provider.py`