### PR TITLE
[DPE-4581] TLS

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -23,6 +23,7 @@ from core.structured_config import CharmConfig
 from events.balancer import BalancerOperator
 from events.broker import BrokerOperator
 from events.peer_cluster import PeerClusterEventsHandler
+from events.tls import TLSHandler
 from literals import (
     CHARM_KEY,
     JMX_CC_PORT,
@@ -34,7 +35,6 @@ from literals import (
     DebugLevel,
     Status,
 )
-from events.tls import TLSHandler
 from workload import KafkaWorkload
 
 logger = logging.getLogger(__name__)

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,6 +34,7 @@ from literals import (
     DebugLevel,
     Status,
 )
+from events.tls import TLSHandler
 from workload import KafkaWorkload
 
 logger = logging.getLogger(__name__)
@@ -79,6 +80,8 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         # Register roles event handlers after global ones, so that they get the priority.
         self.broker = BrokerOperator(self)
         self.balancer = BalancerOperator(self)
+
+        self.tls = TLSHandler(self)
 
     def _on_install(self, _) -> None:
         """Handler for `install` event."""

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -139,8 +139,7 @@ class BalancerOperator(Object):
             self.config_manager.set_broker_capacities()
             self.config_manager.set_zk_jaas_config()
 
-            self.workload.restart()
-            # self._on_start(event)
+            self._on_start(event)
 
     def rebalance(self, event: ActionEvent) -> None:
         """Handles the `rebalance` Juju Action."""

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -54,7 +54,8 @@ class BalancerOperator(Object):
         self.framework.observe(self.charm.on.leader_elected, self._on_start)
 
         # ensures data updates, eventually
-        self.framework.observe(getattr(self.charm.on, "update_status"), self._on_config_changed)
+        self.framework.observe(self.charm.on.update_status, self._on_config_changed)
+        self.framework.observe(self.charm.on.config_changed, self._on_config_changed)
 
         self.framework.observe(getattr(self.charm.on, "rebalance_action"), self.rebalance)
 

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -19,6 +19,7 @@ from literals import (
 )
 from managers.balancer import BalancerManager
 from managers.config import BalancerConfigManager
+from managers.tls import TLSManager
 from workload import BalancerWorkload
 
 if TYPE_CHECKING:
@@ -36,6 +37,9 @@ class BalancerOperator(Object):
 
         self.workload = BalancerWorkload()
 
+        self.tls_manager = TLSManager(
+            state=self.charm.state, workload=self.workload, substrate=self.charm.substrate
+        )
         # Fast exit after workload instantiation, but before any event observer
         if BALANCER.value not in self.charm.config.roles or not self.charm.unit.is_leader():
             return
@@ -134,7 +138,8 @@ class BalancerOperator(Object):
             self.config_manager.set_broker_capacities()
             self.config_manager.set_zk_jaas_config()
 
-            self._on_start(event)
+            self.workload.restart()
+            # self._on_start(event)
 
     def rebalance(self, event: ActionEvent) -> None:
         """Handles the `rebalance` Juju Action."""

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -21,7 +21,6 @@ from ops import (
 from events.oauth import OAuthHandler
 from events.password_actions import PasswordActionEvents
 from events.provider import KafkaProvider
-from events.tls import TLSHandler
 from events.upgrade import KafkaDependencyModel, KafkaUpgrade
 from events.zookeeper import ZooKeeperHandler
 from health import KafkaHealth

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -1,5 +1,6 @@
 """Broker role core charm logic."""
 
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -54,6 +55,9 @@ class BrokerOperator(Object):
 
         self.workload = KafkaWorkload()
 
+        self.tls_manager = TLSManager(
+            state=self.charm.state, workload=self.workload, substrate=self.charm.substrate
+        )
         # Fast exit after workload instantiation, but before any event observer
         if BROKER.value not in self.charm.config.roles:
             return
@@ -68,7 +72,6 @@ class BrokerOperator(Object):
         self.password_action_events = PasswordActionEvents(self)
         self.zookeeper = ZooKeeperHandler(self)
         self.oauth = OAuthHandler(self)
-        self.tls = TLSHandler(self)
         self.provider = KafkaProvider(self)
 
         # MANAGERS
@@ -78,9 +81,6 @@ class BrokerOperator(Object):
             workload=self.workload,
             config=self.charm.config,
             current_version=self.upgrade.current_version,
-        )
-        self.tls_manager = TLSManager(
-            state=self.charm.state, workload=self.workload, substrate=self.charm.substrate
         )
         self.auth_manager = AuthManager(
             state=self.charm.state,
@@ -201,6 +201,9 @@ class BrokerOperator(Object):
         if self.model.relations.get(REL_NAME, None) and self.charm.unit.is_leader():
             self.update_client_data()
 
+        if self.charm.state.peer_cluster_relation and self.charm.unit.is_leader():
+            self.update_peer_cluster_data()
+
     def _on_update_status(self, _: UpdateStatusEvent) -> None:
         """Handler for `update-status` events."""
         if not self.healthy or not self.upgrade.idle:
@@ -318,3 +321,24 @@ class BrokerOperator(Object):
                     "tls-ca": client.tls,  # TODO: fix tls-ca
                 }
             )
+
+    def update_peer_cluster_data(self) -> None:
+        """Writes updated relation data to other peer_cluster apps."""
+        if not self.charm.unit.is_leader() or not self.healthy:
+            return
+
+        self.charm.state.balancer.update(
+            {
+                "roles": self.charm.state.roles,
+                "broker-username": self.charm.state.balancer.broker_username,
+                "broker-password": self.charm.state.balancer.broker_password,
+                "broker-uris": self.charm.state.balancer.broker_uris,
+                "racks": str(self.charm.state.balancer.racks),
+                "broker-capacities": json.dumps(self.charm.state.balancer.broker_capacities),
+                "zk-uris": self.charm.state.balancer.zk_uris,
+                "zk-username": self.charm.state.balancer.zk_username,
+                "zk-password": self.charm.state.balancer.zk_password,
+            }
+        )
+
+        # self.charm.on.config_changed.emit()  # ensure both broker+balancer get a changed event

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -32,8 +32,6 @@ from literals import TLS_RELATION, TRUSTED_CA_RELATION, TRUSTED_CERTIFICATE_RELA
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
-    # from events.broker import BrokerOperator
-    # from events.balancer import BalancerOperator
 
 logger = logging.getLogger(__name__)
 
@@ -264,17 +262,12 @@ class TLSHandler(Object):
             {"certificate": event.certificate, "ca-cert": event.ca, "ca": ""}
         )
 
-        self.charm.broker.tls_manager.set_server_key()
-        self.charm.broker.tls_manager.set_ca()
-        self.charm.broker.tls_manager.set_certificate()
-        self.charm.broker.tls_manager.set_truststore()
-        self.charm.broker.tls_manager.set_keystore()
-
-        self.charm.balancer.tls_manager.set_server_key()
-        self.charm.balancer.tls_manager.set_ca()
-        self.charm.balancer.tls_manager.set_certificate()
-        self.charm.balancer.tls_manager.set_truststore()
-        self.charm.balancer.tls_manager.set_keystore()
+        for dependent in ["broker", "balancer"]:
+            getattr(self.charm, dependent).tls_manager.set_server_key()
+            getattr(self.charm, dependent).tls_manager.set_ca()
+            getattr(self.charm, dependent).tls_manager.set_certificate()
+            getattr(self.charm, dependent).tls_manager.set_truststore()
+            getattr(self.charm, dependent).tls_manager.set_keystore()
 
         # single-unit Kafka can lose restart events if it loses connection with TLS-enabled ZK
         self.charm.on.config_changed.emit()

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -32,7 +32,8 @@ from literals import TLS_RELATION, TRUSTED_CA_RELATION, TRUSTED_CERTIFICATE_RELA
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
-    from events.broker import BrokerOperator
+    # from events.broker import BrokerOperator
+    # from events.balancer import BalancerOperator
 
 logger = logging.getLogger(__name__)
 
@@ -40,10 +41,9 @@ logger = logging.getLogger(__name__)
 class TLSHandler(Object):
     """Handler for managing the client and unit TLS keys/certs."""
 
-    def __init__(self, dependent: "BrokerOperator") -> None:
-        super().__init__(dependent, "tls")
-        self.dependent = dependent
-        self.charm: "KafkaCharm" = dependent.charm
+    def __init__(self, charm: "KafkaCharm") -> None:
+        super().__init__(charm, "tls")
+        self.charm: "KafkaCharm" = charm
 
         self.certificates = TLSCertificatesRequiresV1(self.charm, TLS_RELATION)
 
@@ -120,7 +120,8 @@ class TLSHandler(Object):
         )
 
         # remove all existing keystores from the unit so we don't preserve certs
-        self.dependent.tls_manager.remove_stores()
+        self.charm.broker.tls_manager.remove_stores()
+        self.charm.balancer.tls_manager.remove_stores()
 
         if not self.charm.unit.is_leader():
             return
@@ -150,7 +151,7 @@ class TLSHandler(Object):
             event.defer()
             return
 
-        alias = self.dependent.tls_manager.generate_alias(
+        alias = self.charm.broker.tls_manager.generate_alias(
             app_name=event.app.name,
             relation_id=event.relation.id,
         )
@@ -191,7 +192,7 @@ class TLSHandler(Object):
             event.defer()
             return
 
-        alias = self.dependent.tls_manager.generate_alias(
+        alias = self.charm.broker.tls_manager.generate_alias(
             event.relation.app.name,
             event.relation.id,
         )
@@ -206,7 +207,7 @@ class TLSHandler(Object):
         self.charm.workload.write(
             content=content, path=f"{self.charm.workload.paths.conf_path}/{filename}"
         )
-        self.dependent.tls_manager.import_cert(alias=f"{alias}", filename=filename)
+        self.charm.broker.tls_manager.import_cert(alias=f"{alias}", filename=filename)
 
         # ensuring new config gets applied
         self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
@@ -223,13 +224,13 @@ class TLSHandler(Object):
             return
 
         # All units will need to remove the cert from their truststore
-        alias = self.dependent.tls_manager.generate_alias(
+        alias = self.charm.broker.tls_manager.generate_alias(
             app_name=event.relation.app.name,
             relation_id=event.relation.id,
         )
 
         logger.info(f"Removing {alias=} from truststore...")
-        self.dependent.tls_manager.remove_cert(alias=alias)
+        self.charm.broker.tls_manager.remove_cert(alias=alias)
 
         # The leader will also handle removing the "mtls" flag if needed
         if not self.charm.unit.is_leader():
@@ -263,11 +264,17 @@ class TLSHandler(Object):
             {"certificate": event.certificate, "ca-cert": event.ca, "ca": ""}
         )
 
-        self.dependent.tls_manager.set_server_key()
-        self.dependent.tls_manager.set_ca()
-        self.dependent.tls_manager.set_certificate()
-        self.dependent.tls_manager.set_truststore()
-        self.dependent.tls_manager.set_keystore()
+        self.charm.broker.tls_manager.set_server_key()
+        self.charm.broker.tls_manager.set_ca()
+        self.charm.broker.tls_manager.set_certificate()
+        self.charm.broker.tls_manager.set_truststore()
+        self.charm.broker.tls_manager.set_keystore()
+
+        self.charm.balancer.tls_manager.set_server_key()
+        self.charm.balancer.tls_manager.set_ca()
+        self.charm.balancer.tls_manager.set_certificate()
+        self.charm.balancer.tls_manager.set_truststore()
+        self.charm.balancer.tls_manager.set_keystore()
 
         # single-unit Kafka can lose restart events if it loses connection with TLS-enabled ZK
         self.charm.on.config_changed.emit()

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -631,7 +631,6 @@ class ConfigManager(CommonConfigManager):
         updated_env_list = [
             self.kafka_opts,
             self.kafka_jmx_opts,
-            self.cc_jmx_opts,
             self.jvm_performance_opts,
             self.heap_opts,
             self.log_level,

--- a/tests/integration/test_balancer.py
+++ b/tests/integration/test_balancer.py
@@ -9,7 +9,7 @@ from subprocess import CalledProcessError
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from literals import PEER_CLUSTER_ORCHESTRATOR_RELATION, PEER_CLUSTER_RELATION
+from literals import PEER_CLUSTER_ORCHESTRATOR_RELATION, PEER_CLUSTER_RELATION, TLS_RELATION
 
 from .helpers import (
     APP_NAME,
@@ -27,6 +27,7 @@ pytestmark = pytest.mark.balancer
 
 BALANCER_APP = "balancer"
 PRODUCER_APP = "producer"
+TLS_NAME = "self-signed-certificates"
 
 
 @pytest.fixture(params=[APP_NAME, BALANCER_APP], scope="module")
@@ -234,6 +235,29 @@ class TestBalancer:
         for key, value in pre_rebalance_replica_counts.items():
             # verify that post-rebalance, surviving units increased replica counts
             assert int(value) < int(post_rebalance_replica_counts.get(key, 0))
+
+    async def test_tls(self, ops_test: OpsTest, balancer_app):
+        # deploy and integrate tls
+        tls_config = {"ca-common-name": "kafka"}
+
+        await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config, series="jammy")
+        await ops_test.model.wait_for_idle(apps=[TLS_NAME], idle_period=15, timeout=1800)
+        assert ops_test.model.applications[TLS_NAME].status == "active"
+
+        await ops_test.model.add_relation(TLS_NAME, ZK_NAME)
+        await ops_test.model.add_relation(TLS_NAME, f"{APP_NAME}:{TLS_RELATION}")
+
+        if balancer_app != APP_NAME:
+            await ops_test.model.add_relation(TLS_NAME, f"{BALANCER_APP}:{TLS_RELATION}")
+
+        await ops_test.model.wait_for_idle(
+            apps=list({APP_NAME, ZK_NAME, balancer_app}), idle_period=30
+        )
+        async with ops_test.fast_forward(fast_interval="20s"):
+            await asyncio.sleep(60)  # ensure update-status adds broker-capacities if missed
+
+        # Assert that balancer is running and using certificates
+        assert balancer_is_running(model_full_name=ops_test.model_full_name, app_name=balancer_app)
 
     @pytest.mark.abort_on_fail
     async def test_cleanup(self, ops_test: OpsTest, balancer_app):

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -51,10 +51,10 @@ async def test_deploy_charms_relate_active(
     await ops_test.model.add_relation(APP_NAME, ZK)
     await ops_test.model.add_relation(APP_NAME, f"{DUMMY_NAME_1}:{REL_NAME_CONSUMER}")
 
-    async with ops_test.fast_forward(fast_interval="60s"):
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, DUMMY_NAME_1, ZK], idle_period=30, status="active"
-        )
+    # async with ops_test.fast_forward(fast_interval="60s"):
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, DUMMY_NAME_1, ZK], idle_period=30, status="active"
+    )
 
     usernames.update(get_client_usernames(ops_test))
 

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -104,13 +104,13 @@ def test_extra_sans_config(harness: Harness[KafkaCharm]):
     )
 
     harness.update_config({"certificate_extra_sans": ""})
-    assert harness.charm.broker.tls._extra_sans == []
+    assert harness.charm.tls._extra_sans == []
 
     harness.update_config({"certificate_extra_sans": "worker{unit}.com"})
-    assert harness.charm.broker.tls._extra_sans == ["worker0.com"]
+    assert harness.charm.tls._extra_sans == ["worker0.com"]
 
     harness.update_config({"certificate_extra_sans": "worker{unit}.com,{unit}.example"})
-    assert harness.charm.broker.tls._extra_sans == ["worker0.com", "0.example"]
+    assert harness.charm.tls._extra_sans == ["worker0.com", "0.example"]
 
 
 def test_sans(harness: Harness[KafkaCharm]):
@@ -124,14 +124,14 @@ def test_sans(harness: Harness[KafkaCharm]):
 
     sock_dns = socket.getfqdn()
     if SUBSTRATE == "vm":
-        assert harness.charm.broker.tls._sans == {
+        assert harness.charm.tls._sans == {
             "sans_ip": ["treebeard"],
             "sans_dns": [f"{CHARM_KEY}/0", sock_dns, "worker0.com"],
         }
     elif SUBSTRATE == "k8s":
         # NOTE previous k8s sans_ip like kafka-k8s-0.kafka-k8s-endpoints or binding pod address
         with patch("ops.model.Model.get_binding"):
-            assert harness.charm.broker.tls._sans["sans_dns"] == [
+            assert harness.charm.tls._sans["sans_dns"] == [
                 "kafka-k8s-0",
                 "kafka-k8s-0.kafka-k8s-endpoints",
                 sock_dns,


### PR DESCRIPTION
First iteration of TLS for Cruise Control.

## Context
When Kafka - Zookeeper have tls enabled, cruise control needs updated properties to be able to maintain connection.

## Changes

- TLS events are declared at `charm` level. This means that the same events are used for both roles.
- `events/tls.py` now will duplicate its calls to the managers API. One for each role.
- TLS managers are now instantiated for both broker and balancer. This is done before exiting the manager early because the events will need to trigger manager API.

## Found issues
- Restart for the balancer doesn't seem to go through until `update_status`
- `peer_cluster` doesn't update `bootstrap_servers` and `zookeeper_uris` when they change. This is mitigated [here](https://github.com/canonical/kafka-operator/pull/220/files#diff-168ff0fb69a03619c31bb042470b3f46e7a22ffc12864f02b6e55fbc68e72362R204-R205), but it has more implications like password rotations or generally changes to the main databag.

## TBD
Managers having a no-op API so a node running single role doesn't create trustores/keystores for all components.

