### PR TITLE
DPE-1965 - chore: use keytool snap app

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,11 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
+      - name: Set permissions
+        id: set-permissions
+        run: |
+          sudo usermod -aG root $USER
+          sudo -s -u ${USER} bash -c 'whoami && groups'
       - name: Run integration tests
         run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,8 @@ jobs:
         run: |
           sudo usermod -aG root $USER
           sudo -s -u ${USER} bash -c 'whoami && groups'
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Run integration tests
         run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,12 +56,12 @@ jobs:
       fail-fast: false
       matrix:
         tox-environments:
-          # - integration-charm
-          # - integration-provider
-          # - integration-scaling
-          # - integration-password-rotation
+          - integration-charm
+          - integration-provider
+          - integration-scaling
+          - integration-password-rotation
           - integration-tls
-          # - integration-upgrade
+          - integration-upgrade
     name: ${{ matrix.tox-environments }}
     needs:
       - lint
@@ -99,8 +99,6 @@ jobs:
         run: |
           sudo usermod -aG root $USER
           sudo -s -u ${USER} bash -c 'whoami && groups'
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
       - name: Run integration tests
         run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,11 +94,6 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
-      - name: Set permissions
-        id: set-permissions
-        run: |
-          sudo usermod -aG root $USER
-          sudo -s -u ${USER} bash -c 'whoami && groups'
       - name: Run integration tests
         run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,12 +56,12 @@ jobs:
       fail-fast: false
       matrix:
         tox-environments:
-          - integration-charm
-          - integration-provider
-          - integration-scaling
-          - integration-password-rotation
+          # - integration-charm
+          # - integration-provider
+          # - integration-scaling
+          # - integration-password-rotation
           - integration-tls
-          - integration-upgrade
+          # - integration-upgrade
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/docs/how-to/h-create-mtls-client-credentials.md
+++ b/docs/how-to/h-create-mtls-client-credentials.md
@@ -87,11 +87,10 @@ Inject Root CA and Server CA into the truststore file:
 ```bash
 
 # ---------- Truststore
-keytool -keystore client.truststore.jks -storepass $KAFKA_CLIENT_TRUSTSTORE_PASSWORD -noprompt \
--importcert -alias kafka-ca -file kafka_ca.pem
-
-keytool -keystore client.truststore.jks -storepass $KAFKA_CLIENT_TRUSTSTORE_PASSWORD -noprompt \
--importcert -alias CARoot -file ss_ca.pem
+charmed-kafka.keytool -keystore client.truststore.jks -storepass $KAFKA_CLIENT_TRUSTSTORE_PASSWORD -noprompt \
+  -importcert -alias kafka-ca -file kafka_ca.pem
+charmed-kafka.keytool -keystore client.truststore.jks -storepass $KAFKA_CLIENT_TRUSTSTORE_PASSWORD -noprompt \
+  -importcert -alias CARoot -file ss_ca.pem
 ```
 
 ### Check certificates validity
@@ -100,13 +99,12 @@ keytool -keystore client.truststore.jks -storepass $KAFKA_CLIENT_TRUSTSTORE_PASS
 
 # ---------- Check certs validity
 echo "Client certs in Keystore:"
-keytool -list -keystore client.keystore.p12 -storepass $KAFKA_CLIENT_KEYSTORE_PASSWORD -rfc | grep "Alias name"
-keytool -list -keystore client.keystore.p12 -storepass $KAFKA_CLIENT_KEYSTORE_PASSWORD -v | grep until
+charmed-kafka.keytool -list -keystore client.keystore.p12 -storepass $KAFKA_CLIENT_KEYSTORE_PASSWORD -rfc | grep "Alias name"
+charmed-kafka.keytool -list -keystore client.keystore.p12 -storepass $KAFKA_CLIENT_KEYSTORE_PASSWORD -v | grep until
 
 echo "Server certs in Truststore:"
-keytool -list -keystore client.truststore.jks -storepass $KAFKA_CLIENT_TRUSTSTORE_PASSWORD -rfc | grep "Alias name"
-keytool -list -keystore client.truststore.jks -storepass $KAFKA_CLIENT_TRUSTSTORE_PASSWORD -v | grep until
-
+charmed-kafka.keytool -list -keystore client.truststore.jks -storepass $KAFKA_CLIENT_TRUSTSTORE_PASSWORD -rfc | grep "Alias name"
+charmed-kafka.keytool -list -keystore client.truststore.jks -storepass $KAFKA_CLIENT_TRUSTSTORE_PASSWORD -v | grep until
 ```
 ### mTLS
 This is a mutual TLS communication which means:

--- a/src/literals.py
+++ b/src/literals.py
@@ -13,7 +13,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase
 
 CHARM_KEY = "kafka"
 SNAP_NAME = "charmed-kafka"
-CHARMED_KAFKA_SNAP_REVISION = 16
+CHARMED_KAFKA_SNAP_REVISION = 19
 
 PEER = "cluster"
 ZK = "zookeeper"

--- a/src/snap.py
+++ b/src/snap.py
@@ -45,7 +45,7 @@ class KafkaSnap:
         """
         try:
             apt.update()
-            apt.add_package(["snapd", "openjdk-17-jre-headless"])
+            apt.add_package(["snapd"])
             cache = snap.SnapCache()
             kafka = cache[SNAP_NAME]
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -440,7 +440,7 @@ class KafkaTLS(Object):
         """Adds CA to JKS truststore."""
         try:
             subprocess.check_output(
-                f"keytool -import -v -alias ca -file ca.pem -keystore truststore.jks -storepass {self.truststore_password} -noprompt",
+                f"charmed-kafka.keytool -import -v -alias ca -file ca.pem -keystore truststore.jks -storepass {self.truststore_password} -noprompt",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
@@ -475,7 +475,7 @@ class KafkaTLS(Object):
         """Add a certificate to the truststore."""
         try:
             subprocess.check_output(
-                f"keytool -import -v -alias {alias} -file {filename} -keystore truststore.jks -storepass {self.truststore_password} -noprompt",
+                f"charmed-kafka.keytool -import -v -alias {alias} -file {filename} -keystore truststore.jks -storepass {self.truststore_password} -noprompt",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
@@ -493,7 +493,7 @@ class KafkaTLS(Object):
         """Remove a cert from the truststore."""
         try:
             subprocess.check_output(
-                f"keytool -delete -v -alias {alias} -keystore truststore.jks -storepass {self.truststore_password} -noprompt",
+                f"charmed-kafka.keytool -delete -v -alias {alias} -keystore truststore.jks -storepass {self.truststore_password} -noprompt",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,

--- a/tests/integration/app-charm/lib/charms/operator_libs_linux/v1/snap.py
+++ b/tests/integration/app-charm/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 12
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -222,7 +222,7 @@ class Snap(object):
         name,
         state: SnapState,
         channel: str,
-        revision: str,
+        revision: int,
         confinement: str,
         apps: Optional[List[Dict[str, str]]] = None,
         cohort: Optional[str] = "",
@@ -393,6 +393,22 @@ class Snap(object):
         except CalledProcessError as e:
             raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
 
+    def hold(self, duration: Optional[timedelta] = None) -> None:
+        """Add a refresh hold to a snap.
+
+        Args:
+            duration: duration for the hold, or None (the default) to hold this snap indefinitely.
+        """
+        hold_str = "forever"
+        if duration is not None:
+            seconds = round(duration.total_seconds())
+            hold_str = f"{seconds}s"
+        self._snap("refresh", [f"--hold={hold_str}"])
+
+    def unhold(self) -> None:
+        """Remove the refresh hold of a snap."""
+        self._snap("refresh", ["--unhold"])
+
     def restart(
         self, services: Optional[List[str]] = None, reload: Optional[bool] = False
     ) -> None:
@@ -407,12 +423,18 @@ class Snap(object):
         args = ["restart", "--reload"] if reload else ["restart"]
         self._snap_daemons(args, services)
 
-    def _install(self, channel: Optional[str] = "", cohort: Optional[str] = "") -> None:
+    def _install(
+        self,
+        channel: Optional[str] = "",
+        cohort: Optional[str] = "",
+        revision: Optional[int] = None,
+    ) -> None:
         """Add a snap to the system.
 
         Args:
           channel: the channel to install from
           cohort: optional, the key of a cohort that this snap belongs to
+          revision: optional, the revision of the snap to install
         """
         cohort = cohort or self._cohort
 
@@ -421,6 +443,8 @@ class Snap(object):
             args.append("--classic")
         if channel:
             args.append('--channel="{}"'.format(channel))
+        if revision:
+            args.append('--revision="{}"'.format(revision))
         if cohort:
             args.append('--cohort="{}"'.format(cohort))
 
@@ -430,6 +454,7 @@ class Snap(object):
         self,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
+        revision: Optional[int] = None,
         leave_cohort: Optional[bool] = False,
     ) -> None:
         """Refresh a snap.
@@ -437,10 +462,15 @@ class Snap(object):
         Args:
           channel: the channel to install from
           cohort: optionally, specify a cohort.
+          revision: optionally, specify the revision of the snap to refresh
           leave_cohort: leave the current cohort.
         """
-        channel = '--channel="{}"'.format(channel) if channel else ""
-        args = [channel]
+        args = []
+        if channel:
+            args.append('--channel="{}"'.format(channel))
+
+        if revision:
+            args.append('--revision="{}"'.format(revision))
 
         if not cohort:
             cohort = self._cohort
@@ -468,6 +498,7 @@ class Snap(object):
         classic: Optional[bool] = False,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
+        revision: Optional[int] = None,
     ):
         """Ensure that a snap is in a given state.
 
@@ -476,6 +507,10 @@ class Snap(object):
           classic: an (Optional) boolean indicating whether classic confinement should be used
           channel: the channel to install from
           cohort: optional. Specify the key of a snap cohort.
+          revision: optional. the revision of the snap to install/refresh
+
+        While both channel and revision could be specified, the underlying snap install/refresh
+        command will determine which one takes precedence (revision at this time)
 
         Raises:
           SnapError if an error is encountered
@@ -494,10 +529,10 @@ class Snap(object):
             # We are installing or refreshing a snap.
             if self._state not in (SnapState.Present, SnapState.Latest):
                 # The snap is not installed, so we install it.
-                self._install(channel, cohort)
+                self._install(channel, cohort, revision)
             else:
                 # The snap is installed, but we are changing it (e.g., switching channels).
-                self._refresh(channel, cohort)
+                self._refresh(channel, cohort, revision)
 
         self._update_snap_apps()
         self._state = state
@@ -540,7 +575,7 @@ class Snap(object):
         self._state = state
 
     @property
-    def revision(self) -> str:
+    def revision(self) -> int:
         """Returns the revision for a snap."""
         return self._revision
 
@@ -570,6 +605,12 @@ class Snap(object):
                 services[app["name"]] = SnapService(**app).as_dict()
 
         return services
+
+    @property
+    def held(self) -> bool:
+        """Report whether the snap has a hold."""
+        info = self._snap("info")
+        return "hold:" in info
 
 
 class _UnixSocketConnection(http.client.HTTPConnection):
@@ -787,7 +828,7 @@ class SnapCache(Mapping):
                 name=i["name"],
                 state=SnapState.Latest,
                 channel=i["channel"],
-                revision=i["revision"],
+                revision=int(i["revision"]),
                 confinement=i["confinement"],
                 apps=i.get("apps", None),
             )
@@ -805,7 +846,7 @@ class SnapCache(Mapping):
             name=info["name"],
             state=SnapState.Available,
             channel=info["channel"],
-            revision=info["revision"],
+            revision=int(info["revision"]),
             confinement=info["confinement"],
             apps=None,
         )
@@ -815,9 +856,10 @@ class SnapCache(Mapping):
 def add(
     snap_names: Union[str, List[str]],
     state: Union[str, SnapState] = SnapState.Latest,
-    channel: Optional[str] = "latest",
+    channel: Optional[str] = "",
     classic: Optional[bool] = False,
     cohort: Optional[str] = "",
+    revision: Optional[int] = None,
 ) -> Union[Snap, List[Snap]]:
     """Add a snap to the system.
 
@@ -829,10 +871,14 @@ def add(
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
         cohort: an (Optional) string specifying the snap cohort to use
+        revision: an (Optional) integer specifying the snap revision to use
 
     Raises:
         SnapError if some snaps failed to install or were not found.
     """
+    if not channel and not revision:
+        channel = "latest"
+
     snap_names = [snap_names] if type(snap_names) is str else snap_names
     if not snap_names:
         raise TypeError("Expected at least one snap to add, received zero!")
@@ -840,7 +886,7 @@ def add(
     if type(state) is str:
         state = SnapState(state)
 
-    return _wrap_snap_operations(snap_names, state, channel, classic, cohort)
+    return _wrap_snap_operations(snap_names, state, channel, classic, cohort, revision)
 
 
 @_cache_init
@@ -864,9 +910,10 @@ def remove(snap_names: Union[str, List[str]]) -> Union[Snap, List[Snap]]:
 def ensure(
     snap_names: Union[str, List[str]],
     state: str,
-    channel: Optional[str] = "latest",
+    channel: Optional[str] = "",
     classic: Optional[bool] = False,
     cohort: Optional[str] = "",
+    revision: Optional[int] = None,
 ) -> Union[Snap, List[Snap]]:
     """Ensure specified snaps are in a given state on the system.
 
@@ -877,12 +924,19 @@ def ensure(
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
         cohort: an (Optional) string specifying the snap cohort to use
+        revision: an (Optional) integer specifying the snap revision to use
+
+    When both channel and revision are specified, the underlying snap install/refresh
+    command will determine the precedence (revision at the time of adding this)
 
     Raises:
         SnapError if the snap is not in the cache.
     """
-    if state in ("present", "latest"):
-        return add(snap_names, SnapState(state), channel, classic, cohort)
+    if not revision and not channel:
+        channel = "latest"
+
+    if state in ("present", "latest") or revision:
+        return add(snap_names, SnapState(state), channel, classic, cohort, revision)
     else:
         return remove(snap_names)
 
@@ -893,6 +947,7 @@ def _wrap_snap_operations(
     channel: str,
     classic: bool,
     cohort: Optional[str] = "",
+    revision: Optional[int] = None,
 ) -> Union[Snap, List[Snap]]:
     """Wrap common operations for bare commands."""
     snaps = {"success": [], "failed": []}
@@ -905,7 +960,9 @@ def _wrap_snap_operations(
             if state is SnapState.Absent:
                 snap.ensure(state=SnapState.Absent)
             else:
-                snap.ensure(state=state, classic=classic, channel=channel, cohort=cohort)
+                snap.ensure(
+                    state=state, classic=classic, channel=channel, cohort=cohort, revision=revision
+                )
             snaps["success"].append(snap)
         except SnapError as e:
             logger.warning("Failed to {} snap {}: {}!".format(op, s, e.message))
@@ -976,19 +1033,27 @@ def _system_set(config_item: str, value: str) -> None:
         raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
 
 
-def hold_refresh(days: int = 90) -> bool:
+def hold_refresh(days: int = 90, forever: bool = False) -> bool:
     """Set the system-wide snap refresh hold.
 
     Args:
         days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
+        forever: if True, will set a hold forever.
     """
-    # Currently the snap daemon can only hold for a maximum of 90 days
-    if not isinstance(days, int) or days > 90:
-        raise ValueError("days must be an int between 1 and 90")
+    if not isinstance(forever, bool):
+        raise TypeError("forever must be a bool")
+    if not isinstance(days, int):
+        raise TypeError("days must be an int")
+    if forever:
+        _system_set("refresh.hold", "forever")
+        logger.info("Set system-wide snap refresh hold to: forever")
     elif days == 0:
         _system_set("refresh.hold", "")
         logger.info("Removed system-wide snap refresh hold")
     else:
+        # Currently the snap daemon can only hold for a maximum of 90 days
+        if not 1 <= days <= 90:
+            raise ValueError("days must be between 1 and 90")
         # Add the number of days to current time
         target_date = datetime.now(timezone.utc).astimezone() + timedelta(days=days)
         # Format for the correct datetime format

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -141,7 +141,7 @@ class ApplicationCharm(CharmBase):
 
             logger.info("importing certificate to keystore")
             subprocess.check_output(
-                "charmed-kafka.keytool -keystore {SNAP_PATH}/client.keystore.jks -alias client-cert -importcert -file {SNAP_PATH}/client.cert -storepass password -noprompt",
+                f"charmed-kafka.keytool -keystore {SNAP_PATH}/client.keystore.jks -alias client-cert -importcert -file {SNAP_PATH}/client.cert -storepass password -noprompt",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
@@ -228,7 +228,7 @@ class ApplicationCharm(CharmBase):
         logger.info("running producer application")
         try:
             subprocess.check_output(
-                f"/snap/charmed-kafka/current/bin/kafka-console-producer.sh --bootstrap-server {bootstrap_servers} --topic=TEST-TOPIC --producer.config {SNAP_PATH}/client.properties < {SNAP_PATH}/data",
+                f"/snap/charmed-kafka/current/bin/kafka-console-producer.sh --bootstrap-server {bootstrap_servers} --topic=TEST-TOPIC --producer --command-config {SNAP_PATH}/client.properties < {SNAP_PATH}/data",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -13,6 +13,7 @@ import logging
 import os
 import shutil
 import subprocess
+import time
 from socket import getfqdn
 
 from charms.data_platform_libs.v0.data_interfaces import KafkaRequires, TopicCreatedEvent
@@ -262,6 +263,9 @@ class ApplicationCharm(CharmBase):
             cwd=SNAP_PATH,
         )
         logger.info(ls)
+
+        logger.info("SLEEPING")
+        time.sleep(10000)
 
         logger.info("running producer application")
         try:

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -94,12 +94,11 @@ class ApplicationCharm(CharmBase):
     def _install_packages(self):
         logger.info("INSTALLING PACKAGES")
         apt.update()
-        apt.add_package(["snapd", "openjdk-17-jre-headless"])
+        apt.add_package(["snapd"])
         cache = snap.SnapCache()
         kafka = cache["charmed-kafka"]
 
-        if not kafka.present:
-            kafka.ensure(snap.SnapState.Latest, channel="3/edge")
+        kafka.ensure(snap.SnapState.Latest, channel="3/edge")
 
     def _create_keystore(self, unit_name: str, unit_host: str):
         try:

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -105,7 +105,7 @@ class ApplicationCharm(CharmBase):
         try:
             logger.info("creating the keystore")
             subprocess.check_output(
-                f'keytool -keystore client.keystore.jks -alias client-key -validity 90 -genkey -keyalg RSA -noprompt -storepass password -dname "CN=client" -ext SAN=DNS:{unit_name},IP:{unit_host}',
+                f'charmed-kafka.keytool -keystore client.keystore.jks -alias client-key -validity 90 -genkey -keyalg RSA -noprompt -storepass password -dname "CN=client" -ext SAN=DNS:{unit_name},IP:{unit_host}',
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
@@ -124,7 +124,7 @@ class ApplicationCharm(CharmBase):
 
             logger.info("signing certificate")
             subprocess.check_output(
-                "keytool -keystore client.keystore.jks -alias client-key -certreq -file client.csr -storepass password",
+                "charmed-kafka.keytool -keystore client.keystore.jks -alias client-key -certreq -file client.csr -storepass password",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
@@ -141,7 +141,7 @@ class ApplicationCharm(CharmBase):
 
             logger.info("importing certificate to keystore")
             subprocess.check_output(
-                "keytool -keystore client.keystore.jks -alias client-cert -importcert -file client.cert -storepass password -noprompt",
+                "charmed-kafka.keytool -keystore client.keystore.jks -alias client-cert -importcert -file client.cert -storepass password -noprompt",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
@@ -175,7 +175,7 @@ class ApplicationCharm(CharmBase):
             try:
                 logger.info(f"adding {file} to truststore")
                 subprocess.check_output(
-                    f"keytool -keystore client.truststore.jks -alias {file.replace('.', '-')} -importcert -file {file} -storepass password -noprompt",
+                    f"charmed-kafka.keytool -keystore client.truststore.jks -alias {file.replace('.', '-')} -importcert -file {file} -storepass password -noprompt",
                     stderr=subprocess.PIPE,
                     shell=True,
                     universal_newlines=True,

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -265,7 +265,7 @@ class ApplicationCharm(CharmBase):
         logger.info(ls)
 
         logger.info("SLEEPING")
-        time.sleep(10000)
+        time.sleep(100000)
 
         logger.info("running producer application")
         try:

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -142,7 +142,7 @@ class ApplicationCharm(CharmBase):
 
             logger.info("importing certificate to keystore")
             subprocess.check_output(
-                f"charmed-kafka.keytool -keystore {SNAP_PATH}/client.keystore.jks -alias client-cert -importcert -file {SNAP_PATH}/client.cert -storepass password -noprompt",
+                f"sudo charmed-kafka.keytool -keystore {SNAP_PATH}/client.keystore.jks -alias client-cert -importcert -file {SNAP_PATH}/client.cert -storepass password -noprompt",
                 stderr=subprocess.STDOUT,
                 shell=True,
                 universal_newlines=True,

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -106,7 +106,7 @@ class ApplicationCharm(CharmBase):
         try:
             logger.info("creating the keystore")
             subprocess.check_output(
-                f'keytool -keystore client.keystore.jks -alias client-key -validity 90 -genkey -keyalg RSA -noprompt -storepass password -dname "CN=client" -ext SAN=DNS:{unit_name},IP:{unit_host}',
+                f'charmed-kafka.keytool -keystore client.keystore.jks -alias client-key -validity 90 -genkey -keyalg RSA -noprompt -storepass password -dname "CN=client" -ext SAN=DNS:{unit_name},IP:{unit_host}',
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
@@ -125,7 +125,7 @@ class ApplicationCharm(CharmBase):
 
             logger.info("signing certificate")
             subprocess.check_output(
-                "keytool -keystore client.keystore.jks -alias client-key -certreq -file client.csr -storepass password",
+                "charmed-kafka.keytool -keystore client.keystore.jks -alias client-key -certreq -file client.csr -storepass password",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
@@ -142,7 +142,7 @@ class ApplicationCharm(CharmBase):
 
             logger.info("importing certificate to keystore")
             subprocess.check_output(
-                "keytool -keystore client.keystore.jks -alias client-cert -importcert -file client.cert -storepass password -noprompt",
+                "charmed-kafka.keytool -keystore client.keystore.jks -alias client-cert -importcert -file client.cert -storepass password -noprompt",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -33,6 +33,7 @@ REL_NAME_ADMIN = "kafka-client-admin"
 ZK = "zookeeper"
 CONSUMER_GROUP_PREFIX = "test-prefix"
 SNAP_PATH = "/var/snap/charmed-kafka/current/etc/kafka"
+CHARMED_KAFKA_SNAP_REVISION = 19
 
 
 class ApplicationCharm(CharmBase):
@@ -99,7 +100,7 @@ class ApplicationCharm(CharmBase):
         cache = snap.SnapCache()
         kafka = cache["charmed-kafka"]
 
-        kafka.ensure(snap.SnapState.Latest, channel="3/edge")
+        kafka.ensure(snap.SnapState.Latest, channel="3/edge", revision=19)
 
     def _create_keystore(self, unit_name: str, unit_host: str):
         try:

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -106,12 +106,11 @@ class ApplicationCharm(CharmBase):
         try:
             logger.info("creating the keystore")
             subprocess.check_output(
-                f'charmed-kafka.keytool -keystore {SNAP_PATH}/client.keystore.jks -alias client-key -validity 90 -genkey -keyalg RSA -noprompt -storepass password -dname "CN=client" -ext SAN=DNS:{unit_name},IP:{unit_host}',
+                f'charmed-kafka.keytool -keystore client.keystore.jks -alias client-key -validity 90 -genkey -keyalg RSA -noprompt -storepass password -dname "CN=client" -ext SAN=DNS:{unit_name},IP:{unit_host}',
                 stderr=subprocess.STDOUT,
                 shell=True,
                 universal_newlines=True,
             )
-            shutil.chown(f"{SNAP_PATH}/client.keystore.jks", user="snap_daemon", group="root")
 
             logger.info("creating a ca")
             subprocess.check_output(
@@ -125,7 +124,7 @@ class ApplicationCharm(CharmBase):
 
             logger.info("signing certificate")
             subprocess.check_output(
-                f"charmed-kafka.keytool -keystore {SNAP_PATH}/client.keystore.jks -alias client-key -certreq -file {SNAP_PATH}/client.csr -storepass password",
+                f"charmed-kafka.keytool -keystore client.keystore.jks -alias client-key -certreq -file {SNAP_PATH}/client.csr -storepass password",
                 stderr=subprocess.STDOUT,
                 shell=True,
                 universal_newlines=True,
@@ -142,11 +141,12 @@ class ApplicationCharm(CharmBase):
 
             logger.info("importing certificate to keystore")
             subprocess.check_output(
-                f"sudo charmed-kafka.keytool -keystore {SNAP_PATH}/client.keystore.jks -alias client-cert -importcert -file {SNAP_PATH}/client.cert -storepass password -noprompt",
+                f"charmed-kafka.keytool -keystore client.keystore.jks -alias client-cert -importcert -file {SNAP_PATH}/client.cert -storepass password -noprompt",
                 stderr=subprocess.STDOUT,
                 shell=True,
                 universal_newlines=True,
             )
+            shutil.copyfile(src="client.keystore.jks", dst=SNAP_PATH)
             shutil.chown(f"{SNAP_PATH}/client.keystore.jks", user="snap_daemon", group="root")
 
             logger.info("grabbing cert content")

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -177,9 +177,8 @@ class ApplicationCharm(CharmBase):
         for file in ["broker.cert", "ca.cert", "client.cert"]:
             try:
                 logger.info(f"adding {file} to truststore")
-                alias = f"{SNAP_PATH}/{file.replace('.', '-')}"
                 subprocess.check_output(
-                    f"charmed-kafka.keytool -keystore {SNAP_PATH}/client.truststore.jks -alias {alias} -importcert -file {SNAP_PATH}/{file} -storepass password -noprompt",
+                    f"charmed-kafka.keytool -keystore {SNAP_PATH}/client.truststore.jks -alias {file.replace('.', '-')} -importcert -file {SNAP_PATH}/{file} -storepass password -noprompt",
                     stderr=subprocess.PIPE,
                     shell=True,
                     universal_newlines=True,

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -231,7 +231,7 @@ async def test_connection_updated_on_tls_enabled(ops_test: OpsTest, app_charm):
 
     # deploying tls
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
-    await ops_test.model.deploy(TLS_NAME, channel="beta", config=tls_config, series="jammy")
+    await ops_test.model.deploy(TLS_NAME, channel="stable", config=tls_config, series="jammy")
     await ops_test.model.wait_for_idle(
         apps=[TLS_NAME], idle_period=30, timeout=1800, status="active"
     )

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -45,7 +45,7 @@ async def test_deploy_tls(ops_test: OpsTest, kafka_charm):
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
 
     await asyncio.gather(
-        ops_test.model.deploy(TLS_NAME, channel="beta", config=tls_config, series="jammy"),
+        ops_test.model.deploy(TLS_NAME, channel="stable", config=tls_config, series="jammy"),
         ops_test.model.deploy(ZK, channel="edge", series="jammy", application_name=ZK),
         ops_test.model.deploy(
             kafka_charm,
@@ -165,7 +165,7 @@ async def test_mtls(ops_test: OpsTest):
         "ca-certificate": encoded_client_ca,
     }
     await ops_test.model.deploy(
-        TLS_NAME, channel="beta", config=tls_config, series="jammy", application_name=MTLS_NAME
+        TLS_NAME, channel="stable", config=tls_config, series="jammy", application_name=MTLS_NAME
     )
     await ops_test.model.wait_for_idle(apps=[MTLS_NAME], timeout=1000, idle_period=15)
     async with ops_test.fast_forward():


### PR DESCRIPTION
Depends on https://github.com/canonical/charmed-kafka-snap/pull/27

## Changes Made
#### `chore: remove openjdk-17-jre-headless`
- Was originally installed to use `keytool`
- Now usable through `charmed-kafka.keytool`
