### PR TITLE
[DPE-5208] - fix: secure written znodes

### DIFF
--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -299,6 +299,7 @@ class ConfigManager(CommonConfigManager):
         return [
             f"broker.id={self.state.unit_broker.unit_id}",
             f"zookeeper.connect={self.state.zookeeper.connect}",
+            "zookeeper.set.acl=true",
         ]
 
     @property


### PR DESCRIPTION
## Changes Made
#### `fix: set ACLs on written zNodes`
- Fixes https://github.com/canonical/kafka-operator/issues/230
- ZooKeeper ACLs are not recursive, meaning that any written data to a zNode nested under the `chroot`, will be readable by all
- Setting`zookeeper.set.acl=true` ensures that there are protections on the zNodes written by Kafka 