### PR TITLE
[DPE-5226] - refactor: make 'broker' the central relation

### DIFF
--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -124,9 +124,9 @@ class ClusterState(Object):
         return set(self.model.relations[REL_NAME])
 
     @property
-    def peer_cluster_orchestrator_relations(self) -> set[Relation]:
-        """The `peer-cluster-orchestrator` relations that this charm is providing."""
-        return set(self.model.relations[PEER_CLUSTER_ORCHESTRATOR_RELATION])
+    def peer_cluster_orchestrator_relation(self) -> Relation | None:
+        """The `peer-cluster-orchestrator` relation that this charm is providing."""
+        return self.model.get_relation(PEER_CLUSTER_ORCHESTRATOR_RELATION)
 
     @property
     def peer_cluster_relation(self) -> Relation | None:
@@ -134,27 +134,33 @@ class ClusterState(Object):
         return self.model.get_relation(PEER_CLUSTER_RELATION)
 
     @property
-    def peer_clusters(self) -> set[PeerCluster]:
-        """The state for all related `peer-cluster` applications that this charm is providing for."""
-        peer_clusters = set()
-        balancer_kwargs: dict[str, Any] = {
-            "balancer_username": self.cluster.balancer_username,
-            "balancer_password": self.cluster.balancer_password,
-            "balancer_uris": self.cluster.balancer_uris,
-        }
-        for relation in self.peer_cluster_orchestrator_relations:
-            if not relation.app or not self.runs_balancer:
-                continue
+    def peer_cluster_orchestrator(self) -> PeerCluster:
+        """The state for the related `peer-cluster-orchestrator` application that this charm is requiring from."""
+        balancer_kwargs: dict[str, Any] = (
+            {
+                "balancer_username": self.cluster.balancer_username,
+                "balancer_password": self.cluster.balancer_password,
+                "balancer_uris": self.cluster.balancer_uris,
+            }
+            if self.runs_balancer
+            else {}
+        )
 
-            peer_clusters.add(
-                PeerCluster(
-                    relation=relation,
-                    data_interface=PeerClusterOrchestratorData(self.model, relation.name),
-                    **balancer_kwargs,
-                )
-            )
+        return PeerCluster(
+            relation=self.peer_cluster_relation,
+            data_interface=PeerClusterData(self.model, PEER_CLUSTER_RELATION),
+            **balancer_kwargs,
+        )
 
-        return peer_clusters
+    @property
+    def peer_cluster(self) -> PeerCluster:
+        """The state for the related `peer-cluster` application that this charm is providing to."""
+        return PeerCluster(
+            relation=self.peer_cluster_orchestrator_relation,
+            data_interface=PeerClusterOrchestratorData(
+                self.model, PEER_CLUSTER_ORCHESTRATOR_RELATION
+            ),
+        )
 
     # FIXME: will need renaming once we use Kraft as the orchestrator
     # uses the 'already there' BALANCER username now

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -392,17 +392,17 @@ class KafkaCluster(RelationState):
         return self.relation_data.get("mtls", "disabled") == "enabled"
 
     @property
-    def balancer_username(self) -> bool:
+    def balancer_username(self) -> str:
         """Persisted balancer username."""
         return self.relation_data.get("balancer-username", "")
 
     @property
-    def balancer_password(self) -> bool:
+    def balancer_password(self) -> str:
         """Persisted balancer password."""
         return self.relation_data.get("balancer-password", "")
 
     @property
-    def balancer_uris(self) -> bool:
+    def balancer_uris(self) -> str:
         """Persisted balancer uris."""
         return self.relation_data.get("balancer-uris", "")
 

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -107,7 +107,6 @@ class BalancerOperator(Object):
             return
 
         if not self.charm.state.cluster.balancer_password:
-            external_cluster = next(iter(self.charm.state.peer_clusters), None)
             payload = {
                 "balancer-username": BALANCER_WEBSERVER_USER,
                 "balancer-password": self.charm.workload.generate_password(),
@@ -115,8 +114,9 @@ class BalancerOperator(Object):
             }
             # Update relation data intra & extra cluster (if it exists)
             self.charm.state.cluster.update(payload)
-            if external_cluster:
-                external_cluster.update(payload)
+
+            if self.charm.state.peer_cluster_orchestrator:
+                self.charm.state.peer_cluster_orchestrator.update(payload)
 
         self.config_manager.set_cruise_control_properties()
         self.config_manager.set_broker_capacities()

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -61,7 +61,7 @@ class PeerClusterEventsHandler(Object):
 
         # ensures data updates, eventually
         self.framework.observe(
-            getattr(self.charm.on, "update_status"), self._on_peer_cluster_changed
+            getattr(self.charm.on, "update_status"), self._on_peer_cluster_orchestrator_changed
         )
 
     def _on_secret_changed_event(self, _: SecretChangedEvent) -> None:
@@ -94,8 +94,31 @@ class PeerClusterEventsHandler(Object):
         """Generic handler for peer-cluster `relation-changed` events."""
         if (
             not self.charm.unit.is_leader()
-            or not self.charm.state.runs_broker
-            or "balancer" not in self.charm.state.balancer.roles
+            or not self.charm.state.runs_balancer  # only balancer needs handle this event
+            or not self.charm.state.balancer.roles  # ensures secrets have set-up before writing
+        ):
+            return
+
+        self._default_relation_changed(event)
+
+        # will no-op if relation does not exist
+        self.charm.state.balancer.update(
+            {
+                "balancer-username": self.charm.state.balancer.balancer_username,
+                "balancer-password": self.charm.state.balancer.balancer_password,
+                "balancer-uris": self.charm.state.balancer.balancer_uris,
+            }
+        )
+
+        self.charm.on.config_changed.emit()  # ensure both broker+balancer get a changed event
+
+    def _on_peer_cluster_orchestrator_changed(self, event: RelationChangedEvent) -> None:
+        """Generic handler for peer-cluster-orchestrator `relation-changed` events."""
+        if (
+            not self.charm.unit.is_leader()
+            or not self.charm.state.runs_broker  # only broker needs handle this event
+            or "balancer"
+            not in self.charm.state.balancer.roles  # ensures secrets have set-up before writing, and only writing to balancers
         ):
             return
 
@@ -115,29 +138,6 @@ class PeerClusterEventsHandler(Object):
                 "zk-password": self.charm.state.balancer.zk_password,
             }
         )
-
-        self.charm.on.config_changed.emit()  # ensure both broker+balancer get a changed event
-
-    def _on_peer_cluster_orchestrator_changed(self, event: RelationChangedEvent) -> None:
-        """Generic handler for peer-cluster-orchestrator `relation-changed` events."""
-        if not self.charm.unit.is_leader() or not self.charm.state.runs_balancer:
-            return
-
-        self._default_relation_changed(event)
-
-        for peer_cluster in self.charm.state.peer_clusters:
-            if "broker" not in peer_cluster.roles:
-                # TODO: maybe a log here?
-                continue
-
-            # will no-op if relation does not exist
-            peer_cluster.update(
-                {
-                    "balancer-username": self.charm.state.balancer.balancer_username,
-                    "balancer-password": self.charm.state.balancer.balancer_password,
-                    "balancer-uris": self.charm.state.balancer.balancer_uris,
-                }
-            )
 
         self.charm.on.config_changed.emit()  # ensure both broker+balancer get a changed event
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -134,7 +134,7 @@ BROKER = Role(
     value="broker",
     service="daemon",
     paths=PATHS["kafka"],
-    relation=PEER_CLUSTER_RELATION,
+    relation=PEER_CLUSTER_ORCHESTRATOR_RELATION,
     requested_secrets=[
         "balancer-username",
         "balancer-password",
@@ -145,7 +145,7 @@ BALANCER = Role(
     value="balancer",
     service="cruise-control",
     paths=PATHS["cruise-control"],
-    relation=PEER_CLUSTER_ORCHESTRATOR_RELATION,
+    relation=PEER_CLUSTER_RELATION,
     requested_secrets=[
         "broker-username",
         "broker-password",


### PR DESCRIPTION
## Changes Made
#### `refactor: make brokers the center of the 'star'`
- Swapping around what's in the `PeerCluster` vs `PeerClusterOrchestrator` relations and data interfaces

#### `refactor: assume single-peer-cluster relation`
- Constraint of supporting either one of the following deployment topologies:
    - `broker,balancer`
    - `broker` <-> `balancer` 