### PR TITLE
[DPE-2195] Add `certificate_extra_sans` config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -83,6 +83,6 @@ options:
      type: string
      default: production
   certificate_extra_sans:
-     description: Config options to add extra-sans to the ones used when requesting server certificates. The extra-sans are specified by comma-separated rule list to be added when requesting signed certificates.
+     description: Config options to add extra-sans to the ones used when requesting server certificates. The extra-sans are specified by comma-separated names to be added when requesting signed certificates. Use "{unit}" as a placeholder to be filled with the unit number, e.g. "worker-{unit}" will be translated as "worker-0" for unit 0 and "worker-1" for unit 1 when requesting the certificate.
      type: string
      default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -82,3 +82,7 @@ options:
      description: 'Profile representing the scope of deployment, and used to enable high-level customisation of sysconfigs, resource checks/allocation, warning levels, etc. Allowed values are: “production”, “staging” and “testing”'
      type: string
      default: production
+  certificate_extra_sans:
+     description: Config options to add extra-sans to the ones used when requesting server certificates. The extra-sans are specified by comma-separated rule list to be added when requesting signed certificates.
+     type: string
+     default: ""

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -62,6 +62,7 @@ class CharmConfig(BaseConfigModel):
     replication_quota_window_num: int
     zookeeper_ssl_cipher_suites: Optional[str]
     profile: str
+    certificate_extra_sans: Optional[str]
 
     @validator("*", pre=True)
     @classmethod

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -88,12 +88,14 @@ def test_extra_sans_config(harness: Harness):
     peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_relation_id, "kafka/0")
     harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
-    harness.update_config({"certificate_extra_sans": "worker{unit}.com"})
 
+    harness.update_config({"certificate_extra_sans": ""})
+    assert harness.charm.tls._extra_sans == []
+
+    harness.update_config({"certificate_extra_sans": "worker{unit}.com"})
     assert harness.charm.tls._extra_sans == ["worker0.com"]
 
     harness.update_config({"certificate_extra_sans": "worker{unit}.com,{unit}.example"})
-
     assert harness.charm.tls._extra_sans == ["worker0.com", "0.example"]
 
 

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -2,6 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import socket
 from pathlib import Path
 
 import pytest
@@ -80,3 +81,31 @@ def test_mtls_flag_added(harness: Harness):
     peer_relation_data = harness.get_relation_data(peer_relation_id, "kafka")
     assert peer_relation_data.get("mtls", "disabled") == "enabled"
     assert isinstance(harness.charm.app.status, ActiveStatus)
+
+
+def test_extra_sans_config(harness: Harness):
+    # Create peer relation
+    peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_relation_id, "kafka/0")
+    harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
+    harness.update_config({"certificate_extra_sans": "worker{unit}.com"})
+
+    assert harness.charm.tls._extra_sans == ["worker0.com"]
+
+    harness.update_config({"certificate_extra_sans": "worker{unit}.com,{unit}.example"})
+
+    assert harness.charm.tls._extra_sans == ["worker0.com", "0.example"]
+
+
+def test_sans(harness: Harness):
+    # Create peer relation
+    peer_relation_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_relation_id, "kafka/0")
+    harness.update_relation_data(peer_relation_id, "kafka/0", {"private-address": "treebeard"})
+    harness.update_config({"certificate_extra_sans": "worker{unit}.com"})
+
+    sock_dns = socket.getfqdn()
+    assert harness.charm.tls._sans == {
+        "sans_ip": ["treebeard"],
+        "sans_dns": ["kafka/0", sock_dns, "worker0.com"],
+    }


### PR DESCRIPTION
Adds config option to specify extra sans.

- A new property on `tls.py` has been added that parses the contents of `certificate_extra_sans`.
- Config option uses `{unit}` placeholder and replaces it with the unit number.

#### MISC
- Removed `peer_relation` property from `KafkaTLS`, to use `charm.peer_relation` instead.