### PR TITLE
[DPE-2644] Test: network cut

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          bootstrap-options: "--agent-version 2.9.38"
+          bootstrap-options: "--agent-version 2.9.45"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:

--- a/src/charm.py
+++ b/src/charm.py
@@ -206,13 +206,15 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
 
         # NOTE: integration with kafka-broker-rack-awareness charm.
         # Load current properties set in the charm workload and check
-        # if rack.properties file exists
+        # if rack.properties file exists.
+        # Also, check if listeners changed (IP change)
         properties = safe_get_file(self.kafka_config.server_properties_filepath)
         if properties and (
-            self.kafka_config.rack_properties != []
+            (self.kafka_config.rack_properties != [] or not self.kafka_config.listeners_updated)
             and (set(self.kafka_config.server_properties) ^ set(properties))
         ):
             self._on_config_changed(event)
+            self._restart(event)
 
         if not broker_active(
             unit=self.unit,

--- a/src/charm.py
+++ b/src/charm.py
@@ -356,6 +356,7 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
                     callback_override="_disable_enable_restart"
                 )
             else:
+                logger.info("Acquiring lock from _on_config_changed...")
                 self.on[f"{self.restart.name}"].acquire_lock.emit()
 
         # update client_properties whenever possible

--- a/src/config.py
+++ b/src/config.py
@@ -417,19 +417,6 @@ class KafkaConfig:
         return [self.internal_listener] + self.client_listeners
 
     @property
-    def listeners_updated(self) -> bool:
-        """Check if listeners in properties file match the ones expected.
-
-        This method can be used to verify if a IP change happened and there is a divergence between
-        the properties file and actual IP.
-        """
-        properties = safe_get_file(self.server_properties_filepath) or []
-        advertised_listeners = [listener.advertised_listener for listener in self.all_listeners]
-        advertised_listeners = f"advertised.listeners={','.join(advertised_listeners)}"
-
-        return advertised_listeners in properties
-
-    @property
     def super_users(self) -> str:
         """Generates all users with super/admin permissions for the cluster from relations.
 

--- a/src/config.py
+++ b/src/config.py
@@ -417,6 +417,19 @@ class KafkaConfig:
         return [self.internal_listener] + self.client_listeners
 
     @property
+    def listeners_updated(self) -> bool:
+        """Check if listeners in properties file match the ones expected.
+
+        This method can be used to verify if a IP change happened and there is a divergence between
+        the properties file and actual IP.
+        """
+        properties = safe_get_file(self.server_properties_filepath) or []
+        advertised_listeners = [listener.advertised_listener for listener in self.all_listeners]
+        advertised_listeners = f"advertised.listeners={','.join(advertised_listeners)}"
+
+        return advertised_listeners in properties
+
+    @property
     def super_users(self) -> str:
         """Generates all users with super/admin permissions for the cluster from relations.
 

--- a/src/health.py
+++ b/src/health.py
@@ -84,9 +84,12 @@ class KafkaHealth(Object):
             f"--bootstrap-server {','.join(self.charm.kafka_config.bootstrap_server)}",
             f"--command-config {self.charm.kafka_config.client_properties_filepath}",
         ]
-        log_dirs = self.charm.snap.run_bin_command(
-            bin_keyword="log-dirs", bin_args=log_dirs_command
-        )
+        try:
+            log_dirs = self.charm.snap.run_bin_command(
+                bin_keyword="log-dirs", bin_args=log_dirs_command
+            )
+        except subprocess.CalledProcessError:
+            return (0, 0)
 
         dirs = {}
         for line in log_dirs.splitlines():

--- a/tests/integration/ha/ha_helpers.py
+++ b/tests/integration/ha/ha_helpers.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 from dataclasses import dataclass
 from subprocess import PIPE, check_output
+from typing import Optional
 
 from pytest_operator.plugin import OpsTest
 
@@ -36,12 +37,15 @@ class ProcessRunningError(Exception):
     """Raised when a process is running when it is not expected to be."""
 
 
-async def get_topic_description(ops_test: OpsTest, topic: str) -> TopicDescription:
+async def get_topic_description(
+        ops_test: OpsTest, topic: str, unit_name: Optional[str] = None
+) -> TopicDescription:
     """Get the broker with the topic leader.
 
     Args:
         ops_test: OpsTest utility class
         topic: the desired topic to check
+        unit_name: unit to run the command on
     """
     bootstrap_servers = []
     for unit in ops_test.model.applications[APP_NAME].units:
@@ -49,7 +53,7 @@ async def get_topic_description(ops_test: OpsTest, topic: str) -> TopicDescripti
             await get_address(ops_test=ops_test, unit_num=unit.name.split("/")[-1])
             + f":{SECURITY_PROTOCOL_PORTS['SASL_PLAINTEXT'].client}"
         )
-    unit_name = ops_test.model.applications[APP_NAME].units[0].name
+    unit_name = unit_name or ops_test.model.applications[APP_NAME].units[0].name
 
     output = check_output(
         f"JUJU_MODEL={ops_test.model_full_name} juju ssh {unit_name} sudo -i 'charmed-kafka.topics --bootstrap-server {','.join(bootstrap_servers)} --command-config {KafkaSnap.CONF_PATH}/client.properties --describe --topic {topic}'",
@@ -64,12 +68,15 @@ async def get_topic_description(ops_test: OpsTest, topic: str) -> TopicDescripti
     return TopicDescription(leader, in_sync_replicas)
 
 
-async def get_topic_offsets(ops_test: OpsTest, topic: str) -> list[str]:
+async def get_topic_offsets(
+        ops_test: OpsTest, topic: str, unit_name: Optional[str] = None
+) -> list[str]:
     """Get the offsets of a topic on a unit.
 
     Args:
         ops_test: OpsTest utility class
         topic: the desired topic to check
+        unit_name: unit to run the command on
     """
     bootstrap_servers = []
     for unit in ops_test.model.applications[APP_NAME].units:
@@ -77,7 +84,7 @@ async def get_topic_offsets(ops_test: OpsTest, topic: str) -> list[str]:
             await get_address(ops_test=ops_test, unit_num=unit.name.split("/")[-1])
             + f":{SECURITY_PROTOCOL_PORTS['SASL_PLAINTEXT'].client}"
         )
-    unit_name = ops_test.model.applications[APP_NAME].units[0].name
+    unit_name = unit_name or ops_test.model.applications[APP_NAME].units[0].name
 
     # example of topic offset output: 'test-topic:0:10'
     result = check_output(
@@ -182,6 +189,28 @@ def network_release(machine_name: str) -> None:
     subprocess.check_call(limit_set_command.split())
     limit_set_command = f"lxc config set {machine_name} limits.network.priority="
     subprocess.check_call(limit_set_command.split())
+
+
+def network_cut(machine_name: str) -> None:
+    """Cut network from a lxc container.
+
+    Args:
+        machine_name: lxc container hostname
+    """
+    # apply a mask (device type `none`)
+    cut_network_command = f"lxc config device add {machine_name} eth0 none"
+    subprocess.check_call(cut_network_command.split())
+
+
+def network_restore(machine_name: str) -> None:
+    """Restore network from a lxc container.
+
+    Args:
+        machine_name: lxc container hostname
+    """
+    # remove mask from eth0
+    restore_network_command = f"lxc config device remove {machine_name} eth0"
+    subprocess.check_call(restore_network_command.split())
 
 
 def is_up(ops_test: OpsTest, broker_id: int) -> bool:

--- a/tests/integration/ha/ha_helpers.py
+++ b/tests/integration/ha/ha_helpers.py
@@ -38,7 +38,7 @@ class ProcessRunningError(Exception):
 
 
 async def get_topic_description(
-        ops_test: OpsTest, topic: str, unit_name: Optional[str] = None
+    ops_test: OpsTest, topic: str, unit_name: Optional[str] = None
 ) -> TopicDescription:
     """Get the broker with the topic leader.
 
@@ -69,7 +69,7 @@ async def get_topic_description(
 
 
 async def get_topic_offsets(
-        ops_test: OpsTest, topic: str, unit_name: Optional[str] = None
+    ops_test: OpsTest, topic: str, unit_name: Optional[str] = None
 ) -> list[str]:
     """Get the offsets of a topic on a unit.
 

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -308,7 +308,7 @@ async def test_network_cut_without_ip_change(
     result = c_writes.stop()
     assert_continuous_writes_consistency(result=result)
 
-@pytest.mark.do_test
+
 @pytest.mark.abort_on_fail
 async def test_network_cut(
     ops_test: OpsTest,

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -64,7 +64,7 @@ async def restart_delay(ops_test: OpsTest):
     for unit in ops_test.model.applications[APP_NAME].units:
         await remove_restart_delay(ops_test=ops_test, unit_name=unit.name)
 
-@pytest.mark.do_test
+
 @pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, kafka_charm, app_charm):
@@ -92,10 +92,6 @@ async def test_build_and_deploy(ops_test: OpsTest, kafka_charm, app_charm):
     assert ops_test.model.applications[APP_NAME].status == "active"
     assert ops_test.model.applications[DUMMY_NAME].status == "active"
 
-    await ops_test.model.applications[APP_NAME].add_units(count=2)
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=600, idle_period=120, wait_for_exact_units=3
-    )
 
 async def test_replicated_events(ops_test: OpsTest):
     await ops_test.model.applications[APP_NAME].add_units(count=2)
@@ -264,6 +260,9 @@ async def test_network_cut_without_ip_change(
     c_writes: ContinuousWrites,
     c_writes_runner: ContinuousWrites,
 ):
+    # Let some time pass for messages to be produced
+    await asyncio.sleep(10)
+
     topic_description = await get_topic_description(
         ops_test=ops_test, topic=ContinuousWrites.TOPIC_NAME
     )
@@ -309,7 +308,7 @@ async def test_network_cut_without_ip_change(
     result = c_writes.stop()
     assert_continuous_writes_consistency(result=result)
 
-@pytest.mark.do_test
+
 @pytest.mark.abort_on_fail
 async def test_network_cut(
     ops_test: OpsTest,

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -308,7 +308,7 @@ async def test_network_cut_without_ip_change(
     result = c_writes.stop()
     assert_continuous_writes_consistency(result=result)
 
-
+@pytest.mark.do_test
 @pytest.mark.abort_on_fail
 async def test_network_cut(
     ops_test: OpsTest,
@@ -358,9 +358,9 @@ async def test_network_cut(
     logger.info(f"Restoring network of broker: {initial_leader_num}")
     network_restore(machine_name=leader_machine_name)
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward(fast_interval="15s"):
         result = c_writes.stop()
-        await asyncio.sleep(CLIENT_TIMEOUT)
+        await asyncio.sleep(CLIENT_TIMEOUT * 8)
 
     topic_description = await get_topic_description(
         ops_test=ops_test, topic=ContinuousWrites.TOPIC_NAME

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -315,6 +315,9 @@ async def test_network_cut(
     c_writes: ContinuousWrites,
     c_writes_runner: ContinuousWrites,
 ):
+    # Let some time pass for messages to be produced
+    await asyncio.sleep(10)
+
     topic_description = await get_topic_description(
         ops_test=ops_test, topic=ContinuousWrites.TOPIC_NAME
     )
@@ -349,12 +352,11 @@ async def test_network_cut(
         ops_test=ops_test, topic=ContinuousWrites.TOPIC_NAME, unit_name=available_unit
     )
 
-    assert int(next_offsets[-1]) > int(initial_offsets[-1])
+    assert int(next_offsets[-1]) > int(initial_offsets[-1]), "Messages not increasing"
 
     # Release the network
     logger.info(f"Restoring network of broker: {initial_leader_num}")
     network_restore(machine_name=leader_machine_name)
-    await asyncio.sleep(REELECTION_TIME)
 
     async with ops_test.fast_forward():
         result = c_writes.stop()

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -356,13 +356,16 @@ async def test_network_cut(
     network_restore(machine_name=leader_machine_name)
     await asyncio.sleep(REELECTION_TIME)
 
+    async with ops_test.fast_forward():
+        result = c_writes.stop()
+        await asyncio.sleep(CLIENT_TIMEOUT)
+
     topic_description = await get_topic_description(
         ops_test=ops_test, topic=ContinuousWrites.TOPIC_NAME
     )
     # verify the unit is now rejoined the cluster
     assert topic_description.in_sync_replicas == {0, 1, 2}
 
-    result = c_writes.stop()
     assert_continuous_writes_consistency(result=result)
 
 


### PR DESCRIPTION
Adds network cut, which includes an IP change to the unit.

- Broker won't rejoin the cluster until the next `update_status` triggers.