### PR TITLE
[DPE-3880] Remove all instances of $job variable in dashboard

### DIFF
--- a/src/grafana_dashboards/kafka-metrics.json
+++ b/src/grafana_dashboards/kafka-metrics.json
@@ -151,7 +151,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(kafka_server_replicamanager_leadercount{job=~\"$job\"})",
+          "expr": "count(kafka_server_replicamanager_leadercount{})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -243,7 +243,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_controller_kafkacontroller_activecontrollercount{job=~\"$job\"})",
+          "expr": "sum(kafka_controller_kafkacontroller_activecontrollercount{})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -334,7 +334,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_controller_kafkacontroller_globaltopiccount{job=~\"$job\"})",
+          "expr": "sum(kafka_controller_kafkacontroller_globaltopiccount{})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -425,7 +425,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_server_replicamanager_underreplicatedpartitions{job=~\"$job\"})",
+          "expr": "sum(kafka_server_replicamanager_underreplicatedpartitions{})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -516,7 +516,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_server_replicamanager_partitioncount{job=~\"$job\"})",
+          "expr": "sum(kafka_server_replicamanager_partitioncount{})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -605,7 +605,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_controller_kafkacontroller_offlinepartitionscount{job=~\"$job\"})",
+          "expr": "sum(kafka_controller_kafkacontroller_offlinepartitionscount{})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -742,7 +742,7 @@
       ],
       "targets": [
         {
-          "expr": "kafka_controller_kafkacontroller_activecontrollercount{job=~\"$job\"}",
+          "expr": "kafka_controller_kafkacontroller_activecontrollercount{}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -805,7 +805,7 @@
       "pluginVersion": "7.3.4",
       "targets": [
         {
-          "expr": "sum(kafka_server_brokertopicmetrics_messagesinpersec{job=\"$job\",topic=\"\"})",
+          "expr": "sum(kafka_server_brokertopicmetrics_messagesinpersec{topic=\"\"})",
           "interval": "",
           "legendFormat": "Total messages in per sec ",
           "refId": "A"
@@ -967,7 +967,7 @@
       ],
       "targets": [
         {
-          "expr": "kafka_server_replicamanager_leadercount{job=~\"$job\"} / kafka_server_replicamanager_partitioncount{job=\"$job\"} * 100",
+          "expr": "kafka_server_replicamanager_leadercount{} / kafka_server_replicamanager_partitioncount{} * 100",
           "format": "table",
           "hide": true,
           "instant": true,
@@ -977,7 +977,7 @@
           "refId": "C"
         },
         {
-          "expr": "kafka_server_replicamanager_leadercount{job=~\"$job\"}",
+          "expr": "kafka_server_replicamanager_leadercount{}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -987,7 +987,7 @@
           "refId": "A"
         },
         {
-          "expr": "count(kafka_cluster_partition_replicascount{job=\"$job\"} <= 1)by(instance)",
+          "expr": "count(kafka_cluster_partition_replicascount{} <= 1)by(instance)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -1050,7 +1050,7 @@
       "pluginVersion": "7.3.4",
       "targets": [
         {
-          "expr": "sum(increase(kafka_server_brokertopicmetrics_messagesinpersec{job=\"$job\",topic=\"\"}[$__range]))",
+          "expr": "sum(increase(kafka_server_brokertopicmetrics_messagesinpersec{topic=\"\"}[$__range]))",
           "interval": "",
           "legendFormat": "Total messages from ${__from:date:MM-DD hA} to ${__to:date:MM-DD hA}",
           "refId": "A"
@@ -1129,7 +1129,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "100 - (kafka_network_socketserver_networkprocessoravgidlepercent{job=\"$job\",instance=~\"$broker\"}*100)",
+          "expr": "100 - (kafka_network_socketserver_networkprocessoravgidlepercent{instance=~\"$broker\"}*100)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1226,7 +1226,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_total{job=\"$job\",instance=~\"$broker\"}",
+          "expr": "kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_total{instance=~\"$broker\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1316,7 +1316,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "avg by(request) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",job=\"$job\",quantile=\"0.99\",request=\"Produce\"})",
+          "expr": "avg by(request) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",quantile=\"0.99\",request=\"Produce\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1390,7 +1390,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "avg by(request) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",job=\"$job\",quantile=\"0.99\",request=\"FetchConsumer\"})",
+          "expr": "avg by(request) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",quantile=\"0.99\",request=\"FetchConsumer\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1464,7 +1464,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "avg by(request) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",job=\"$job\",quantile=\"0.99\",request=\"FetchFollower\"})",
+          "expr": "avg by(request) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",quantile=\"0.99\",request=\"FetchFollower\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1533,7 +1533,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by(instance) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",job=\"$job\",quantile=\"0.99\",request=\"Produce\"})",
+          "expr": "avg by(instance) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",quantile=\"0.99\",request=\"Produce\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1638,7 +1638,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by(instance) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",job=\"$job\",quantile=\"0.99\",request=\"FetchConsumer\"})",
+          "expr": "avg by(instance) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",quantile=\"0.99\",request=\"FetchConsumer\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1743,7 +1743,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by(instance) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",job=\"$job\",quantile=\"0.99\",request=\"FetchFollower\"})",
+          "expr": "avg by(instance) (kafka_network_requestmetrics_totaltimems{instance=~\"$broker\",quantile=\"0.99\",request=\"FetchFollower\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1862,7 +1862,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kafka_server_brokertopicmetrics_messagesinpersec{instance=~\"$broker\", job=\"$job\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", topic!=\"\", topic=~\"$topic\"}[5m])",
+          "expr": "rate(kafka_server_brokertopicmetrics_messagesinpersec{instance=~\"$broker\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", topic!=\"\", topic=~\"$topic\"}[5m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1970,7 +1970,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kafka_server_brokertopicmetrics_bytesinpersec{instance=~\"$broker\",job=\"$job\",topic!=\"\",topic=~\"$topic\"}[5m])",
+          "expr": "rate(kafka_server_brokertopicmetrics_bytesinpersec{instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"}[5m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2084,7 +2084,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kafka_server_brokertopicmetrics_totalproducerequestspersec{instance=~\"$broker\", job=\"$job\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", topic!=\"\"}[5m])",
+          "expr": "rate(kafka_server_brokertopicmetrics_totalproducerequestspersec{instance=~\"$broker\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", topic!=\"\"}[5m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2189,7 +2189,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kafka_network_requestmetrics_requestspersec{instance=~\"$broker\", job=\"$job\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", request=~\"Produce\"}[5m])",
+          "expr": "rate(kafka_network_requestmetrics_requestspersec{instance=~\"$broker\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", request=~\"Produce\"}[5m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2308,7 +2308,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kafka_server_brokertopicmetrics_failedproducerequestspersec{instance=~\"$broker\", job=~\"$job\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", topic!=\"\", topic=~\"$topic\"}[5m])",
+          "expr": "rate(kafka_server_brokertopicmetrics_failedproducerequestspersec{instance=~\"$broker\",  juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", topic!=\"\", topic=~\"$topic\"}[5m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2413,7 +2413,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(topic) (kafka_server_brokertopicmetrics_failedfetchrequestspersec{instance=~\"$broker\",job=~\"$job\",topic!=\"\",topic=~\"$topic\"})",
+          "expr": "sum by(topic) (kafka_server_brokertopicmetrics_failedfetchrequestspersec{instance=~\"$broker\",topic!=\"\",topic=~\"$topic\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2518,7 +2518,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kafka_server_brokertopicmetrics_failedproducerequestspersec{instance=~\"$broker\",job=~\"$job\",juju_application=\"$juju_application\",juju_model=\"$juju_model\",juju_model_uuid=\"$juju_model_uuid\",juju_unit=\"$juju_unit\"}[5m])",
+          "expr": "rate(kafka_server_brokertopicmetrics_failedproducerequestspersec{instance=~\"$broker\",juju_application=\"$juju_application\",juju_model=\"$juju_model\",juju_model_uuid=\"$juju_model_uuid\",juju_unit=\"$juju_unit\"}[5m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2623,7 +2623,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (kafka_server_sessionexpirelistener_zookeeperdisconnectspersec{job=\"$job\",instance=~\"$broker\"})by(instance)",
+          "expr": "sum (kafka_server_sessionexpirelistener_zookeeperdisconnectspersec{instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2727,7 +2727,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (kafka_server_sessionexpirelistener_zookeeperexpirespersec{job=\"$job\",instance=~\"$broker\"})by(instance)",
+          "expr": "sum (kafka_server_sessionexpirelistener_zookeeperexpirespersec{instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2833,7 +2833,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_server_zookeeperclientmetrics_zookeeperrequestlatencyms{job=\"$job\",instance=~\"$broker\"})by(instance)",
+          "expr": "sum(kafka_server_zookeeperclientmetrics_zookeeperrequestlatencyms{instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2944,7 +2944,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (kafka_server_replicamanager_isrshrinkspersec{job=\"$job\",instance=~\"$broker\"})",
+          "expr": "sum (kafka_server_replicamanager_isrshrinkspersec{instance=~\"$broker\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2952,7 +2952,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum (kafka_server_replicamanager_isrexpandspersec{job=\"$job\",instance=~\"$broker\"})",
+          "expr": "sum (kafka_server_replicamanager_isrexpandspersec{instance=~\"$broker\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3056,7 +3056,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kafka_network_requestmetrics_requestspersec{instance=~\"$broker\", job=\"$job\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", request=~\"FetchFollower\"}[5m])",
+          "expr": "rate(kafka_network_requestmetrics_requestspersec{instance=~\"$broker\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", request=~\"FetchFollower\"}[5m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3162,7 +3162,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kafka_network_requestmetrics_requestspersec{instance=~\"$broker\", job=\"$job\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", request=\"FetchConsumer\"}[5m])",
+          "expr": "rate(kafka_network_requestmetrics_requestspersec{instance=~\"$broker\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", request=\"FetchConsumer\"}[5m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3272,7 +3272,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (kafka_server_delayedoperationpurgatory_purgatorysize{job=\"$job\",delayedOperation=\"Fetch\",instance=~\"$broker\"})by(instance)",
+          "expr": "sum (kafka_server_delayedoperationpurgatory_purgatorysize{delayedOperation=\"Fetch\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3376,7 +3376,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kafka_server_brokertopicmetrics_totalfetchrequestspersec{instance=~\"$broker\", job=\"$job\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", topic!=\"\"}[5m])",
+          "expr": "rate(kafka_server_brokertopicmetrics_totalfetchrequestspersec{instance=~\"$broker\", juju_application=\"$juju_application\", juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_unit=\"$juju_unit\", topic!=\"\"}[5m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3482,7 +3482,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (kafka_server_delayedoperationpurgatory_purgatorysize{job=\"$job\",delayedOperation=\"Produce\",instance=~\"$broker\"})by(instance)",
+          "expr": "sum (kafka_server_delayedoperationpurgatory_purgatorysize{delayedOperation=\"Produce\",instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3589,7 +3589,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (kafka_controller_controllerstats_leaderelectionrateandtimems{job=\"$job\",instance=~\"$broker\"})by(instance)",
+          "expr": "sum (kafka_controller_controllerstats_leaderelectionrateandtimems{instance=~\"$broker\"})by(instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3768,7 +3768,7 @@
       ],
       "targets": [
         {
-          "expr": "kafka_cluster_partition_replicascount{job=~\"$job\",topic=~\"$topic\"}",
+          "expr": "kafka_cluster_partition_replicascount{topic=~\"$topic\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -3838,7 +3838,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sort(sum(kafka_log_log_size{job=~\"$job\",instance=~\"$broker\"})by(instance))",
+          "expr": "sort(sum(kafka_log_log_size{instance=~\"$broker\"})by(instance))",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -3944,7 +3944,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sort(sum(kafka_server_replicamanager_partitioncount{job=~\"$job\"}) by (instance))",
+          "expr": "sort(sum(kafka_server_replicamanager_partitioncount{}) by (instance))",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -4063,7 +4063,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "jvm_threads_current{job=\"$job\",instance=~\"$broker\"}",
+              "expr": "jvm_threads_current{instance=~\"$broker\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -4165,7 +4165,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum without(area)(jvm_memory_bytes_used{job=\"$job\",instance=~\"$broker\"} )",
+              "expr": "sum without(area)(jvm_memory_bytes_used{instance=~\"$broker\"} )",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -4267,7 +4267,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(process_cpu_seconds_total{job=~\"$job\",instance=~\"$broker\"}[5m])",
+              "expr": "rate(process_cpu_seconds_total{instance=~\"$broker\"}[5m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -4369,7 +4369,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum without(gc)(rate(jvm_gc_collection_seconds_sum{job=\"$job\",instance=~\"$broker\"}[1m]))",
+              "expr": "sum without(gc)(rate(jvm_gc_collection_seconds_sum{instance=~\"$broker\"}[1m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -4436,30 +4436,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${prometheusds}",
-        "definition": "label_values(kafka_controller_kafkacontroller_controllerstate, job)",
-        "error": null,
-        "hide": 0,
-        "includeAll": false,
-        "label": "job",
-        "multi": false,
-        "name": "job",
-        "options": [],
-        "query": "label_values(kafka_controller_kafkacontroller_controllerstate, job)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "${prometheusds}",
-        "definition": "label_values(kafka_controller_kafkacontroller_controllerstate{job=\"$job\"}, instance)",
+        "definition": "label_values(kafka_controller_kafkacontroller_controllerstate{instance)",
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -4467,7 +4444,7 @@
         "multi": true,
         "name": "broker",
         "options": [],
-        "query": "label_values(kafka_controller_kafkacontroller_controllerstate{job=\"$job\"}, instance)",
+        "query": "label_values(kafka_controller_kafkacontroller_controllerstate{}, instance)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4482,7 +4459,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${prometheusds}",
-        "definition": "label_values(kafka_cluster_partition_replicascount{job=\"$job\"}, topic)",
+        "definition": "label_values(kafka_cluster_partition_replicascount{}, topic)",
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -4490,7 +4467,7 @@
         "multi": true,
         "name": "topic",
         "options": [],
-        "query": "label_values(kafka_cluster_partition_replicascount{job=\"$job\"}, topic)",
+        "query": "label_values(kafka_cluster_partition_replicascount{}, topic)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -4505,7 +4482,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${prometheusds}",
-        "definition": "query_result(count(up{job=~\"$job\"}))",
+        "definition": "query_result(count(up{}))",
         "error": null,
         "hide": 2,
         "includeAll": false,
@@ -4513,7 +4490,7 @@
         "multi": false,
         "name": "online_broker",
         "options": [],
-        "query": "query_result(count(up{job=~\"$job\"}))",
+        "query": "query_result(count(up{}))",
         "refresh": 1,
         "regex": "/.* ([^\\ ]*) .*/",
         "skipUrlSync": false,


### PR DESCRIPTION
Both kafka and kafka-k8s charms include a grafana dashboard which uses a variable $job.

This variable does not seem to add value to the monitoring capability, as it is both redundant with other filters (namely juju-model), and not configured to enable multi selection (which causes issues when we deploy a vm cluster and a k8s cluster related to the same monitoring stack).