### PR TITLE
KRaft

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,8 @@ jobs:
           - integration-upgrade
           - integration-balancer-single
           - integration-balancer-multi
+          - integration-kraft-single
+          - integration-kraft-multi
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ options:
   roles:
     description: |
       Comma separated list of the roles assigned to the nodes of this cluster.
-      This configuration accepts the following roles: 'broker' (standard functionality), 'balancer' (cruise control).
+      This configuration accepts the following roles: 'broker' (standard functionality), 'balancer' (cruise control), 'controller' (KRaft mode).
     type: string
     default: broker
   compression_type:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 asyncio_mode = "auto"
-markers = ["unstable", "broker", "balancer"]
+markers = ["unstable", "broker", "balancer", "kraft"]
 
 # Formatting tools configuration
 [tool.black]

--- a/src/charm.py
+++ b/src/charm.py
@@ -92,6 +92,11 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
             self._set_status(Status.SNAP_NOT_INSTALLED)
             return
 
+        # TODO: run on install
+        # if self.state.runs_controller:
+        #     uuid = self.workload.run_bin_command(bin_keyword="storage", bin_args=["random-uuid"])
+        #     self.state.cluster.update({"cluster-uuid": uuid.strip()})
+
         self._set_os_config()
 
     def _set_os_config(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -92,11 +92,6 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
             self._set_status(Status.SNAP_NOT_INSTALLED)
             return
 
-        # TODO: run on install
-        # if self.state.runs_controller:
-        #     uuid = self.workload.run_bin_command(bin_keyword="storage", bin_args=["random-uuid"])
-        #     self.state.cluster.update({"cluster-uuid": uuid.strip()})
-
         self._set_os_config()
 
     def _set_os_config(self) -> None:
@@ -125,7 +120,10 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         This handler is in charge of stopping the workloads, since the sub-operators would not
         be instantiated if roles are changed.
         """
-        if not self.state.runs_broker and self.broker.workload.active():
+        if (
+            not (self.state.runs_broker or self.state.runs_controller)
+            and self.broker.workload.active()
+        ):
             self.broker.workload.stop()
 
         if (
@@ -184,8 +182,9 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         if not self.broker.workload.active():
             event.add_status(Status.BROKER_NOT_RUNNING.value.status)
 
-        if not self.state.zookeeper.broker_active():
-            event.add_status(Status.ZK_NOT_CONNECTED.value.status)
+        if not self.state.kraft_mode:
+            if not self.state.zookeeper.broker_active():
+                event.add_status(Status.ZK_NOT_CONNECTED.value.status)
 
 
 if __name__ == "__main__":

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -37,6 +37,7 @@ from literals import (
     ADMIN_USER,
     BALANCER,
     BROKER,
+    CONTROLLER,
     INTERNAL_USERS,
     MIN_REPLICAS,
     OAUTH_REL_NAME,
@@ -475,15 +476,17 @@ class ClusterState(Object):
         if not self.runs_broker:
             return Status.ACTIVE
 
-        if not self.zookeeper:
-            return Status.ZK_NOT_RELATED
+        # FIXME
+        if not self.runs_controller:
+            if not self.zookeeper:
+                return Status.ZK_NOT_RELATED
 
-        if not self.zookeeper.zookeeper_connected:
-            return Status.ZK_NO_DATA
+            if not self.zookeeper.zookeeper_connected:
+                return Status.ZK_NO_DATA
 
-        # TLS must be enabled for Kafka and ZK or disabled for both
-        if self.cluster.tls_enabled ^ self.zookeeper.tls:
-            return Status.ZK_TLS_MISMATCH
+            # TLS must be enabled for Kafka and ZK or disabled for both
+            if self.cluster.tls_enabled ^ self.zookeeper.tls:
+                return Status.ZK_TLS_MISMATCH
 
         if self.cluster.tls_enabled and not self.unit_broker.certificate:
             return Status.NO_CERT
@@ -502,3 +505,8 @@ class ClusterState(Object):
     def runs_broker(self) -> bool:
         """Is the charm enabling the broker(s)?"""
         return BROKER.value in self.roles
+
+    @property
+    def runs_controller(self) -> bool:
+        """Is the charm enabling the controller?"""
+        return CONTROLLER.value in self.roles

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -38,7 +38,9 @@ from literals import (
     BALANCER,
     BROKER,
     CONTROLLER,
+    CONTROLLER_PORT,
     INTERNAL_USERS,
+    KRAFT_NODE_ID_OFFSET,
     MIN_REPLICAS,
     OAUTH_REL_NAME,
     PEER,
@@ -85,7 +87,7 @@ class PeerClusterData(ProviderData, RequirerData):
     """Broker provider data model."""
 
     SECRET_LABEL_MAP = SECRET_LABEL_MAP
-    SECRET_FIELDS = BALANCER.requested_secrets
+    SECRET_FIELDS = list(set(BALANCER.requested_secrets) | set(CONTROLLER.requested_secrets))
 
 
 class ClusterState(Object):
@@ -137,46 +139,48 @@ class ClusterState(Object):
     @property
     def peer_cluster_orchestrator(self) -> PeerCluster:
         """The state for the related `peer-cluster-orchestrator` application that this charm is requiring from."""
-        balancer_kwargs: dict[str, Any] = (
-            {
-                "balancer_username": self.cluster.balancer_username,
-                "balancer_password": self.cluster.balancer_password,
-                "balancer_uris": self.cluster.balancer_uris,
-            }
-            if self.runs_balancer
-            else {}
-        )
+        extra_kwargs: dict[str, Any] = {}
+
+        if self.runs_balancer:
+            extra_kwargs.update(
+                {
+                    "balancer_username": self.cluster.balancer_username,
+                    "balancer_password": self.cluster.balancer_password,
+                    "balancer_uris": self.cluster.balancer_uris,
+                }
+            )
+
+        if self.runs_controller:
+            extra_kwargs.update(
+                {
+                    "controller_quorum_uris": self.cluster.controller_quorum_uris,
+                }
+            )
 
         return PeerCluster(
             relation=self.peer_cluster_relation,
             data_interface=PeerClusterData(self.model, PEER_CLUSTER_RELATION),
-            **balancer_kwargs,
+            **extra_kwargs,
         )
 
     @property
     def peer_cluster(self) -> PeerCluster:
-        """The state for the related `peer-cluster` application that this charm is providing to."""
-        return PeerCluster(
-            relation=self.peer_cluster_orchestrator_relation,
-            data_interface=PeerClusterOrchestratorData(
-                self.model, PEER_CLUSTER_ORCHESTRATOR_RELATION
-            ),
-        )
-
-    @property
-    def balancer(self) -> PeerCluster:
         """The state for the `peer-cluster-orchestrator` related balancer application."""
-        balancer_kwargs: dict[str, Any] = (
-            {
-                "balancer_username": self.cluster.balancer_username,
-                "balancer_password": self.cluster.balancer_password,
-                "balancer_uris": self.cluster.balancer_uris,
-            }
-            if self.runs_balancer
-            else {}
-        )
+        extra_kwargs: dict[str, Any] = {}
 
-        if self.runs_broker:  # must be providing, initialise with necessary broker data
+        if self.runs_controller or self.runs_balancer:
+            extra_kwargs.update(
+                {
+                    "balancer_username": self.cluster.balancer_username,
+                    "balancer_password": self.cluster.balancer_password,
+                    "balancer_uris": self.cluster.balancer_uris,
+                    "controller_quorum_uris": self.cluster.controller_quorum_uris,
+                }
+            )
+
+        # FIXME: `cluster_manager` check instead of running broker
+        # must be providing, initialise with necessary broker data
+        if self.runs_broker:
             return PeerCluster(
                 relation=self.peer_cluster_orchestrator_relation,  # if same app, this will be None and OK
                 data_interface=PeerClusterOrchestratorData(
@@ -185,12 +189,13 @@ class ClusterState(Object):
                 broker_username=ADMIN_USER,
                 broker_password=self.cluster.internal_user_credentials.get(ADMIN_USER, ""),
                 broker_uris=self.bootstrap_server,
+                cluster_uuid=self.cluster.cluster_uuid,
                 racks=self.racks,
                 broker_capacities=self.broker_capacities,
                 zk_username=self.zookeeper.username,
                 zk_password=self.zookeeper.password,
                 zk_uris=self.zookeeper.uris,
-                **balancer_kwargs,  # in case of roles=broker,balancer on this app
+                **extra_kwargs,  # in case of roles=broker,[balancer,controller] on this app
             )
 
         else:  # must be roles=balancer only then, only load with necessary balancer data
@@ -346,7 +351,11 @@ class ClusterState(Object):
     def enabled_auth(self) -> list[AuthMap]:
         """The currently enabled auth.protocols and their auth.mechanisms, based on related applications."""
         enabled_auth = []
-        if self.client_relations or self.runs_balancer or self.peer_cluster_orchestrator_relation:
+        if (
+            self.client_relations
+            or self.runs_balancer
+            or BALANCER.value in self.peer_cluster_orchestrator.roles
+        ):
             enabled_auth.append(self.default_auth)
         if self.oauth_relation:
             enabled_auth.append(AuthMap(self.default_auth.protocol, "OAUTHBEARER"))
@@ -394,6 +403,21 @@ class ClusterState(Object):
                 ]
             )
         )
+
+    @property
+    def controller_quorum_uris(self) -> str:
+        """The current controller quorum uris when running KRaft mode."""
+        # FIXME: when running broker node.id will be unit-id + 100. If unit is only running
+        # the controller node.id == unit-id. This way we can keep a human readable mapping of ids.
+        if self.runs_controller:
+            node_offset = KRAFT_NODE_ID_OFFSET if self.runs_broker else 0
+            return ",".join(
+                [
+                    f"{broker.unit_id + node_offset}@{broker.host}:{CONTROLLER_PORT}"
+                    for broker in self.brokers
+                ]
+            )
+        return ""
 
     @property
     def log_dirs(self) -> str:
@@ -447,7 +471,7 @@ class ClusterState(Object):
         if not self.peer_relation:
             return Status.NO_PEER_RELATION
 
-        for status in [self._broker_status, self._balancer_status]:
+        for status in [self._broker_status, self._balancer_status, self._controller_status]:
             if status != Status.ACTIVE:
                 return status
 
@@ -462,22 +486,31 @@ class ClusterState(Object):
         if not self.peer_cluster_relation and not self.runs_broker:
             return Status.NO_PEER_CLUSTER_RELATION
 
-        if not self.balancer.broker_connected:
+        if not self.peer_cluster.broker_connected:
             return Status.NO_BROKER_DATA
 
-        if len(self.balancer.broker_capacities.get("brokerCapacities", [])) < MIN_REPLICAS:
+        if len(self.peer_cluster.broker_capacities.get("brokerCapacities", [])) < MIN_REPLICAS:
             return Status.NOT_ENOUGH_BROKERS
 
         return Status.ACTIVE
 
     @property
-    def _broker_status(self) -> Status:
+    def _broker_status(self) -> Status:  # noqa: C901
         """Checks for role=broker specific readiness."""
         if not self.runs_broker:
             return Status.ACTIVE
 
-        # FIXME
-        if not self.runs_controller:
+        # Neither ZooKeeper or KRaft are active
+        if self.kraft_mode is None:
+            return Status.MISSING_MODE
+
+        if self.kraft_mode:
+            if not self.peer_cluster.controller_quorum_uris:  # FIXME: peer_cluster or cluster?
+                return Status.NO_QUORUM_URIS
+            if not self.cluster.cluster_uuid:
+                return Status.NO_CLUSTER_UUID
+
+        if self.kraft_mode == False:  # noqa: E712
             if not self.zookeeper:
                 return Status.ZK_NOT_RELATED
 
@@ -495,6 +528,37 @@ class ClusterState(Object):
             return Status.NO_BROKER_CREDS
 
         return Status.ACTIVE
+
+    @property
+    def _controller_status(self) -> Status:
+        """Checks for role=controller specific readiness."""
+        if not self.runs_controller:
+            return Status.ACTIVE
+
+        if not self.peer_cluster_relation and not self.runs_broker:
+            return Status.NO_PEER_CLUSTER_RELATION
+
+        if not self.peer_cluster.broker_connected_kraft_mode:
+            return Status.NO_BROKER_DATA
+
+        return Status.ACTIVE
+
+    @property
+    def kraft_mode(self) -> bool | None:
+        """Is the deployment running in KRaft mode?
+
+        Returns:
+            True if Kraft mode, False if ZooKeeper, None when undefined.
+        """
+        # NOTE: self.roles when running colocated, peer_cluster.roles when multiapp
+        if CONTROLLER.value in (self.roles + self.peer_cluster.roles):
+            return True
+        if self.zookeeper_relation:
+            return False
+
+        # FIXME raise instead of none. `not kraft_mode` is falsy
+        # NOTE: if previous checks are not met, we don't know yet how the charm is being deployed
+        return None
 
     @property
     def runs_balancer(self) -> bool:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -407,6 +407,10 @@ class KafkaCluster(RelationState):
         """Persisted balancer uris."""
         return self.relation_data.get("balancer-uris", "")
 
+    @property
+    def cluster_uuid(self) -> str:
+        """Cluster uuid used for initializing storages."""
+        return self.relation_data.get("cluster-uuid", "")
 
 class KafkaBroker(RelationState):
     """State collection metadata for a unit."""

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -93,6 +93,8 @@ class PeerCluster(RelationState):
         broker_username: str = "",
         broker_password: str = "",
         broker_uris: str = "",
+        cluster_uuid: str = "",
+        controller_quorum_uris: str = "",
         racks: int = 0,
         broker_capacities: BrokerCapacities = {},
         zk_username: str = "",
@@ -106,6 +108,8 @@ class PeerCluster(RelationState):
         self._broker_username = broker_username
         self._broker_password = broker_password
         self._broker_uris = broker_uris
+        self._cluster_uuid = cluster_uuid
+        self._controller_quorum_uris = controller_quorum_uris
         self._racks = racks
         self._broker_capacities = broker_capacities
         self._zk_username = zk_username
@@ -173,6 +177,38 @@ class PeerCluster(RelationState):
             relation=self.relation,
             fields=BALANCER.requested_secrets,
         ).get("broker-uris", "")
+
+    @property
+    def controller_quorum_uris(self) -> str:
+        """The quorum voters in KRaft mode."""
+        if self._controller_quorum_uris:
+            return self._controller_quorum_uris
+
+        if not self.relation or not self.relation.app:
+            return ""
+
+        return (
+            self.data_interface.fetch_relation_field(
+                relation_id=self.relation.id, field="controller-quorum-uris"
+            )
+            or ""
+        )
+
+    @property
+    def cluster_uuid(self) -> str:
+        """The cluster uuid used to format storages in KRaft mode."""
+        if self._cluster_uuid:
+            return self._cluster_uuid
+
+        if not self.relation or not self.relation.app:
+            return ""
+
+        return (
+            self.data_interface.fetch_relation_field(
+                relation_id=self.relation.id, field="cluster-uuid"
+            )
+            or ""
+        )
 
     @property
     def racks(self) -> int:
@@ -303,6 +339,7 @@ class PeerCluster(RelationState):
     @property
     def broker_connected(self) -> bool:
         """Checks if there is an active broker relation with all necessary data."""
+        # FIXME rename to specify balancer-broker connection
         if not all(
             [
                 self.broker_username,
@@ -315,6 +352,14 @@ class PeerCluster(RelationState):
                 # rack is optional, empty if not rack-aware
             ]
         ):
+            return False
+
+        return True
+
+    @property
+    def broker_connected_kraft_mode(self) -> bool:
+        """Checks for necessary data required by a controller."""
+        if not all([self.broker_username, self.broker_password, self.cluster_uuid]):
             return False
 
         return True
@@ -408,9 +453,15 @@ class KafkaCluster(RelationState):
         return self.relation_data.get("balancer-uris", "")
 
     @property
+    def controller_quorum_uris(self) -> str:
+        """Persisted controller quorum voters."""
+        return self.relation_data.get("controller-quorum-uris", "")
+
+    @property
     def cluster_uuid(self) -> str:
         """Cluster uuid used for initializing storages."""
         return self.relation_data.get("cluster-uuid", "")
+
 
 class KafkaBroker(RelationState):
     """State collection metadata for a unit."""

--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -10,7 +10,7 @@ from enum import Enum
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import Field, validator
 
-from literals import BALANCER, BROKER, SUBSTRATE
+from literals import BALANCER, BROKER, CONTROLLER, SUBSTRATE
 
 logger = logging.getLogger(__name__)
 
@@ -261,7 +261,7 @@ class CharmConfig(BaseConfigModel):
         """Check roles values."""
         roles = set(map(str.strip, value.split(",")))
 
-        if unknown_roles := roles - {BROKER.value, BALANCER.value}:
+        if unknown_roles := roles - {BROKER.value, BALANCER.value, CONTROLLER.value}:
             raise ValueError("Unknown role(s):", unknown_roles)
 
         return ",".join(sorted(roles))  # this has to be a string as it goes in to properties

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -33,14 +33,6 @@ class CharmedKafkaPaths:
         return f"{self.conf_path}/server.properties"
 
     @property
-    def controller_properties(self):
-        """The controller.properties filepath.
-
-        Contains all the main configuration for the service when running in KRaft mode.
-        """
-        return f"{self.conf_path}/controller.properties"
-
-    @property
     def client_properties(self):
         """The main client.properties filepath.
 

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -33,6 +33,14 @@ class CharmedKafkaPaths:
         return f"{self.conf_path}/server.properties"
 
     @property
+    def controller_properties(self):
+        """The controller.properties filepath.
+
+        Contains all the main configuration for the service when running in KRaft mode.
+        """
+        return f"{self.conf_path}/controller.properties"
+
+    @property
     def client_properties(self):
         """The main client.properties filepath.
 

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -169,7 +169,7 @@ class BalancerOperator(Object):
                 content_changed = True
 
         # On k8s, adding/removing a broker does not change the bootstrap server property if exposed by nodeport
-        broker_capacities = self.charm.state.balancer.broker_capacities
+        broker_capacities = self.charm.state.peer_cluster.broker_capacities
         if (
             file_content := json.loads(
                 "".join(self.workload.read(self.workload.paths.capacity_jbod_json))
@@ -200,8 +200,8 @@ class BalancerOperator(Object):
             available_brokers = [broker.unit_id for broker in self.charm.state.brokers]
         else:
             brokers = (
-                [broker.name for broker in self.charm.state.balancer.relation.units]
-                if self.charm.state.balancer.relation
+                [broker.name for broker in self.charm.state.peer_cluster.relation.units]
+                if self.charm.state.peer_cluster.relation
                 else []
             )
             available_brokers = [int(broker.split("/")[1]) for broker in brokers]

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -43,10 +43,10 @@ from literals import (
 )
 from managers.auth import AuthManager
 from managers.balancer import BalancerManager
-from managers.config import TESTING_OPTIONS, ConfigManager
+from managers.config import TESTING_OPTIONS, ConfigManager, ControllerConfigManager
 from managers.k8s import K8sManager
 from managers.tls import TLSManager
-from workload import KafkaWorkload
+from workload import ControllerWorkload, KafkaWorkload
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
@@ -66,6 +66,7 @@ class BrokerOperator(Object):
                 self.charm.unit.get_container(CONTAINER) if self.charm.substrate == "k8s" else None
             )
         )
+        self.controller_workload = ControllerWorkload()
 
         self.tls_manager = TLSManager(
             state=self.charm.state,
@@ -98,6 +99,11 @@ class BrokerOperator(Object):
             workload=self.workload,
             config=self.charm.config,
             current_version=self.upgrade.current_version,
+        )
+        self.controller_config_manager = ControllerConfigManager(
+            state=self.charm.state,
+            workload=self.controller_workload,
+            config=self.charm.config,
         )
         self.auth_manager = AuthManager(
             state=self.charm.state,
@@ -162,6 +168,9 @@ class BrokerOperator(Object):
         # don't want to run default start/pebble-ready events during upgrades
         if not self.upgrade.idle:
             return
+
+        self.controller_config_manager.set_controller_properties()
+        self.controller_workload.start()
 
         self.charm._set_status(self.charm.state.ready_to_start)
         if not isinstance(self.charm.unit.status, ActiveStatus):

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -33,6 +33,7 @@ from health import KafkaHealth
 from literals import (
     BROKER,
     CONTAINER,
+    CONTROLLER,
     DEPENDENCIES,
     GROUP,
     INTERNAL_USERS,
@@ -76,7 +77,7 @@ class BrokerOperator(Object):
         )
 
         # Fast exit after workload instantiation, but before any event observer
-        if BROKER.value not in self.charm.config.roles:
+        if not any(role in self.charm.config.roles for role in [BROKER.value, CONTROLLER.value]):
             return
 
         self.health = KafkaHealth(self) if self.charm.substrate == "vm" else None
@@ -151,7 +152,7 @@ class BrokerOperator(Object):
                 f"{TESTING_OPTIONS}"
             )
 
-    def _on_start(self, event: StartEvent | PebbleReadyEvent) -> None:
+    def _on_start(self, event: StartEvent | PebbleReadyEvent) -> None:  # noqa: C901
         """Handler for `start` or `pebble-ready` events."""
         if not self.workload.container_can_connect:
             event.defer()
@@ -166,32 +167,18 @@ class BrokerOperator(Object):
         if not self.upgrade.idle:
             return
 
-        # NOTE make init_server no-op and always run
-        if self.charm.state.runs_controller:
-            if not self.charm.state.cluster.cluster_uuid and self.model.unit.is_leader():
-                uuid = self.workload.run_bin_command(bin_keyword="storage", bin_args=["random-uuid", "2>", "/dev/null"]).strip()
-                self.charm.state.cluster.update({"cluster-uuid": uuid})
-
-            if not self.charm.state.cluster.internal_user_credentials and self.model.unit.is_leader():
-                for username, password in self._create_internal_credentials():
-                    self.charm.state.cluster.update({f"{username}-password": password})
-
-            if not self.charm.state.cluster.cluster_uuid or not self.charm.state.cluster.internal_user_credentials:
-                event.defer()
-                self.charm._set_status(Status.NO_BROKER_CREDS)
-                return
-
-            self.config_manager.set_server_properties()
-            self.workload.format_storages(
-                uuid=self.charm.state.cluster.cluster_uuid,
-                internal_user_credentials=self.charm.state.cluster.internal_user_credentials,
-            )
+        if self.charm.state.kraft_mode:
+            self._init_kraft_mode()
 
         # FIXME ready to start probably needs to account for credentials being created beforehand
         self.charm._set_status(self.charm.state.ready_to_start)
         if not isinstance(self.charm.unit.status, ActiveStatus):
             event.defer()
             return
+
+        if self.charm.state.kraft_mode:
+            self.config_manager.set_server_properties()
+            self._format_storages()
 
         self.update_external_services()
 
@@ -217,12 +204,19 @@ class BrokerOperator(Object):
         self.workload.start()
         logger.info("Kafka service started")
 
-        # Update users
-        if self.charm.state.runs_controller:
-            for username, password in self.charm.state.cluster.internal_user_credentials.items():
-                self.auth_manager.add_user(
-                    username=username, password=password, zk_auth=False, internal=True,
-                )
+        # TODO: Update users. Not sure if this is the best place, as cluster might be still
+        # stabilizing.
+        # if self.charm.state.kraft_mode and self.charm.state.runs_broker:
+        #     for username, password in self.charm.state.cluster.internal_user_credentials.items():
+        #         try:
+        #             self.auth_manager.add_user(
+        #                username=username, password=password, zk_auth=False, internal=True,
+        #             )
+        #         except subprocess.CalledProcessError:
+        #             logger.warning("Error adding users, cluster might not be ready yet")
+        #             logger.error(f"\n\tOn start:\nAdding user {username} failed. Let the rest of the hook run\n")
+        #             # event.defer()
+        #             continue
 
         # service_start might fail silently, confirm with ZK if kafka is actually connected
         self.charm.on.update_status.emit()
@@ -318,7 +312,7 @@ class BrokerOperator(Object):
         if self.model.relations.get(REL_NAME, None) and self.charm.unit.is_leader():
             self.update_client_data()
 
-        if self.charm.state.peer_cluster_relation and self.charm.unit.is_leader():
+        if self.charm.state.peer_cluster_orchestrator_relation and self.charm.unit.is_leader():
             self.update_peer_cluster_data()
 
     def _on_update_status(self, _: UpdateStatusEvent) -> None:
@@ -326,7 +320,7 @@ class BrokerOperator(Object):
         if not self.upgrade.idle or not self.healthy:
             return
 
-        if not self.charm.state.runs_controller:
+        if not self.charm.state.kraft_mode:
             if not self.charm.state.zookeeper.broker_active():
                 self.charm._set_status(Status.ZK_NOT_CONNECTED)
                 return
@@ -368,7 +362,7 @@ class BrokerOperator(Object):
         self.charm.state.unit_broker.update({"storages": self.balancer_manager.storages})
 
         # FIXME: if KRaft, don't execute
-        if self.charm.substrate == "vm" and not self.charm.state.runs_controller:
+        if self.charm.substrate == "vm" and not self.charm.state.kraft_mode:
             # new dirs won't be used until topic partitions are assigned to it
             # either automatically for new topics, or manually for existing
             # set status only for running services, not on startup
@@ -423,22 +417,49 @@ class BrokerOperator(Object):
 
         return True
 
-    def _create_internal_credentials(self) -> list[tuple[str, str]]:
-        """Creates internal SCRAM users during cluster start.
+    def _init_kraft_mode(self) -> None:
+        """Initialize the server when running controller mode."""
+        # NOTE: checks for `runs_broker` in this method should be `is_cluster_manager` in
+        # the large deployment feature.
+        if not self.model.unit.is_leader():
+            return
 
-        Returns:
-            List of (username, password) for all internal users
+        if not self.charm.state.cluster.internal_user_credentials and self.charm.state.runs_broker:
+            credentials = [
+                (username, self.charm.workload.generate_password()) for username in INTERNAL_USERS
+            ]
+            for username, password in credentials:
+                self.charm.state.cluster.update({f"{username}-password": password})
 
-        Raises:
-            RuntimeError if called from non-leader unit
-            KeyError if attempted to update non-leader unit
-            subprocess.CalledProcessError if command to ZooKeeper failed
-        """
-        credentials = [
-            (username, self.charm.workload.generate_password()) for username in INTERNAL_USERS
-        ]
+        # cluster-uuid is only created on the broker (`cluster-manager` in large deployments)
+        if not self.charm.state.cluster.cluster_uuid and self.charm.state.runs_broker:
+            uuid = self.workload.run_bin_command(
+                bin_keyword="storage", bin_args=["random-uuid", "2>", "/dev/null"]
+            ).strip()
+            self.charm.state.cluster.update({"cluster-uuid": uuid})
+            self.charm.state.peer_cluster.update({"cluster-uuid": uuid})
 
-        return credentials
+        # Controller is tasked with populating quorum uris
+        if self.charm.state.runs_controller:
+            quorum_uris = {"controller-quorum-uris": self.charm.state.controller_quorum_uris}
+            self.charm.state.cluster.update(quorum_uris)
+
+            if self.charm.state.peer_cluster_orchestrator:
+                self.charm.state.peer_cluster_orchestrator.update(quorum_uris)
+
+    def _format_storages(self) -> None:
+        """Format storages provided relevant keys exist."""
+        if self.charm.state.runs_broker:
+            credentials = self.charm.state.cluster.internal_user_credentials
+        elif self.charm.state.runs_controller:
+            credentials = {
+                self.charm.state.peer_cluster.broker_username: self.charm.state.peer_cluster.broker_password
+            }
+
+        self.workload.format_storages(
+            uuid=self.charm.state.peer_cluster.cluster_uuid,
+            internal_user_credentials=credentials,
+        )
 
     def update_external_services(self) -> None:
         """Attempts to update any external Kubernetes services."""
@@ -485,17 +506,18 @@ class BrokerOperator(Object):
         if not self.charm.unit.is_leader() or not self.healthy:
             return
 
-        self.charm.state.balancer.update(
+        self.charm.state.peer_cluster.update(
             {
                 "roles": self.charm.state.roles,
-                "broker-username": self.charm.state.balancer.broker_username,
-                "broker-password": self.charm.state.balancer.broker_password,
-                "broker-uris": self.charm.state.balancer.broker_uris,
-                "racks": str(self.charm.state.balancer.racks),
-                "broker-capacities": json.dumps(self.charm.state.balancer.broker_capacities),
-                "zk-uris": self.charm.state.balancer.zk_uris,
-                "zk-username": self.charm.state.balancer.zk_username,
-                "zk-password": self.charm.state.balancer.zk_password,
+                "broker-username": self.charm.state.peer_cluster.broker_username,
+                "broker-password": self.charm.state.peer_cluster.broker_password,
+                "broker-uris": self.charm.state.peer_cluster.broker_uris,
+                "cluster-uuid": self.charm.state.peer_cluster.cluster_uuid,
+                "racks": str(self.charm.state.peer_cluster.racks),
+                "broker-capacities": json.dumps(self.charm.state.peer_cluster.broker_capacities),
+                "zk-uris": self.charm.state.peer_cluster.zk_uris,
+                "zk-username": self.charm.state.peer_cluster.zk_username,
+                "zk-password": self.charm.state.peer_cluster.zk_password,
             }
         )
 

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -16,13 +16,20 @@ from charms.data_platform_libs.v0.data_interfaces import (
     diff,
     set_encoded_field,
 )
-from ops.charm import RelationChangedEvent, RelationCreatedEvent, RelationEvent, SecretChangedEvent
+from ops.charm import (
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+    RelationEvent,
+    SecretChangedEvent,
+)
 from ops.framework import Object
 
 from core.cluster import custom_secret_groups
 from literals import (
     BALANCER,
     BROKER,
+    CONTROLLER,
     PEER_CLUSTER_ORCHESTRATOR_RELATION,
     PEER_CLUSTER_RELATION,
 )
@@ -72,18 +79,20 @@ class PeerClusterEventsHandler(Object):
         if not self.charm.unit.is_leader() or not event.relation.app:
             return
 
-        requested_secrets = (
-            BALANCER.requested_secrets
-            if self.charm.state.runs_balancer
-            else BROKER.requested_secrets
-        ) or []
+        requested_secrets = set()
+        if self.charm.state.runs_balancer:
+            requested_secrets |= set(BALANCER.requested_secrets)
+        if self.charm.state.runs_controller:
+            requested_secrets |= set(CONTROLLER.requested_secrets)
+        if self.charm.state.runs_broker:
+            requested_secrets |= set(BROKER.requested_secrets)
 
         # request secrets for the relation
         set_encoded_field(
             event.relation,
             self.charm.state.cluster.app,
             REQ_SECRET_FIELDS,
-            requested_secrets,
+            list(requested_secrets),
         )
 
         # explicitly update the roles early, as we can't determine which model to instantiate
@@ -92,21 +101,19 @@ class PeerClusterEventsHandler(Object):
 
     def _on_peer_cluster_changed(self, event: RelationChangedEvent) -> None:
         """Generic handler for peer-cluster `relation-changed` events."""
-        if (
-            not self.charm.unit.is_leader()
-            or not self.charm.state.runs_balancer  # only balancer needs handle this event
-            or not self.charm.state.balancer.roles  # ensures secrets have set-up before writing
-        ):
+        # ensures secrets have set-up before writing
+        if not self.charm.unit.is_leader() or not self.charm.state.peer_cluster.roles:
             return
 
         self._default_relation_changed(event)
 
         # will no-op if relation does not exist
-        self.charm.state.balancer.update(
+        self.charm.state.peer_cluster.update(
             {
-                "balancer-username": self.charm.state.balancer.balancer_username,
-                "balancer-password": self.charm.state.balancer.balancer_password,
-                "balancer-uris": self.charm.state.balancer.balancer_uris,
+                "balancer-username": self.charm.state.peer_cluster.balancer_username,
+                "balancer-password": self.charm.state.peer_cluster.balancer_password,
+                "balancer-uris": self.charm.state.peer_cluster.balancer_uris,
+                "controller-quorum-uris": self.charm.state.peer_cluster.controller_quorum_uris,
             }
         )
 
@@ -114,32 +121,64 @@ class PeerClusterEventsHandler(Object):
 
     def _on_peer_cluster_orchestrator_changed(self, event: RelationChangedEvent) -> None:
         """Generic handler for peer-cluster-orchestrator `relation-changed` events."""
+        # TODO: `cluster_manager` check instead of runs_broker
         if (
             not self.charm.unit.is_leader()
             or not self.charm.state.runs_broker  # only broker needs handle this event
-            or "balancer"
-            not in self.charm.state.balancer.roles  # ensures secrets have set-up before writing, and only writing to balancers
+            or not any(
+                role in self.charm.state.peer_cluster.roles
+                for role in [BALANCER.value, CONTROLLER.value]
+            )  # ensures secrets have set-up before writing, and only writing to controller,balancers
         ):
             return
 
         self._default_relation_changed(event)
 
         # will no-op if relation does not exist
-        self.charm.state.balancer.update(
+        self.charm.state.peer_cluster.update(
             {
                 "roles": self.charm.state.roles,
-                "broker-username": self.charm.state.balancer.broker_username,
-                "broker-password": self.charm.state.balancer.broker_password,
-                "broker-uris": self.charm.state.balancer.broker_uris,
-                "racks": str(self.charm.state.balancer.racks),
-                "broker-capacities": json.dumps(self.charm.state.balancer.broker_capacities),
-                "zk-uris": self.charm.state.balancer.zk_uris,
-                "zk-username": self.charm.state.balancer.zk_username,
-                "zk-password": self.charm.state.balancer.zk_password,
+                "broker-username": self.charm.state.peer_cluster.broker_username,
+                "broker-password": self.charm.state.peer_cluster.broker_password,
+                "broker-uris": self.charm.state.peer_cluster.broker_uris,
+                "cluster-uuid": self.charm.state.peer_cluster.cluster_uuid,
+                "racks": str(self.charm.state.peer_cluster.racks),
+                "broker-capacities": json.dumps(self.charm.state.peer_cluster.broker_capacities),
+                "zk-uris": self.charm.state.peer_cluster.zk_uris,
+                "zk-username": self.charm.state.peer_cluster.zk_username,
+                "zk-password": self.charm.state.peer_cluster.zk_password,
             }
         )
 
         self.charm.on.config_changed.emit()  # ensure both broker+balancer get a changed event
+
+    def _on_peer_cluster_broken(self, _: RelationBrokenEvent):
+        """Handle the required logic to remove."""
+        if self.charm.state.kraft_mode is not None:
+            return
+
+        self.charm.workload.stop()
+        logger.info(f'Service {self.model.unit.name.split("/")[1]} stopped')
+
+        # FIXME: probably a mix between cluster_manager and broker
+        if self.charm.state.runs_broker:
+            # Kafka keeps a meta.properties in every log.dir with a unique ClusterID
+            # this ID is provided by ZK, and removing it on relation-broken allows
+            # re-joining to another ZK cluster.
+            for storage in self.charm.model.storages["data"]:
+                self.charm.workload.exec(
+                    [
+                        "rm",
+                        f"{storage.location}/meta.properties",
+                        f"{storage.location}/__cluster_metadata-0/quorum-state",
+                    ]
+                )
+
+            if self.charm.unit.is_leader():
+                # other charm methods assume credentials == ACLs
+                # necessary to clean-up credentials once ZK relation is lost
+                for username in self.charm.state.cluster.internal_user_credentials:
+                    self.charm.state.cluster.update({f"{username}-password": ""})
 
     def _default_relation_changed(self, event: RelationChangedEvent):
         """Implements required logic from multiple 'handled' events from the `data-interfaces` library."""

--- a/src/literals.py
+++ b/src/literals.py
@@ -86,6 +86,8 @@ SECURITY_PROTOCOL_PORTS: dict[AuthMap, Ports] = {
     AuthMap("SASL_PLAINTEXT", "OAUTHBEARER"): Ports(9095, 19095, 29095),
     AuthMap("SASL_SSL", "OAUTHBEARER"): Ports(9096, 19096, 29096),
 }
+# FIXME this port should exist on the previous abstraction
+CONTROLLER_PORT = 9097
 
 DebugLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
 DatabagScope = Literal["unit", "app"]
@@ -114,12 +116,6 @@ PATHS = {
         "DATA": f"/var/snap/{SNAP_NAME}/common/var/lib/cruise-control",
         "BIN": f"/snap/{SNAP_NAME}/current/opt/cruise-control",
     },
-    "kraft": {
-        "CONF": f"/var/snap/{SNAP_NAME}/current/etc/kraft",
-        "LOGS": f"/var/snap/{SNAP_NAME}/common/var/log/kraft",
-        "DATA": f"/var/snap/{SNAP_NAME}/common/var/lib/kraft",
-        "BIN": f"/snap/{SNAP_NAME}/current/opt/kraft",
-    },
 }
 
 
@@ -147,6 +143,13 @@ BROKER = Role(
         "balancer-uris",
     ],
 )
+CONTROLLER = Role(
+    value="controller",
+    service="daemon",
+    paths=PATHS["kafka"],
+    relation=PEER_CLUSTER_RELATION,
+    requested_secrets=[],
+)
 BALANCER = Role(
     value="balancer",
     service="cruise-control",
@@ -160,13 +163,6 @@ BALANCER = Role(
         "zk-password",
         "zk-uris",
     ],
-)
-CONTROLLER = Role(
-    value="controller",
-    service="controller",
-    paths=PATHS["kraft"],
-    relation=PEER_CLUSTER_ORCHESTRATOR_RELATION,
-    requested_secrets=[],
 )
 
 DEFAULT_BALANCER_GOALS = [

--- a/src/literals.py
+++ b/src/literals.py
@@ -12,7 +12,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase
 
 CHARM_KEY = "kafka"
 SNAP_NAME = "charmed-kafka"
-CHARMED_KAFKA_SNAP_REVISION = 39
+CHARMED_KAFKA_SNAP_REVISION = 42
 CONTAINER = "kafka"
 SUBSTRATE = "vm"
 STORAGE = "data"
@@ -114,6 +114,12 @@ PATHS = {
         "DATA": f"/var/snap/{SNAP_NAME}/common/var/lib/cruise-control",
         "BIN": f"/snap/{SNAP_NAME}/current/opt/cruise-control",
     },
+    "kraft": {
+        "CONF": f"/var/snap/{SNAP_NAME}/current/etc/kraft",
+        "LOGS": f"/var/snap/{SNAP_NAME}/common/var/log/kraft",
+        "DATA": f"/var/snap/{SNAP_NAME}/common/var/lib/kraft",
+        "BIN": f"/snap/{SNAP_NAME}/current/opt/kraft",
+    },
 }
 
 
@@ -154,6 +160,13 @@ BALANCER = Role(
         "zk-password",
         "zk-uris",
     ],
+)
+CONTROLLER = Role(
+    value="controller",
+    service="controller",
+    paths=PATHS["kraft"],
+    relation=PEER_CLUSTER_ORCHESTRATOR_RELATION,
+    requested_secrets=[],
 )
 
 DEFAULT_BALANCER_GOALS = [

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -136,7 +136,9 @@ class AuthManager:
 
         return consumer_acls
 
-    def add_user(self, username: str, password: str, zk_auth: bool = False) -> None:
+    def add_user(
+        self, username: str, password: str, zk_auth: bool = False, internal: bool = False
+    ) -> None:
         """Adds new user credentials to ZooKeeper.
 
         Args:
@@ -144,6 +146,7 @@ class AuthManager:
             password: the user password
             zk_auth: flag to specify adding users using ZooKeeper authorizer
                 For use before cluster start
+            internal: flag to use internal ports or client ones
 
         Raises:
             `(subprocess.CalledProcessError | ops.pebble.ExecError)`: if the error returned a non-zero exit code
@@ -164,8 +167,9 @@ class AuthManager:
             ]
             opts = [self.kafka_opts]
         else:
+            bootstrap_server = f"{self.state.unit_broker.internal_address}:19092" if internal else self.state.bootstrap_server
             command = base_command + [
-                f"--bootstrap-server={self.state.bootstrap_server}",
+                f"--bootstrap-server={bootstrap_server}",
                 f"--command-config={self.workload.paths.client_properties}",
             ]
             opts = []

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -13,6 +13,7 @@ from ops.pebble import ExecError
 
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
+from literals import SECURITY_PROTOCOL_PORTS
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +168,11 @@ class AuthManager:
             ]
             opts = [self.kafka_opts]
         else:
-            bootstrap_server = f"{self.state.unit_broker.internal_address}:19092" if internal else self.state.bootstrap_server
+            bootstrap_server = (
+                f"{self.state.unit_broker.internal_address}:{SECURITY_PROTOCOL_PORTS[self.state.default_auth].internal}"
+                if internal
+                else self.state.bootstrap_server
+            )
             command = base_command + [
                 f"--bootstrap-server={bootstrap_server}",
                 f"--command-config={self.workload.paths.client_properties}",

--- a/src/managers/balancer.py
+++ b/src/managers/balancer.py
@@ -137,8 +137,8 @@ class BalancerManager:
     def cruise_control(self) -> CruiseControlClient:
         """Client for the CruiseControl REST API."""
         return CruiseControlClient(
-            username=self.charm.state.balancer.balancer_username,
-            password=self.charm.state.balancer.balancer_password,
+            username=self.charm.state.peer_cluster.balancer_username,
+            password=self.charm.state.peer_cluster.balancer_password,
         )
 
     @property
@@ -160,7 +160,7 @@ class BalancerManager:
 
     def create_internal_topics(self) -> None:
         """Create Cruise Control topics."""
-        bootstrap_servers = self.charm.state.balancer.broker_uris
+        bootstrap_servers = self.charm.state.peer_cluster.broker_uris
         property_file = f'{BALANCER.paths["CONF"]}/cruisecontrol.properties'
 
         for topic in BALANCER_TOPICS:

--- a/src/workload.py
+++ b/src/workload.py
@@ -19,7 +19,6 @@ from literals import (
     BALANCER,
     BROKER,
     CHARMED_KAFKA_SNAP_REVISION,
-    CONTROLLER,
     GROUP,
     SNAP_NAME,
     USER,
@@ -185,6 +184,30 @@ class Workload(WorkloadBase):
         command = f"{opts_str} {SNAP_NAME}.{bin_keyword} {bin_str}"
         return self.exec(command)
 
+    def format_storages(self, uuid: str, internal_user_credentials: dict[str, str] | None = None) -> None:
+        """Use a passed uuid to format storages."""
+        # NOTE data dirs have changed permissions by storage_attached hook. For some reason
+        # storage command bin needs these locations to be root owned. Momentarily raise permissions
+        # during the format phase.
+        self.exec(["chown", "-R", "root:root", f"{self.paths.data_path}"])
+
+        command = [
+            "format",
+            "--ignore-formatted",
+            "--cluster-id",
+            uuid,
+            "-c",
+            self.paths.server_properties,
+        ]
+        if internal_user_credentials:
+            for user, password in internal_user_credentials.items():
+                command += ["--add-scram", f"'SCRAM-SHA-512=[name={user},password={password}]'"]
+        self.run_bin_command(bin_keyword="storage", bin_args=command)
+
+        # Drop permissions again for the main process
+        self.exec(["chmod", "-R", "750", f"{self.paths.data_path}"])
+        self.exec(["chown", "-R", f"{USER}:{GROUP}", f"{self.paths.data_path}"])
+
 
 class KafkaWorkload(Workload):
     """Broker specific wrapper."""
@@ -213,21 +236,6 @@ class BalancerWorkload(Workload):
     @override
     def get_version(self) -> str:
         raise NotImplementedError
-
-    @property
-    @override
-    def layer(self) -> pebble.Layer:
-        raise NotImplementedError
-
-
-class ControllerWorkload(Workload):
-    """Controller specific wrapper"""
-
-    def __init__(self, container: Container | None = None) -> None:
-        super().__init__(container=container)
-        self.paths = CharmedKafkaPaths(CONTROLLER)
-        self.service = CONTROLLER.service
-        self.container = container
 
     @property
     @override

--- a/src/workload.py
+++ b/src/workload.py
@@ -19,6 +19,7 @@ from literals import (
     BALANCER,
     BROKER,
     CHARMED_KAFKA_SNAP_REVISION,
+    CONTROLLER,
     GROUP,
     SNAP_NAME,
     USER,
@@ -212,6 +213,21 @@ class BalancerWorkload(Workload):
     @override
     def get_version(self) -> str:
         raise NotImplementedError
+
+    @property
+    @override
+    def layer(self) -> pebble.Layer:
+        raise NotImplementedError
+
+
+class ControllerWorkload(Workload):
+    """Controller specific wrapper"""
+
+    def __init__(self, container: Container | None = None) -> None:
+        super().__init__(container=container)
+        self.paths = CharmedKafkaPaths(CONTROLLER)
+        self.service = CONTROLLER.service
+        self.container = container
 
     @property
     @override

--- a/src/workload.py
+++ b/src/workload.py
@@ -184,7 +184,9 @@ class Workload(WorkloadBase):
         command = f"{opts_str} {SNAP_NAME}.{bin_keyword} {bin_str}"
         return self.exec(command)
 
-    def format_storages(self, uuid: str, internal_user_credentials: dict[str, str] | None = None) -> None:
+    def format_storages(
+        self, uuid: str, internal_user_credentials: dict[str, str] | None = None
+    ) -> None:
         """Use a passed uuid to format storages."""
         # NOTE data dirs have changed permissions by storage_attached hook. For some reason
         # storage command bin needs these locations to be root owned. Momentarily raise permissions

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+import os
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from literals import (
+    CONTROLLER_PORT,
+    PEER_CLUSTER_ORCHESTRATOR_RELATION,
+    PEER_CLUSTER_RELATION,
+    SECURITY_PROTOCOL_PORTS,
+)
+
+from .helpers import (
+    APP_NAME,
+    check_socket,
+    get_address,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.kraft
+
+CONTROLLER_APP = "controller"
+PRODUCER_APP = "producer"
+
+
+class TestKRaft:
+
+    deployment_strat: str = os.environ.get("DEPLOYMENT", "multi")
+    controller_app: str = {"single": APP_NAME, "multi": CONTROLLER_APP}[deployment_strat]
+
+    @pytest.mark.abort_on_fail
+    async def test_build_and_deploy(self, ops_test: OpsTest, kafka_charm):
+        await ops_test.model.add_machine(series="jammy")
+        machine_ids = await ops_test.model.get_machines()
+
+        await asyncio.gather(
+            ops_test.model.deploy(
+                kafka_charm,
+                application_name=APP_NAME,
+                num_units=1,
+                series="jammy",
+                to=machine_ids[0],
+                config={
+                    "roles": "broker,controller" if self.controller_app == APP_NAME else "broker",
+                    "profile": "testing",
+                },
+                trust=True,
+            ),
+            ops_test.model.deploy(
+                "kafka-test-app",
+                application_name=PRODUCER_APP,
+                channel="edge",
+                num_units=1,
+                series="jammy",
+                config={
+                    "topic_name": "HOT-TOPIC",
+                    "num_messages": 100000,
+                    "role": "producer",
+                    "partitions": 20,
+                    "replication_factor": "1",
+                },
+                trust=True,
+            ),
+        )
+
+        if self.controller_app != APP_NAME:
+            await ops_test.model.deploy(
+                kafka_charm,
+                application_name=self.controller_app,
+                num_units=1,
+                series="jammy",
+                config={
+                    "roles": self.controller_app,
+                    "profile": "testing",
+                },
+                trust=True,
+            )
+
+        await ops_test.model.wait_for_idle(
+            apps=list({APP_NAME, self.controller_app}),
+            idle_period=30,
+            timeout=1800,
+            raise_on_error=False,
+        )
+        if self.controller_app != APP_NAME:
+            assert ops_test.model.applications[APP_NAME].status == "blocked"
+            assert ops_test.model.applications[self.controller_app].status == "blocked"
+        else:
+            assert ops_test.model.applications[APP_NAME].status == "active"
+
+    @pytest.mark.abort_on_fail
+    async def test_integrate(self, ops_test: OpsTest):
+        if self.controller_app != APP_NAME:
+            await ops_test.model.add_relation(
+                f"{APP_NAME}:{PEER_CLUSTER_ORCHESTRATOR_RELATION}",
+                f"{CONTROLLER_APP}:{PEER_CLUSTER_RELATION}",
+            )
+
+        await ops_test.model.wait_for_idle(
+            apps=list({APP_NAME, self.controller_app}), idle_period=30
+        )
+
+        async with ops_test.fast_forward(fast_interval="40s"):
+            await asyncio.sleep(120)
+
+        assert ops_test.model.applications[APP_NAME].status == "active"
+        assert ops_test.model.applications[self.controller_app].status == "active"
+
+    @pytest.mark.abort_on_fail
+    async def test_listeners(self, ops_test: OpsTest):
+        address = await get_address(ops_test=ops_test)
+        assert check_socket(
+            address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].internal
+        )  # Internal listener
+
+        # Client listener should not be enabled if there is no relations
+        assert not check_socket(
+            address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
+        )
+
+        # Check controller socket
+        if self.controller_app != APP_NAME:
+            address = await get_address(ops_test=ops_test, app_name=self.controller_app)
+
+        assert check_socket(address, CONTROLLER_PORT)

--- a/tests/unit/scenario/test_kraft.py
+++ b/tests/unit/scenario/test_kraft.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from ops import ActiveStatus
+from scenario import Container, Context, PeerRelation, Relation, State
+
+from charm import KafkaCharm
+from literals import (
+    CONTAINER,
+    PEER,
+    PEER_CLUSTER_ORCHESTRATOR_RELATION,
+    PEER_CLUSTER_RELATION,
+    SUBSTRATE,
+    Status,
+)
+
+pytestmark = pytest.mark.kraft
+
+logger = logging.getLogger(__name__)
+
+
+CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
+ACTIONS = yaml.safe_load(Path("./actions.yaml").read_text())
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+@pytest.fixture()
+def charm_configuration():
+    """Enable direct mutation on configuration dict."""
+    return json.loads(json.dumps(CONFIG))
+
+
+@pytest.fixture()
+def base_state():
+
+    if SUBSTRATE == "k8s":
+        state = State(leader=True, containers=[Container(name=CONTAINER, can_connect=True)])
+
+    else:
+        state = State(leader=True)
+
+    return state
+
+
+def test_ready_to_start_maintenance_no_peer_relation(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    state_in = State(leader=True, relations=[])
+
+    # When
+    state_out = ctx.run("start", state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_PEER_RELATION.value.status
+
+
+def test_ready_to_start_no_peer_cluster(charm_configuration):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    state_in = State(leader=True, relations=[cluster_peer])
+
+    # When
+    state_out = ctx.run("start", state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_PEER_CLUSTER_RELATION.value.status
+
+
+def test_ready_to_start_missing_data_as_controller(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    charm_configuration["options"]["expose-external"]["default"] = "none"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    peer_cluster = Relation(PEER_CLUSTER_RELATION, "peer_cluster")
+    state_in = base_state.replace(relations=[cluster_peer, peer_cluster])
+
+    # When
+    state_out = ctx.run("start", state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_BROKER_DATA.value.status
+
+
+def test_ready_to_start_missing_data_as_broker(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "broker"
+    charm_configuration["options"]["expose-external"]["default"] = "none"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    peer_cluster = Relation(
+        PEER_CLUSTER_ORCHESTRATOR_RELATION, "peer_cluster", remote_app_data={"roles": "controller"}
+    )
+    state_in = base_state.replace(relations=[cluster_peer, peer_cluster])
+
+    # When
+    with patch("workload.KafkaWorkload.run_bin_command", return_value="cluster-uuid-number"):
+        state_out = ctx.run("start", state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_QUORUM_URIS.value.status
+
+
+def test_ready_to_start(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "broker,controller"
+    charm_configuration["options"]["expose-external"]["default"] = "none"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    state_in = base_state.replace(relations=[cluster_peer])
+
+    # When
+    with (
+        patch(
+            "workload.KafkaWorkload.run_bin_command", return_value="cluster-uuid-number"
+        ) as patched_run_bin_command,
+        patch("health.KafkaHealth.machine_configured", return_value=True),
+        patch("workload.KafkaWorkload.start"),
+        patch("charms.operator_libs_linux.v1.snap.SnapCache"),
+    ):
+        state_out = ctx.run("start", state_in)
+
+    # Then
+    # Second call of format will have to pass "cluster-uuid-number" as set above
+    assert "cluster-uuid-number" in patched_run_bin_command.call_args_list[1][1]["bin_args"]
+    assert "cluster-uuid" in state_out.get_relations(PEER)[0].local_app_data
+    assert "controller-quorum-uris" in state_out.get_relations(PEER)[0].local_app_data
+    # Only the internal users should be created.
+    # FIXME: This is a convoluted way to unpack secret contents.
+    # In scenario v7 use "tracked_content" instead to access last revision directly
+    assert all(
+        user in sorted(state_out.secrets[0].contents.items())[-1][1]
+        for user in ("admin-password", "sync-password")
+    )
+    assert state_out.unit_status == ActiveStatus()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -101,12 +101,12 @@ def test_ready_to_start_maintenance_no_peer_relation(harness: Harness[KafkaCharm
     assert harness.charm.unit.status == Status.NO_PEER_RELATION.value.status
 
 
-def test_ready_to_start_blocks_no_zookeeper_relation(harness: Harness[KafkaCharm]):
+def test_ready_to_start_blocks_no_mode(harness: Harness[KafkaCharm]):
     with harness.hooks_disabled():
         harness.add_relation(PEER, CHARM_KEY)
 
     harness.charm.on.start.emit()
-    assert harness.charm.unit.status == Status.ZK_NOT_RELATED.value.status
+    assert harness.charm.unit.status == Status.MISSING_MODE.value.status
 
 
 def test_ready_to_start_waits_no_zookeeper_data(harness: Harness[KafkaCharm]):

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ set_env =
     ha: TEST_FILE=ha/test_ha.py
     balancer-single: DEPLOYMENT=single
     balancer-multi: DEPLOYMENT=multi
+    kraft-single: DEPLOYMENT=single
+    kraft-multi: DEPLOYMENT=multi
 
 pass_env =
     PYTHONPATH
@@ -113,3 +115,16 @@ pass_env =
 commands =
     poetry install --no-root --with integration
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_balancer.py
+
+[testenv:integration-kraft-{single,multi}]
+description = Run KRaft mode tests
+set_env =
+    {[testenv]set_env}
+    # Workaround for https://github.com/python-poetry/poetry/issues/6958
+    POETRY_INSTALLER_PARALLEL = false
+pass_env =
+    {[testenv]pass_env}
+    CI
+commands =
+    poetry install --no-root --with integration
+    poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_kraft.py


### PR DESCRIPTION
### KRaft mode

--------------------
#### TODO
- [x] Co-located `broker,controller` #235
- [x] Extend peer-cluster-orchestrator (Requires #244) #251 
- [x] Multi app setup `broker` <--> `controller` #257 #253
- [x] Unit tests #257
- [x] Integration tests #257
- [ ] General testing integration across ecosystem
- [x] COS integration


---------
## `broker` <--> `controller` roles
Data flow between "controller" and "broker":

![controller-broker-data](https://github.com/user-attachments/assets/f81960f5-5646-4c53-a86d-a2fe73814c2a)

- If an application is a `controller`, write to own databag/peer_cluster the `controller-quorum-uris` as soon as possible. These uris can be set at any given time, since they only depend on IP and unit id.
- If an application is a `broker`, write to own databag/peer_cluster the `cluster-uuid` as soon as possible. At some point this will be a task for the `cluster_manager` instead of the broker.

### Storage formatting
Formatting the storage before starting the cluster is a needed step on KRaft mode:
```
charmed-kafka.storage format --cluster-id $uuid -c server.properties --add-scram 'SCRAM-SHA-512=[name={user},password={password}]'
```
Running this command requires two things from the charm:
- A well formed `server.properties` file. The command will look at `log.dirs` and `metadata.log.dir` and create the metadata files there. But the rest of the properties need to be, at least, format compliant. This implies that a broker also needs the `controller-quorum-uris` to be set on the file before calling `format storages`. So the `broker` needs to wait for the uris before this step.
- Internal users. The `admin` and `sync` users are added to the metadata at the same time as the format is set. Since the internal users are created on the `broker`, the `controller` side needs to wait for the secret to be passed along.

Once those conditions are met, the service is able to start.

### On unit-id / node.id handling
KRaft mode requires all nodes on the cluster (controller, broker) to have unique id numbers. For the time being, the `node.id` setup will be as follows:
- If I'm running `broker`: `node.id = unit-id + 100`
- If I'm running `controller`: `node.id = unit-id`
  - Broker takes precedence, so running `controller,broker`: `node.id = unit-id + 100`


### Other relevant changes: 
- `jaas.file` has been removed when using KRaft. Users are declared on the properties file, passed at init when formatting storages, or created through the kafka commands.
- Adding the internal users (`admin,sync`) through the ACLS has been removed when running KRaft mode. These users are already on the cluster during formatting.