### PR TITLE
[DPE-5532] Gatekeeper failing on kafka-operator repository

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -3,7 +3,7 @@ name: Sync docs from Discourse
 on:
   workflow_dispatch:
   schedule:
-    - cron: '53 0 * * *' # Daily at 00:53 UTC
+    - cron: '33 0 * * *' # Daily at 00:53 UTC
   # Triggered on push to branch "main" by .github/workflows/release.yaml
   workflow_call:
 
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Open PR with docs changes
-        uses: deusebio/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@main
         id: docs-pr
         with:
           discourse_host: discourse.charmhub.io


### PR DESCRIPTION
The repository got to an inconsistent state where the tag was not updated to latest commit, but the content was up to date and in sync with Discourse.

I have just deleted the tags and re-triggered the automation which has created the tag at the tip of `main`. 

I have also noted that we are not using the official repository. It used to have some issues, that got fixed some months ago. In Spark we are already using the official action since a few months, with no issue. Hopefully the glitch that created the inconsistency here may have also been resolved, as a number of optimizations and improvements have been landed as well. 