### PR TITLE
refactor: Use list of str workload.exec for k8s parity

### DIFF
--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -8,7 +8,7 @@ import secrets
 import string
 from abc import ABC, abstractmethod
 
-from literals import Role
+from literals import BALANCER, BROKER, Role
 
 
 class CharmedKafkaPaths:
@@ -87,12 +87,12 @@ class CharmedKafkaPaths:
     @property
     def jmx_prometheus_config(self):
         """The configuration for the Kafka JMX exporter."""
-        return f"{self.conf_path}/jmx_prometheus.yaml"
+        return f"{BROKER.paths['CONF']}/jmx_prometheus.yaml"
 
     @property
     def jmx_cc_config(self):
         """The configuration for the CruiseControl JMX exporter."""
-        return f"{self.conf_path}/jmx_cruise_control.yaml"
+        return f"{BALANCER.paths['CONF']}/jmx_cruise_control.yaml"
 
     @property
     def cruise_control_properties(self):
@@ -155,7 +155,10 @@ class WorkloadBase(ABC):
 
     @abstractmethod
     def exec(
-        self, command: list[str], env: dict[str, str] | None = None, working_dir: str | None = None
+        self,
+        command: list[str] | str,
+        env: dict[str, str] | None = None,
+        working_dir: str | None = None,
     ) -> str:
         """Runs a command on the workload substrate."""
         ...

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -155,7 +155,7 @@ class WorkloadBase(ABC):
 
     @abstractmethod
     def exec(
-        self, command: str, env: dict[str, str] | None = None, working_dir: str | None = None
+        self, command: list[str], env: dict[str, str] | None = None, working_dir: str | None = None
     ) -> str:
         """Runs a command on the workload substrate."""
         ...

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -249,11 +249,16 @@ class BrokerOperator(Object):
         # new dirs won't be used until topic partitions are assigned to it
         # either automatically for new topics, or manually for existing
         # set status only for running services, not on startup
-        self.workload.exec(f"chmod -R 750 {self.workload.paths.data_path}")
-        self.workload.exec(f"chown -R {USER}:{GROUP} {self.workload.paths.data_path}")
+        self.workload.exec(["chmod", "-R", "750", f"{self.workload.paths.data_path}"])
+        self.workload.exec(["chown", "-R", f"{USER}:{GROUP}", f"{self.workload.paths.data_path}"])
         self.workload.exec(
-            f"""find {self.workload.paths.data_path} -type f -name "meta.properties" -delete || true"""
+            [
+                "bash",
+                "-c",
+                f"""find {self.workload.paths.data_path} -type f -name meta.properties -delete || true""",
+            ]
         )
+
         if self.workload.active():
             self.charm._set_status(Status.ADDED_STORAGE)
             # We need the event handler to know about the original event

--- a/src/events/zookeeper.py
+++ b/src/events/zookeeper.py
@@ -102,7 +102,7 @@ class ZooKeeperHandler(Object):
         # this ID is provided by ZK, and removing it on relation-broken allows
         # re-joining to another ZK cluster.
         for storage in self.charm.model.storages[STORAGE]:
-            self.dependent.workload.exec(f"rm {storage.location}/meta.properties")
+            self.dependent.workload.exec(["bash", "-c", f"rm {storage.location}/meta.properties"])
 
         if not self.charm.unit.is_leader():
             return

--- a/src/events/zookeeper.py
+++ b/src/events/zookeeper.py
@@ -102,7 +102,7 @@ class ZooKeeperHandler(Object):
         # this ID is provided by ZK, and removing it on relation-broken allows
         # re-joining to another ZK cluster.
         for storage in self.charm.model.storages[STORAGE]:
-            self.dependent.workload.exec(["bash", "-c", f"rm {storage.location}/meta.properties"])
+            self.dependent.workload.exec(["rm", f"{storage.location}/meta.properties"])
 
         if not self.charm.unit.is_leader():
             return

--- a/src/health.py
+++ b/src/health.py
@@ -36,23 +36,31 @@ class KafkaHealth(Object):
 
     def _get_current_memory_maps(self) -> int:
         """Gets the current number of memory maps for the Kafka process."""
-        return int(self.dependent.workload.exec(f"cat /proc/{self._service_pid}/maps | wc -l"))
+        return int(
+            self.dependent.workload.exec(
+                ["bash", "-c", f"cat /proc/{self._service_pid}/maps | wc -l"]
+            )
+        )
 
     def _get_current_max_files(self) -> int:
         """Gets the current file descriptor limit for the Kafka process."""
         return int(
             self.dependent.workload.exec(
-                rf"cat /proc/{self._service_pid}/limits | grep files | awk '{{print $5}}'"
+                [
+                    "bash",
+                    "-c",
+                    rf"cat /proc/{self._service_pid}/limits | grep files | awk '{{print $5}}'",
+                ]
             )
         )
 
     def _get_max_memory_maps(self) -> int:
         """Gets the current memory map limit for the machine."""
-        return int(self.dependent.workload.exec("sysctl -n vm.max_map_count"))
+        return int(self.dependent.workload.exec(["sysctl", "-n", "vm.max_map_count"]))
 
     def _get_vm_swappiness(self) -> int:
         """Gets the current vm.swappiness configured for the machine."""
-        return int(self.dependent.workload.exec("sysctl -n vm.swappiness"))
+        return int(self.dependent.workload.exec(["sysctl", "-n", "vm.swappiness"]))
 
     def _get_partitions_size(self) -> tuple[int, int]:
         """Gets the number of partitions and their average size from the log dirs."""

--- a/src/managers/balancer.py
+++ b/src/managers/balancer.py
@@ -134,7 +134,7 @@ class BalancerManager:
     @property
     def cores(self) -> int:
         """Gets the total number of CPU cores for the machine."""
-        return int(self.dependent.workload.exec("nproc --all"))
+        return int(self.dependent.workload.exec(["nproc", "--all"]))
 
     @property
     def storages(self) -> str:
@@ -206,7 +206,9 @@ class BalancerManager:
 
     def _get_storage_size(self, path: str) -> int:
         """Gets the total storage volume of a mounted filepath, in KB."""
-        return int(self.dependent.workload.exec(f"df --output=size {path} | sed 1d"))
+        return int(
+            self.dependent.workload.exec(["bash", "-c", f"df --output=size {path} | sed 1d"])
+        )
 
     def _build_new_key(self, nested_key: str, nested_value: JSON) -> dict[str, JSON]:
         """Builds a nested key:value pair for JSON lists from the output of a rebalance proposal.

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -66,9 +66,9 @@ class TLSManager:
         """Adds CA to JKS truststore."""
         command = f"{self.keytool} -import -v -alias ca -file ca.pem -keystore truststore.jks -storepass {self.state.unit_broker.truststore_password} -noprompt"
         try:
-            self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
-            self.workload.exec(f"chown {USER}:{GROUP} {self.workload.paths.truststore}")
-            self.workload.exec(f"chmod 770 {self.workload.paths.truststore}")
+            self.workload.exec(command=command.split(), working_dir=self.workload.paths.conf_path)
+            self.workload.exec(["chown", f"{USER}:{GROUP}", f"{self.workload.paths.truststore}"])
+            self.workload.exec(["chmod", "770", f"{self.workload.paths.truststore}"])
         except (subprocess.CalledProcessError, ExecError) as e:
             # in case this reruns and fails
             if e.stdout and "already exists" in e.stdout:
@@ -80,9 +80,9 @@ class TLSManager:
         """Creates and adds unit cert and private-key to the keystore."""
         command = f"openssl pkcs12 -export -in server.pem -inkey server.key -passin pass:{self.state.unit_broker.keystore_password} -certfile server.pem -out keystore.p12 -password pass:{self.state.unit_broker.keystore_password}"
         try:
-            self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
-            self.workload.exec(f"chown {USER}:{GROUP} {self.workload.paths.keystore}")
-            self.workload.exec(f"chmod 770 {self.workload.paths.keystore}")
+            self.workload.exec(command=command.split(), working_dir=self.workload.paths.conf_path)
+            self.workload.exec(["chown", f"{USER}:{GROUP}", f"{self.workload.paths.keystore}"])
+            self.workload.exec(["chmod", "770", f"{self.workload.paths.keystore}"])
         except (subprocess.CalledProcessError, ExecError) as e:
             logger.error(e.stdout)
             raise e
@@ -91,7 +91,7 @@ class TLSManager:
         """Add a certificate to the truststore."""
         command = f"{self.keytool} -import -v -alias {alias} -file {filename} -keystore truststore.jks -storepass {self.state.unit_broker.truststore_password} -noprompt"
         try:
-            self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
+            self.workload.exec(command=command.split(), working_dir=self.workload.paths.conf_path)
         except (subprocess.CalledProcessError, ExecError) as e:
             # in case this reruns and fails
             if e.stdout and "already exists" in e.stdout:
@@ -104,8 +104,10 @@ class TLSManager:
         """Remove a cert from the truststore."""
         try:
             command = f"{self.keytool} -delete -v -alias {alias} -keystore truststore.jks -storepass {self.state.unit_broker.truststore_password} -noprompt"
-            self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
-            self.workload.exec(f"rm -f {alias}.pem", working_dir=self.workload.paths.conf_path)
+            self.workload.exec(command=command.split(), working_dir=self.workload.paths.conf_path)
+            self.workload.exec(
+                ["rm", "-f", f"{alias}.pem"], working_dir=self.workload.paths.conf_path
+            )
         except (subprocess.CalledProcessError, ExecError) as e:
             if e.stdout and "does not exist" in e.stdout:
                 logger.warning(e.stdout)
@@ -117,7 +119,7 @@ class TLSManager:
         """Cleans up all keys/certs/stores on a unit."""
         try:
             self.workload.exec(
-                command="rm -rf *.pem *.key *.p12 *.jks",
+                command=["rm", "-rf", "*.pem", "*.key", "*.p12", "*.jks"],
                 working_dir=self.workload.paths.conf_path,
             )
         except (subprocess.CalledProcessError, ExecError) as e:

--- a/src/workload.py
+++ b/src/workload.py
@@ -75,7 +75,7 @@ class Workload(WorkloadBase):
     @override
     def exec(
         self,
-        command: list[str],
+        command: list[str] | str,
         env: Mapping[str, str] | None = None,
         working_dir: str | None = None,
     ) -> str:
@@ -84,7 +84,7 @@ class Workload(WorkloadBase):
                 command,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,
-                shell=True,
+                shell=isinstance(command, str),
                 env=env,
                 cwd=working_dir,
             )
@@ -169,7 +169,7 @@ class Workload(WorkloadBase):
         opts_str = " ".join(opts)
         bin_str = " ".join(bin_args)
         command = f"{opts_str} {SNAP_NAME}.{bin_keyword} {bin_str}"
-        return self.exec(command.split())
+        return self.exec(command)
 
 
 class KafkaWorkload(Workload):

--- a/src/workload.py
+++ b/src/workload.py
@@ -70,11 +70,14 @@ class Workload(WorkloadBase):
         with open(path, mode) as f:
             f.write(content)
 
-        self.exec(f"chown -R {USER}:{GROUP} {path}")
+        self.exec(["chown", "-R", f"{USER}:{GROUP}", f"{path}"])
 
     @override
     def exec(
-        self, command: str, env: Mapping[str, str] | None = None, working_dir: str | None = None
+        self,
+        command: list[str],
+        env: Mapping[str, str] | None = None,
+        working_dir: str | None = None,
     ) -> str:
         try:
             output = subprocess.check_output(
@@ -166,7 +169,7 @@ class Workload(WorkloadBase):
         opts_str = " ".join(opts)
         bin_str = " ".join(bin_args)
         command = f"{opts_str} {SNAP_NAME}.{bin_keyword} {bin_str}"
-        return self.exec(command)
+        return self.exec(command.split())
 
 
 class KafkaWorkload(Workload):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -531,7 +531,7 @@ def test_zookeeper_broken_stops_service_and_removes_meta_properties(harness: Har
         harness.remove_relation(zk_rel_id)
 
         patched_stop_snap_service.assert_called_once()
-        assert re.match(r"rm .*/meta.properties", patched_exec.call_args_list[0].args[0][-1])
+        assert re.match(r"rm .*/meta.properties", " ".join(patched_exec.call_args_list[0].args[0]))
         assert isinstance(harness.charm.unit.status, BlockedStatus)
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -531,7 +531,7 @@ def test_zookeeper_broken_stops_service_and_removes_meta_properties(harness: Har
         harness.remove_relation(zk_rel_id)
 
         patched_stop_snap_service.assert_called_once()
-        assert re.match(r"rm .*/meta.properties", patched_exec.call_args_list[0].args[0])
+        assert re.match(r"rm .*/meta.properties", patched_exec.call_args_list[0].args[0][-1])
         assert isinstance(harness.charm.unit.status, BlockedStatus)
 
 

--- a/tests/unit/test_workload.py
+++ b/tests/unit/test_workload.py
@@ -22,9 +22,9 @@ def test_run_bin_command_args(patched_exec):
     """Checks KAFKA_OPTS env-var and zk-tls flag present in all snap commands."""
     KafkaWorkload().run_bin_command(bin_keyword="configs", bin_args=["--list"], opts=["-Djava"])
 
-    assert "charmed-kafka.configs" in patched_exec.call_args.args[0]
-    assert "-Djava" == patched_exec.call_args.args[0][0]
-    assert "--list" == patched_exec.call_args.args[0][-1]
+    assert "charmed-kafka.configs" in patched_exec.call_args.args[0].split()
+    assert "-Djava" == patched_exec.call_args.args[0].split()[0]
+    assert "--list" == patched_exec.call_args.args[0].split()[-1]
 
 
 def test_get_service_pid_raises():

--- a/tests/unit/test_workload.py
+++ b/tests/unit/test_workload.py
@@ -22,9 +22,9 @@ def test_run_bin_command_args(patched_exec):
     """Checks KAFKA_OPTS env-var and zk-tls flag present in all snap commands."""
     KafkaWorkload().run_bin_command(bin_keyword="configs", bin_args=["--list"], opts=["-Djava"])
 
-    assert "charmed-kafka.configs" in patched_exec.call_args.args[0].split()
-    assert "-Djava" == patched_exec.call_args.args[0].split()[0]
-    assert "--list" == patched_exec.call_args.args[0].split()[-1]
+    assert "charmed-kafka.configs" in patched_exec.call_args.args[0]
+    assert "-Djava" == patched_exec.call_args.args[0][0]
+    assert "--list" == patched_exec.call_args.args[0][-1]
 
 
 def test_get_service_pid_raises():


### PR DESCRIPTION
This PR changes the way we pass commands to be executed by the workload. On k8s, due to pebble using `sh` by default, we cannot use commands using pipes, unless we use the `bash -c <command>`.
