### PR TITLE
[MISC] CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
         run: tox run -e unit
 
   sync-docs:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.event.pull_request.head.repo.full_name, 'canonical/') }}
     uses: ./.github/workflows/sync_docs.yaml
     secrets: inherit
     permissions:


### PR DESCRIPTION
Disabling sync docs for contribution outside of Canonical, such that the checks are clean, even for external contributors