### PR TITLE
[DPE-5218] Enable compatibility with ZK restore feature

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from charms.operator_libs_linux.v0 import sysctl
 from charms.rolling_ops.v0.rollingops import RollingOpsManager, RunWithLock
 from ops import (
+    CollectStatusEvent,
     EventBase,
     StatusBase,
 )
@@ -73,6 +74,7 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         self.framework.observe(getattr(self.on, "install"), self._on_install)
         self.framework.observe(getattr(self.on, "remove"), self._on_remove)
         self.framework.observe(getattr(self.on, "config_changed"), self._on_roles_changed)
+        self.framework.observe(self.on.collect_app_status, self._on_collect_status)
 
         # peer-cluster events are shared between all roles, so necessary to init here to avoid instantiating multiple times
         self.peer_cluster = PeerClusterEventsHandler(self)
@@ -161,6 +163,9 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         else:
             logger.error(f"Broker {self.unit.name.split('/')[1]} failed to restart")
             return
+
+    def _on_collect_status(self, event: CollectStatusEvent):
+        event.add_status(self.state.ready_to_start.value.status)
 
 
 if __name__ == "__main__":

--- a/src/events/zookeeper.py
+++ b/src/events/zookeeper.py
@@ -87,16 +87,17 @@ class ZooKeeperHandler(Object):
             for username, password in internal_user_credentials:
                 self.charm.state.cluster.update({f"{username}-password": password})
 
-        # Kafka keeps a meta.properties in every log.dir with a unique ClusterID
-        # this ID is provided by ZK, and removing it on relation-changed allows
-        # re-joining a ZK cluster undergoing backup restoration.
-        self.charm.workload.exec(
-            [
-                "bash",
-                "-c",
-                f"""find {self.charm.workload.paths.data_path} -type f -name meta.properties -delete || true""",
-            ]
-        )
+        if not self.charm.state.zookeeper.endpoints:
+            # Kafka keeps a meta.properties in every log.dir with a unique ClusterID
+            # this ID is provided by ZK, and removing it on relation-changed allows
+            # re-joining a ZK cluster undergoing backup restoration.
+            self.charm.workload.exec(
+                [
+                    "bash",
+                    "-c",
+                    f"""find {self.charm.workload.paths.data_path} -type f -name meta.properties -delete || true""",
+                ]
+            )
 
         # attempt re-start of Kafka for all units on zookeeper-changed
         # avoids relying on deferred events elsewhere that may not exist after cluster init

--- a/src/events/zookeeper.py
+++ b/src/events/zookeeper.py
@@ -54,6 +54,18 @@ class ZooKeeperHandler(Object):
 
     def _on_zookeeper_changed(self, event: RelationChangedEvent) -> None:
         """Handler for `zookeeper_relation_created/joined/changed` events, ensuring internal users get created."""
+        if not self.charm.state.zookeeper.endpoints:
+            # Kafka keeps a meta.properties in every log.dir with a unique ClusterID
+            # this ID is provided by ZK, and removing it on relation-changed allows
+            # re-joining a ZK cluster undergoing backup restoration.
+            self.charm.workload.exec(
+                [
+                    "bash",
+                    "-c",
+                    f"""find {self.charm.workload.paths.data_path} -type f -name meta.properties -delete || true""",
+                ]
+            )
+
         if not self.charm.state.zookeeper.zookeeper_connected:
             self.charm._set_status(Status.ZK_NO_DATA)
             return
@@ -86,18 +98,6 @@ class ZooKeeperHandler(Object):
             # only set to relation data when all set
             for username, password in internal_user_credentials:
                 self.charm.state.cluster.update({f"{username}-password": password})
-
-        if not self.charm.state.zookeeper.endpoints:
-            # Kafka keeps a meta.properties in every log.dir with a unique ClusterID
-            # this ID is provided by ZK, and removing it on relation-changed allows
-            # re-joining a ZK cluster undergoing backup restoration.
-            self.charm.workload.exec(
-                [
-                    "bash",
-                    "-c",
-                    f"""find {self.charm.workload.paths.data_path} -type f -name meta.properties -delete || true""",
-                ]
-            )
 
         # attempt re-start of Kafka for all units on zookeeper-changed
         # avoids relying on deferred events elsewhere that may not exist after cluster init

--- a/src/events/zookeeper.py
+++ b/src/events/zookeeper.py
@@ -71,7 +71,7 @@ class ZooKeeperHandler(Object):
             event.defer()
             return
 
-        if not self.charm.state.cluster.internal_user_credentials and self.model.unit.is_leader():
+        if self.model.unit.is_leader():
             # loading the minimum config needed to authenticate to zookeeper
             self.dependent.config_manager.set_zk_jaas_config()
             self.dependent.config_manager.set_server_properties()
@@ -86,6 +86,17 @@ class ZooKeeperHandler(Object):
             # only set to relation data when all set
             for username, password in internal_user_credentials:
                 self.charm.state.cluster.update({f"{username}-password": password})
+
+        # Kafka keeps a meta.properties in every log.dir with a unique ClusterID
+        # this ID is provided by ZK, and removing it on relation-changed allows
+        # re-joining a ZK cluster undergoing backup restoration.
+        self.charm.workload.exec(
+            [
+                "bash",
+                "-c",
+                f"""find {self.charm.workload.paths.data_path} -type f -name meta.properties -delete || true""",
+            ]
+        )
 
         # attempt re-start of Kafka for all units on zookeeper-changed
         # avoids relying on deferred events elsewhere that may not exist after cluster init


### PR DESCRIPTION
See https://github.com/canonical/zookeeper-operator/pull/162 for rationale and explanations.

This PR includes a quick fix for the dreaded `"blocked" == "active"` flaky CI error. I'll be working on that during this pulse and probably the next.