### PR TITLE
[DPE-2704] Integrate Kafka built from source

### DIFF
--- a/src/literals.py
+++ b/src/literals.py
@@ -13,7 +13,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase
 
 CHARM_KEY = "kafka"
 SNAP_NAME = "charmed-kafka"
-CHARMED_KAFKA_SNAP_REVISION = 19
+CHARMED_KAFKA_SNAP_REVISION = 20
 
 PEER = "cluster"
 ZK = "zookeeper"

--- a/src/literals.py
+++ b/src/literals.py
@@ -13,7 +13,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase
 
 CHARM_KEY = "kafka"
 SNAP_NAME = "charmed-kafka"
-CHARMED_KAFKA_SNAP_REVISION = 20
+CHARMED_KAFKA_SNAP_REVISION = 21
 
 PEER = "cluster"
 ZK = "zookeeper"


### PR DESCRIPTION
This PR is to test that the charm work well with a new snap revision that was built from source. That revision is currently sitting on `3/edge/dpe-2704-kafka-from-source`