### PR TITLE
[DPE-5611] Remove cruise-control metrics reporter if no balancer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ name = "kafka-operator"
 version = "1.0"
 description = "kafka-operator"
 authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
@@ -41,7 +42,7 @@ tenacity = ">=8.0.1"
 pure-sasl = ">=0.6.2"
 jsonschema = ">=4.10"
 cryptography = ">42.0.0"
-pydantic ="<2"
+pydantic = "<2"
 pyyaml = "^6.0.1"
 requests = "^2.32.3"
 lightkube = "0.15.0"
@@ -85,7 +86,7 @@ optional = true
 
 [tool.poetry.group.unit.dependencies]
 pytest = ">=7.2"
-coverage = {extras = ["toml"], version = ">7.0"}
+coverage = { extras = ["toml"], version = ">7.0" }
 pytest-mock = "^3.11.1"
 ops-scenario = "^7.0.0"
 
@@ -95,7 +96,7 @@ optional = true
 [tool.poetry.group.integration.dependencies]
 pytest = ">=7.2"
 juju = "3.5.0.0"
-coverage = {extras = ["toml"], version = ">7.0"}
+coverage = { extras = ["toml"], version = ">7.0" }
 pytest-operator = ">0.20"
 kazoo = ">=2.8"
 tenacity = ">=7.0"
@@ -105,8 +106,6 @@ requests = ">2.25"
 
 pytest-operator-cache = {git = "https://github.com/canonical/data-platform-workflows", tag = "v22.0.0", subdirectory = "python/pytest_plugins/pytest_operator_cache"}
 # To be enabled if we are using groups on integration tests
-# pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v7", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
-
 
 [tool.poetry.group.format.dependencies]
 pyright = "^1.1.301"
@@ -115,23 +114,23 @@ pyright = "^1.1.301"
 line-length = 99
 lint.select = ["E", "W", "F", "C", "N", "D", "I001"]
 lint.extend-ignore = [
-    "D203",
-    "D204",
-    "D213",
-    "D215",
-    "D400",
-    "D401",
-    "D404",
-    "D406",
-    "D407",
-    "D408",
-    "D409",
-    "D413",
+  "D203",
+  "D204",
+  "D213",
+  "D215",
+  "D400",
+  "D401",
+  "D404",
+  "D406",
+  "D407",
+  "D408",
+  "D409",
+  "D413",
 ]
 lint.ignore = ["E501", "D107"]
 extend-exclude = ["__pycache__", "*.egg_info", "tests/integration/app-charm/lib"]
-lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104", "E999"], "src/literals.py" = ["D101"]}
-target-version="py310"
+lint.per-file-ignores = { "tests/*" = ["D100", "D101", "D102", "D103", "D104", "E999"], "src/literals.py" = ["D101"] }
+target-version = "py310"
 src = ["src", "tests"]
 
 [tool.ruff.lint.mccabe]

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -45,6 +45,8 @@ DEFAULT_CONFIG_OPTIONS = """
 sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
 allow.everyone.if.no.acl.found=false
 auto.create.topics.enable=false
+"""
+KAFKA_CRUISE_CONTROL_OPTIONS = """
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 """
 TESTING_OPTIONS = """
@@ -667,7 +669,6 @@ class ConfigManager(CommonConfigManager):
             + self.config_properties
             + self.default_replication_properties
             + self.rack_properties
-            + self.metrics_reporter_properties
             + DEFAULT_CONFIG_OPTIONS.split("\n")
             + self.authorizer_class
             + self.controller_properties
@@ -677,6 +678,12 @@ class ConfigManager(CommonConfigManager):
             properties += self.tls_properties
             if self.state.kraft_mode == False:  # noqa: E712
                 properties += self.zookeeper_tls_properties
+
+        # FIXME: change peer_cluster_relation to peer_cluster_orchestrator_relations after the center-of-star
+        #  change is effective
+        if self.state.runs_balancer or self.state.peer_cluster_relation:
+            properties += KAFKA_CRUISE_CONTROL_OPTIONS.splitlines()
+            properties += self.metrics_reporter_properties
 
         if self.config.profile == PROFILE_TESTING:
             properties += TESTING_OPTIONS.split("\n")

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -679,9 +679,7 @@ class ConfigManager(CommonConfigManager):
             if self.state.kraft_mode == False:  # noqa: E712
                 properties += self.zookeeper_tls_properties
 
-        # FIXME: change peer_cluster_relation to peer_cluster_orchestrator_relations after the center-of-star
-        #  change is effective
-        if self.state.runs_balancer or self.state.peer_cluster_relation:
+        if self.state.runs_balancer or self.state.peer_cluster_orchestrator_relation:
             properties += KAFKA_CRUISE_CONTROL_OPTIONS.splitlines()
             properties += self.metrics_reporter_properties
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -21,6 +21,7 @@ from core.structured_config import CharmConfig, LogLevel
 from core.workload import CharmedKafkaPaths, WorkloadBase
 from literals import (
     ADMIN_USER,
+    BALANCER,
     BALANCER_GOALS_TESTING,
     BROKER,
     CONTROLLER_LISTENER_NAME,
@@ -679,7 +680,7 @@ class ConfigManager(CommonConfigManager):
             if self.state.kraft_mode == False:  # noqa: E712
                 properties += self.zookeeper_tls_properties
 
-        if self.state.runs_balancer or self.state.peer_cluster_orchestrator_relation:
+        if self.state.runs_balancer or BALANCER.value in self.state.peer_cluster.roles:
             properties += KAFKA_CRUISE_CONTROL_OPTIONS.splitlines()
             properties += self.metrics_reporter_properties
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,6 +25,7 @@ from literals import (
     JVM_MEM_MIN_GB,
     OAUTH_REL_NAME,
     PEER,
+    PEER_CLUSTER_RELATION,
     SUBSTRATE,
     ZK,
 )
@@ -547,3 +548,16 @@ def test_super_users(harness: Harness[KafkaCharm]):
     harness.update_relation_data(appii_relation_id, "appii", {"extra-user-roles": "consumer"})
 
     assert len(harness.charm.state.super_users.split(";")) == (len(INTERNAL_USERS) + 1)
+
+
+def test_cruise_control_reporter_only_with_balancer(harness: Harness[KafkaCharm]):
+    reporters_config_value = "metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"
+    # Default roles value does not include balancer
+    assert reporters_config_value not in harness.charm.broker.config_manager.server_properties
+
+    # FIXME: change peer_cluster_relation to peer_cluster_orchestrator_relations after the center-of-star
+    #  change is effective
+    with harness.hooks_disabled():
+        harness.add_relation(PEER_CLUSTER_RELATION, "balancer")
+
+    assert reporters_config_value in harness.charm.broker.config_manager.server_properties

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -556,6 +556,11 @@ def test_cruise_control_reporter_only_with_balancer(harness: Harness[KafkaCharm]
     assert reporters_config_value not in harness.charm.broker.config_manager.server_properties
 
     with harness.hooks_disabled():
-        harness.add_relation(PEER_CLUSTER_ORCHESTRATOR_RELATION, "broker")
+        peer_cluster_relation_id = harness.add_relation(
+            PEER_CLUSTER_ORCHESTRATOR_RELATION, CHARM_KEY
+        )
+        harness.update_relation_data(
+            peer_cluster_relation_id, harness.charm.app.name, {"roles": "broker,balancer"}
+        )
 
     assert reporters_config_value in harness.charm.broker.config_manager.server_properties

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,7 +25,7 @@ from literals import (
     JVM_MEM_MIN_GB,
     OAUTH_REL_NAME,
     PEER,
-    PEER_CLUSTER_RELATION,
+    PEER_CLUSTER_ORCHESTRATOR_RELATION,
     SUBSTRATE,
     ZK,
 )
@@ -555,9 +555,7 @@ def test_cruise_control_reporter_only_with_balancer(harness: Harness[KafkaCharm]
     # Default roles value does not include balancer
     assert reporters_config_value not in harness.charm.broker.config_manager.server_properties
 
-    # FIXME: change peer_cluster_relation to peer_cluster_orchestrator_relations after the center-of-star
-    #  change is effective
     with harness.hooks_disabled():
-        harness.add_relation(PEER_CLUSTER_RELATION, "balancer")
+        harness.add_relation(PEER_CLUSTER_ORCHESTRATOR_RELATION, "broker")
 
     assert reporters_config_value in harness.charm.broker.config_manager.server_properties


### PR DESCRIPTION
Changes:
- Set package mode to false in pyproject.toml. This will prevent poetry from emitting a warning every time we use the `install` subcommand
- The properties related to Cruise Control are now set only if we run the balancer workload in the application or if we use the peer-cluster relation. This will prevent the broker from spamming the logs with warnings in simple deployments

I'll keep this PR as a draft until https://github.com/canonical/kafka-operator/pull/244 is merged, as we'll need to update the relation name in the condition