### PR TITLE
[DPE-3780] Set workload version in install hook

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -175,6 +175,7 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
 
         # update environment
         self.config_manager.set_environment()
+        self.unit.set_workload_version(self.version)
 
         if zk_jaas_changed:
             clean_broker_jaas = [conf.strip() for conf in zk_jaas]

--- a/src/charm.py
+++ b/src/charm.py
@@ -126,6 +126,8 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         if self.workload.install():
             self._set_os_config()
             self.config_manager.set_environment()
+            self.unit.set_workload_version(self.version)
+
         else:
             self._set_status(Status.SNAP_NOT_INSTALLED)
 
@@ -331,6 +333,11 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
 
         getattr(logger, log_level.lower())(status.message)
         self.unit.status = status
+
+    @property
+    def version(self) -> str:
+        """Reports the current workload (Kafka) version."""
+        return self.workload.get_version()
 
 
 if __name__ == "__main__":

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -146,6 +146,15 @@ class WorkloadBase(ABC):
         """
         ...
 
+    @abstractmethod
+    def get_version(self) -> str:
+        """Get the workload version.
+
+        Returns:
+            String of kafka version
+        """
+        ...
+
     @staticmethod
     def generate_password() -> str:
         """Creates randomized string for use as app passwords.

--- a/src/workload.py
+++ b/src/workload.py
@@ -165,3 +165,9 @@ class KafkaWorkload(WorkloadBase):
                     return int(pid)
 
         raise snap.SnapError(f"Snap {self.SNAP_NAME} pid not found")
+
+    @override
+    def get_version(self) -> str:
+        if not self.kafka.present:
+            return ""
+        return self.kafka._snap_client.get_snap_information(self.SNAP_NAME).get("version", "")

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -4,7 +4,7 @@
 
 import logging
 from pathlib import Path
-from unittest.mock import mock_open, patch
+from unittest.mock import Mock, mock_open, patch
 
 import pytest
 import yaml
@@ -104,3 +104,8 @@ def test_machine_configured_succeeds_and_fails(harness, mmap, fd, swap, mem):
             assert harness.charm.health.machine_configured()
         else:
             assert not harness.charm.health.machine_configured()
+
+
+def test_workload_version(harness, monkeypatch):
+    monkeypatch.setattr(harness.charm.workload, "get_version", Mock(return_value="1.2.3"))
+    assert harness.charm.version == "1.2.3"


### PR DESCRIPTION
I'd appreciate feedback on:
- do we keep the workload setter statement in the install hook? The one in the config changed hook would be sufficient, but as a reader, I would expect this hook to run this action
- any idea on how we can run an integration test without overmocking everything? IMO the unit test is already a low-value passthrough test 