### PR TITLE
[DPE-5501][DPE-5234] Multi app

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,8 @@ jobs:
           - integration-upgrade
           - integration-balancer-single
           - integration-balancer-multi
+          - integration-kraft-single
+          - integration-kraft-multi
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/src/charm.py
+++ b/src/charm.py
@@ -120,8 +120,10 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         This handler is in charge of stopping the workloads, since the sub-operators would not
         be instantiated if roles are changed.
         """
-
-        if not (self.state.runs_broker or self.state.runs_controller) and self.broker.workload.active():
+        if (
+            not (self.state.runs_broker or self.state.runs_controller)
+            and self.broker.workload.active()
+        ):
             self.broker.workload.stop()
 
         if (

--- a/src/charm.py
+++ b/src/charm.py
@@ -182,8 +182,9 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         if not self.broker.workload.active():
             event.add_status(Status.BROKER_NOT_RUNNING.value.status)
 
-        if not self.state.zookeeper.broker_active():
-            event.add_status(Status.ZK_NOT_CONNECTED.value.status)
+        if not self.state.kraft_mode:
+            if not self.state.zookeeper.broker_active():
+                event.add_status(Status.ZK_NOT_CONNECTED.value.status)
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -92,11 +92,6 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
             self._set_status(Status.SNAP_NOT_INSTALLED)
             return
 
-        # TODO: run on install
-        # if self.state.runs_controller:
-        #     uuid = self.workload.run_bin_command(bin_keyword="storage", bin_args=["random-uuid"])
-        #     self.state.cluster.update({"cluster-uuid": uuid.strip()})
-
         self._set_os_config()
 
     def _set_os_config(self) -> None:
@@ -125,7 +120,8 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         This handler is in charge of stopping the workloads, since the sub-operators would not
         be instantiated if roles are changed.
         """
-        if not self.state.runs_broker and self.broker.workload.active():
+
+        if not (self.state.runs_broker or self.state.runs_controller) and self.broker.workload.active():
             self.broker.workload.stop()
 
         if (

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -351,7 +351,11 @@ class ClusterState(Object):
     def enabled_auth(self) -> list[AuthMap]:
         """The currently enabled auth.protocols and their auth.mechanisms, based on related applications."""
         enabled_auth = []
-        if self.client_relations or self.runs_balancer or self.peer_cluster_orchestrator_relation:
+        if (
+            self.client_relations
+            or self.runs_balancer
+            or BALANCER.value in self.peer_cluster_orchestrator.roles
+        ):
             enabled_auth.append(self.default_auth)
         if self.oauth_relation:
             enabled_auth.append(AuthMap(self.default_auth.protocol, "OAUTHBEARER"))

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -40,6 +40,7 @@ from literals import (
     CONTROLLER,
     CONTROLLER_PORT,
     INTERNAL_USERS,
+    KRAFT_NODE_ID_OFFSET,
     MIN_REPLICAS,
     OAUTH_REL_NAME,
     PEER,
@@ -404,9 +405,13 @@ class ClusterState(Object):
         """The current controller quorum uris when running KRaft mode."""
         # FIXME: when running broker node.id will be unit-id + 100. If unit is only running
         # the controller node.id == unit-id. This way we can keep a human readable mapping of ids.
-        if self.kraft_mode and self.runs_controller:
+        if self.runs_controller:
+            node_offset = KRAFT_NODE_ID_OFFSET if self.runs_broker else 0
             return ",".join(
-                [f"{broker.unit_id}@{broker.host}:{CONTROLLER_PORT}" for broker in self.brokers]
+                [
+                    f"{broker.unit_id + node_offset}@{broker.host}:{CONTROLLER_PORT}"
+                    for broker in self.brokers
+                ]
             )
         return ""
 

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -552,7 +552,7 @@ class ClusterState(Object):
         if self.zookeeper_relation:
             return False
 
-        # FIXME raise instead of none
+        # FIXME raise instead of none. `not kraft_mode` is falsy
         # NOTE: if previous checks are not met, we don't know yet how the charm is being deployed
         return None
 

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -61,7 +61,6 @@ custom_secret_groups = SECRET_GROUPS
 setattr(custom_secret_groups, "BROKER", "broker")
 setattr(custom_secret_groups, "BALANCER", "balancer")
 setattr(custom_secret_groups, "ZOOKEEPER", "zookeeper")
-# setattr(custom_secret_groups, "CONTROLLER", "controller")
 
 SECRET_LABEL_MAP = {
     "broker-username": getattr(custom_secret_groups, "BROKER"),
@@ -73,7 +72,6 @@ SECRET_LABEL_MAP = {
     "balancer-username": getattr(custom_secret_groups, "BALANCER"),
     "balancer-password": getattr(custom_secret_groups, "BALANCER"),
     "balancer-uris": getattr(custom_secret_groups, "BALANCER"),
-    # "controller-quorum-uris": getattr(custom_secret_groups, "CONTROLLER"),
 }
 
 
@@ -404,14 +402,11 @@ class ClusterState(Object):
     @property
     def controller_quorum_uris(self) -> str:
         """The current controller quorum uris when running KRaft mode."""
-        # FIXME: when running controller node.id will be unit.id + 100. If unit is only running
-        # the broker node.id == unit.id. This way we can keep a human readable mapping of ids.
+        # FIXME: when running broker node.id will be unit-id + 100. If unit is only running
+        # the controller node.id == unit-id. This way we can keep a human readable mapping of ids.
         if self.kraft_mode and self.runs_controller:
             return ",".join(
-                [
-                    f"{broker.unit_id+100}@{broker.host}:{CONTROLLER_PORT}"
-                    for broker in self.brokers
-                ]
+                [f"{broker.unit_id}@{broker.host}:{CONTROLLER_PORT}" for broker in self.brokers]
             )
         return ""
 

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -491,7 +491,7 @@ class ClusterState(Object):
         return Status.ACTIVE
 
     @property
-    def _broker_status(self) -> Status:
+    def _broker_status(self) -> Status:  # noqa: C901
         """Checks for role=broker specific readiness."""
         if not self.runs_broker:
             return Status.ACTIVE

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -193,13 +193,6 @@ class PeerCluster(RelationState):
             or ""
         )
 
-        # return self.data_interface._fetch_relation_data_with_secrets(
-        #     component=self.relation.app,
-        #     req_secret_fields=BROKER.requested_secrets,
-        #     relation=self.relation,
-        #     fields=CONTROLLER.requested_secrets,
-        # ).get("controller-quorum-uris", "")
-
     @property
     def cluster_uuid(self) -> str:
         """The cluster uuid used to format storages in KRaft mode."""
@@ -365,13 +358,7 @@ class PeerCluster(RelationState):
     @property
     def broker_connected_kraft_mode(self) -> bool:
         """Checks for necessary data required by a controller."""
-        if not all(
-            [
-                self.broker_username,
-                self.broker_password,
-                self.cluster_uuid,
-            ]
-        ):
+        if not all([self.broker_username, self.broker_password, self.cluster_uuid]):
             return False
 
         return True

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -187,12 +187,14 @@ class PeerCluster(RelationState):
         if not self.relation or not self.relation.app:
             return ""
 
-        return self.data_interface._fetch_relation_data_with_secrets(
-            component=self.relation.app,
-            req_secret_fields=BROKER.requested_secrets,
-            relation=self.relation,
-            fields=CONTROLLER.requested_secrets,
-        ).get("controller-quorum-uris", "")
+        return self.data_interface.fetch_relation_field(relation_id=self.relation.id, field="controller-quorum-uris") or ""
+
+        # return self.data_interface._fetch_relation_data_with_secrets(
+        #     component=self.relation.app,
+        #     req_secret_fields=BROKER.requested_secrets,
+        #     relation=self.relation,
+        #     fields=CONTROLLER.requested_secrets,
+        # ).get("controller-quorum-uris", "")
 
     @property
     def cluster_uuid(self) -> str:
@@ -334,6 +336,7 @@ class PeerCluster(RelationState):
     @property
     def broker_connected(self) -> bool:
         """Checks if there is an active broker relation with all necessary data."""
+        # FIXME rename to specify balancer-broker connection
         if not all(
             [
                 self.broker_username,
@@ -344,6 +347,20 @@ class PeerCluster(RelationState):
                 self.zk_uris,
                 self.broker_capacities,
                 # rack is optional, empty if not rack-aware
+            ]
+        ):
+            return False
+
+        return True
+
+    @property
+    def broker_connected_kraft_mode(self) -> bool:
+        """Checks for necessary data required by a controller."""
+        if not all(
+            [
+                self.broker_username,
+                self.broker_password,
+                self.cluster_uuid,
             ]
         ):
             return False

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -25,7 +25,6 @@ from typing_extensions import override
 from literals import (
     BALANCER,
     BROKER,
-    CONTROLLER,
     INTERNAL_USERS,
     SECRETS_APP,
     Substrates,
@@ -187,7 +186,12 @@ class PeerCluster(RelationState):
         if not self.relation or not self.relation.app:
             return ""
 
-        return self.data_interface.fetch_relation_field(relation_id=self.relation.id, field="controller-quorum-uris") or ""
+        return (
+            self.data_interface.fetch_relation_field(
+                relation_id=self.relation.id, field="controller-quorum-uris"
+            )
+            or ""
+        )
 
         # return self.data_interface._fetch_relation_data_with_secrets(
         #     component=self.relation.app,
@@ -205,7 +209,12 @@ class PeerCluster(RelationState):
         if not self.relation or not self.relation.app:
             return ""
 
-        return self.data_interface.fetch_relation_field(relation_id=self.relation.id, field="cluster-uuid") or ""
+        return (
+            self.data_interface.fetch_relation_field(
+                relation_id=self.relation.id, field="cluster-uuid"
+            )
+            or ""
+        )
 
     @property
     def racks(self) -> int:
@@ -464,6 +473,7 @@ class KafkaCluster(RelationState):
     def cluster_uuid(self) -> str:
         """Cluster uuid used for initializing storages."""
         return self.relation_data.get("cluster-uuid", "")
+
 
 class KafkaBroker(RelationState):
     """State collection metadata for a unit."""

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -169,7 +169,7 @@ class BalancerOperator(Object):
                 content_changed = True
 
         # On k8s, adding/removing a broker does not change the bootstrap server property if exposed by nodeport
-        broker_capacities = self.charm.state.balancer.broker_capacities
+        broker_capacities = self.charm.state.peer_cluster.broker_capacities
         if (
             file_content := json.loads(
                 "".join(self.workload.read(self.workload.paths.capacity_jbod_json))
@@ -200,8 +200,8 @@ class BalancerOperator(Object):
             available_brokers = [broker.unit_id for broker in self.charm.state.brokers]
         else:
             brokers = (
-                [broker.name for broker in self.charm.state.balancer.relation.units]
-                if self.charm.state.balancer.relation
+                [broker.name for broker in self.charm.state.peer_cluster.relation.units]
+                if self.charm.state.peer_cluster.relation
                 else []
             )
             available_brokers = [int(broker.split("/")[1]) for broker in brokers]

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -4,11 +4,9 @@
 
 """Broker role core charm logic."""
 
-import subprocess
 import json
 import logging
 from datetime import datetime
-import time
 from typing import TYPE_CHECKING
 
 from charms.operator_libs_linux.v1.snap import SnapError
@@ -206,8 +204,6 @@ class BrokerOperator(Object):
         self.workload.start()
         logger.info("Kafka service started")
 
-        time.sleep(10)
-
         # TODO: Update users. Not sure if this is the best place, as cluster might be still
         # stabilizing.
         # if self.charm.state.kraft_mode and self.charm.state.runs_broker:
@@ -333,15 +329,14 @@ class BrokerOperator(Object):
         # If properties have changed, the broker will restart.
         self.charm.on.config_changed.emit()
 
-        if self.charm.state.runs_broker:
-            try:
-                if self.health and not self.health.machine_configured():
-                    self.charm._set_status(Status.SYSCONF_NOT_OPTIMAL)
-                    return
-            except SnapError as e:
-                logger.debug(f"Error: {e}")
-                self.charm._set_status(Status.BROKER_NOT_RUNNING)
+        try:
+            if self.health and not self.health.machine_configured():
+                self.charm._set_status(Status.SYSCONF_NOT_OPTIMAL)
                 return
+        except SnapError as e:
+            logger.debug(f"Error: {e}")
+            self.charm._set_status(Status.BROKER_NOT_RUNNING)
+            return
 
         self.charm._set_status(Status.ACTIVE)
 

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -362,7 +362,7 @@ class BrokerOperator(Object):
         self.charm.state.unit_broker.update({"storages": self.balancer_manager.storages})
 
         # FIXME: if KRaft, don't execute
-        if self.charm.substrate == "vm" and not self.charm.state.runs_controller:
+        if self.charm.substrate == "vm" and not self.charm.state.kraft_mode:
             # new dirs won't be used until topic partitions are assigned to it
             # either automatically for new topics, or manually for existing
             # set status only for running services, not on startup

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -166,7 +166,7 @@ class BrokerOperator(Object):
         if not self.upgrade.idle:
             return
 
-        # NOTE make init_server no-op and always run
+        # TODO make init_server no-op and always run
         if self.charm.state.runs_controller:
             if not self.charm.state.cluster.cluster_uuid and self.model.unit.is_leader():
                 uuid = self.workload.run_bin_command(bin_keyword="storage", bin_args=["random-uuid", "2>", "/dev/null"]).strip()
@@ -485,17 +485,19 @@ class BrokerOperator(Object):
         if not self.charm.unit.is_leader() or not self.healthy:
             return
 
-        self.charm.state.balancer.update(
+        self.charm.state.peer_cluster.update(
             {
                 "roles": self.charm.state.roles,
-                "broker-username": self.charm.state.balancer.broker_username,
-                "broker-password": self.charm.state.balancer.broker_password,
-                "broker-uris": self.charm.state.balancer.broker_uris,
-                "racks": str(self.charm.state.balancer.racks),
-                "broker-capacities": json.dumps(self.charm.state.balancer.broker_capacities),
-                "zk-uris": self.charm.state.balancer.zk_uris,
-                "zk-username": self.charm.state.balancer.zk_username,
-                "zk-password": self.charm.state.balancer.zk_password,
+                "broker-username": self.charm.state.peer_cluster.broker_username,
+                "broker-password": self.charm.state.peer_cluster.broker_password,
+                "broker-uris": self.charm.state.peer_cluster.broker_uris,
+                "controller-quorum-uris": self.charm.state.peer_cluster.controller_quorum_uris,
+                "cluster-uuid": self.charm.state.peer_cluster.cluster_uuid,
+                "racks": str(self.charm.state.peer_cluster.racks),
+                "broker-capacities": json.dumps(self.charm.state.peer_cluster.broker_capacities),
+                "zk-uris": self.charm.state.peer_cluster.zk_uris,
+                "zk-username": self.charm.state.peer_cluster.zk_username,
+                "zk-password": self.charm.state.peer_cluster.zk_password,
             }
         )
 

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -16,7 +16,13 @@ from charms.data_platform_libs.v0.data_interfaces import (
     diff,
     set_encoded_field,
 )
-from ops.charm import RelationChangedEvent, RelationCreatedEvent, RelationEvent, SecretChangedEvent
+from ops.charm import (
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+    RelationEvent,
+    SecretChangedEvent,
+)
 from ops.framework import Object
 
 from core.cluster import custom_secret_groups
@@ -142,6 +148,31 @@ class PeerClusterEventsHandler(Object):
         )
 
         self.charm.on.config_changed.emit()  # ensure both broker+balancer get a changed event
+
+    def _on_peer_cluster_broken(self, _: RelationBrokenEvent):
+        """Handle the required logic to remove """
+        if self.charm.state.kraft_mode == None:
+            self.charm.workload.stop()
+            logger.info(f'Service {self.model.unit.name.split("/")[1]} stopped')
+
+            # FIXME: probably a mix between cluster_manager and broker
+            if self.charm.state.runs_broker:
+                # Kafka keeps a meta.properties in every log.dir with a unique ClusterID
+                # this ID is provided by ZK, and removing it on relation-broken allows
+                # re-joining to another ZK cluster.
+                for storage in self.charm.model.storages["data"]:
+                    self.charm.workload.exec(
+                        [
+                            "rm",
+                            f"{storage.location}/meta.properties",
+                            f"{storage.location}/__cluster_metadata-0/quorum-state"]
+                    )
+
+                if self.charm.unit.is_leader():
+                    # other charm methods assume credentials == ACLs
+                    # necessary to clean-up credentials once ZK relation is lost
+                    for username in self.charm.state.cluster.internal_user_credentials:
+                        self.charm.state.cluster.update({f"{username}-password": ""})
 
     def _default_relation_changed(self, event: RelationChangedEvent):
         """Implements required logic from multiple 'handled' events from the `data-interfaces` library."""

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -125,7 +125,10 @@ class PeerClusterEventsHandler(Object):
         if (
             not self.charm.unit.is_leader()
             or not self.charm.state.runs_broker  # only broker needs handle this event
-            or not any([role in self.charm.state.peer_cluster.roles for role in [BALANCER.value, CONTROLLER.value]]) # ensures secrets have set-up before writing, and only writing to controller,balancers
+            or not any(
+                role in self.charm.state.peer_cluster.roles
+                for role in [BALANCER.value, CONTROLLER.value]
+            )  # ensures secrets have set-up before writing, and only writing to controller,balancers
         ):
             return
 
@@ -150,8 +153,8 @@ class PeerClusterEventsHandler(Object):
         self.charm.on.config_changed.emit()  # ensure both broker+balancer get a changed event
 
     def _on_peer_cluster_broken(self, _: RelationBrokenEvent):
-        """Handle the required logic to remove """
-        if self.charm.state.kraft_mode == None:
+        """Handle the required logic to remove."""
+        if self.charm.state.kraft_mode is None:
             self.charm.workload.stop()
             logger.info(f'Service {self.model.unit.name.split("/")[1]} stopped')
 
@@ -165,7 +168,8 @@ class PeerClusterEventsHandler(Object):
                         [
                             "rm",
                             f"{storage.location}/meta.properties",
-                            f"{storage.location}/__cluster_metadata-0/quorum-state"]
+                            f"{storage.location}/__cluster_metadata-0/quorum-state",
+                        ]
                     )
 
                 if self.charm.unit.is_leader():

--- a/src/literals.py
+++ b/src/literals.py
@@ -141,7 +141,6 @@ BROKER = Role(
         "balancer-username",
         "balancer-password",
         "balancer-uris",
-        "controller-quorum-uris",
     ],
 )
 CONTROLLER = Role(
@@ -224,6 +223,9 @@ class Status(Enum):
     BROKER_NOT_RUNNING = StatusLevel(BlockedStatus("Broker not running"), "WARNING")
     NOT_ALL_RELATED = StatusLevel(MaintenanceStatus("not all units related"), "DEBUG")
     CC_NOT_RUNNING = StatusLevel(BlockedStatus("Cruise Control not running"), "WARNING")
+    MISSING_MODE = StatusLevel(BlockedStatus("Application needs ZooKeeper or KRaft mode"), "DEBUG")
+    NO_CLUSTER_UUID = StatusLevel(WaitingStatus("Waiting for cluster uuid"), "DEBUG")
+    NO_QUORUM_URIS = StatusLevel(WaitingStatus("Waiting for quorum uris"), "DEBUG")
     ZK_NOT_RELATED = StatusLevel(BlockedStatus("missing required zookeeper relation"), "DEBUG")
     ZK_NOT_CONNECTED = StatusLevel(BlockedStatus("unit not connected to zookeeper"), "ERROR")
     ZK_TLS_MISMATCH = StatusLevel(

--- a/src/literals.py
+++ b/src/literals.py
@@ -125,7 +125,7 @@ class Role:
     service: str
     paths: dict[str, str]
     relation: str
-    requested_secrets: list[str] = []
+    requested_secrets: list[str]
 
     def __eq__(self, value: object, /) -> bool:
         """Provide an easy comparison to the configuration key."""

--- a/src/literals.py
+++ b/src/literals.py
@@ -88,6 +88,11 @@ SECURITY_PROTOCOL_PORTS: dict[AuthMap, Ports] = {
 }
 # FIXME this port should exist on the previous abstraction
 CONTROLLER_PORT = 9097
+CONTROLLER_LISTENER_NAME = "INTERNAL_CONTROLLER"
+
+# FIXME: when running broker node.id will be unit-id + 100. If unit is only running
+# the controller node.id == unit-id. This way we can keep a human readable mapping of ids.
+KRAFT_NODE_ID_OFFSET = 100
 
 DebugLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
 DatabagScope = Literal["unit", "app"]

--- a/src/literals.py
+++ b/src/literals.py
@@ -141,6 +141,7 @@ BROKER = Role(
         "balancer-username",
         "balancer-password",
         "balancer-uris",
+        "controller-quorum-uris",
     ],
 )
 CONTROLLER = Role(
@@ -148,7 +149,10 @@ CONTROLLER = Role(
     service="daemon",
     paths=PATHS["kafka"],
     relation=PEER_CLUSTER_RELATION,
-    requested_secrets=[],
+    requested_secrets=[
+        "broker-username",
+        "broker-password",
+    ],
 )
 BALANCER = Role(
     value="balancer",

--- a/src/literals.py
+++ b/src/literals.py
@@ -125,7 +125,7 @@ class Role:
     service: str
     paths: dict[str, str]
     relation: str
-    requested_secrets: list[str] | None = None
+    requested_secrets: list[str] = []
 
     def __eq__(self, value: object, /) -> bool:
         """Provide an easy comparison to the configuration key."""

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -13,6 +13,7 @@ from ops.pebble import ExecError
 
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
+from literals import SECURITY_PROTOCOL_PORTS
 
 logger = logging.getLogger(__name__)
 
@@ -168,7 +169,7 @@ class AuthManager:
             opts = [self.kafka_opts]
         else:
             bootstrap_server = (
-                f"{self.state.unit_broker.internal_address}:19092"
+                f"{self.state.unit_broker.internal_address}:{SECURITY_PROTOCOL_PORTS[self.state.default_auth].internal}"
                 if internal
                 else self.state.bootstrap_server
             )

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -167,7 +167,11 @@ class AuthManager:
             ]
             opts = [self.kafka_opts]
         else:
-            bootstrap_server = f"{self.state.unit_broker.internal_address}:19092" if internal else self.state.bootstrap_server
+            bootstrap_server = (
+                f"{self.state.unit_broker.internal_address}:19092"
+                if internal
+                else self.state.bootstrap_server
+            )
             command = base_command + [
                 f"--bootstrap-server={bootstrap_server}",
                 f"--command-config={self.workload.paths.client_properties}",

--- a/src/managers/balancer.py
+++ b/src/managers/balancer.py
@@ -137,8 +137,8 @@ class BalancerManager:
     def cruise_control(self) -> CruiseControlClient:
         """Client for the CruiseControl REST API."""
         return CruiseControlClient(
-            username=self.charm.state.balancer.balancer_username,
-            password=self.charm.state.balancer.balancer_password,
+            username=self.charm.state.peer_cluster.balancer_username,
+            password=self.charm.state.peer_cluster.balancer_password,
         )
 
     @property
@@ -160,7 +160,7 @@ class BalancerManager:
 
     def create_internal_topics(self) -> None:
         """Create Cruise Control topics."""
-        bootstrap_servers = self.charm.state.balancer.broker_uris
+        bootstrap_servers = self.charm.state.peer_cluster.broker_uris
         property_file = f'{BALANCER.paths["CONF"]}/cruisecontrol.properties'
 
         for topic in BALANCER_TOPICS:

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -583,8 +583,9 @@ class ConfigManager(CommonConfigManager):
     @property
     def authorizer_class(self) -> list[str]:
         """Return the authorizer Java class used on Kafka."""
-        if self.state.runs_controller:
-            return ["authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer"]
+        if self.state.kraft_mode:
+            # return ["authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer"]
+            return []
         return ["authorizer.class.name=kafka.security.authorizer.AclAuthorizer"]
 
     @property
@@ -642,6 +643,7 @@ class ConfigManager(CommonConfigManager):
                 properties = (
                     [f"log.dirs={self.state.log_dirs}", f"listeners={controller_listener}"]
                     + self.controller_properties
+                    # + self.authorizer_class
                 )
                 return properties
 
@@ -667,7 +669,7 @@ class ConfigManager(CommonConfigManager):
             + self.rack_properties
             + self.metrics_reporter_properties
             + DEFAULT_CONFIG_OPTIONS.split("\n")
-            # + self.authorizer_class
+            + self.authorizer_class
             + self.controller_properties
         )
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -23,6 +23,7 @@ from literals import (
     ADMIN_USER,
     BALANCER_GOALS_TESTING,
     BROKER,
+    CONTROLLER_LISTENER_NAME,
     CONTROLLER_PORT,
     DEFAULT_BALANCER_GOALS,
     HARD_BALANCER_GOALS,
@@ -31,6 +32,7 @@ from literals import (
     JMX_EXPORTER_PORT,
     JVM_MEM_MAX_GB,
     JVM_MEM_MIN_GB,
+    KRAFT_NODE_ID_OFFSET,
     PROFILE_TESTING,
     SECURITY_PROTOCOL_PORTS,
     AuthMap,
@@ -602,15 +604,15 @@ class ConfigManager(CommonConfigManager):
         node_id = self.state.unit_broker.unit_id
         if self.state.runs_broker:
             roles.append("broker")
+            node_id += KRAFT_NODE_ID_OFFSET
         if self.state.runs_controller:
             roles.append("controller")
-            node_id += 100
 
         properties = [
             f"process.roles={','.join(roles)}",
             f"node.id={node_id}",
             f"controller.quorum.voters={self.state.peer_cluster.controller_quorum_uris}",
-            "controller.listener.names=INTERNAL_CONTROLLER",
+            f"controller.listener.names={CONTROLLER_LISTENER_NAME}",
         ]
 
         return properties
@@ -632,8 +634,8 @@ class ConfigManager(CommonConfigManager):
         advertised_listeners = [listener.advertised_listener for listener in self.all_listeners]
 
         if self.state.kraft_mode:
-            controller_protocol_map = "INTERNAL_CONTROLLER:PLAINTEXT"
-            controller_listener = f"INTERNAL_CONTROLLER://0.0.0.0:{CONTROLLER_PORT}"
+            controller_protocol_map = f"{CONTROLLER_LISTENER_NAME}:PLAINTEXT"
+            controller_listener = f"{CONTROLLER_LISTENER_NAME}://0.0.0.0:{CONTROLLER_PORT}"
 
             # NOTE: Case where the controller is running standalone. Early return with a
             # smaller subset of config options

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -453,9 +453,9 @@ class ConfigManager(CommonConfigManager):
         )
 
     @property
-    def controller_listener(self) -> Listener:
+    def controller_listener(self) -> None:
         """Return the controller listener."""
-        pass # TODO: No good abstraction in place for the controller use case
+        pass  # TODO: No good abstraction in place for the controller use case
 
     @property
     def client_listeners(self) -> list[Listener]:
@@ -606,14 +606,12 @@ class ConfigManager(CommonConfigManager):
             roles.append("controller")
             node_id += 100
 
-        properties = (
-            [
-                f"process.roles={','.join(roles)}",
-                f"node.id={node_id}",
-                f"controller.quorum.voters={self.state.peer_cluster.controller_quorum_uris}",
-                "controller.listener.names=INTERNAL_CONTROLLER",
-            ]
-        )
+        properties = [
+            f"process.roles={','.join(roles)}",
+            f"node.id={node_id}",
+            f"controller.quorum.voters={self.state.peer_cluster.controller_quorum_uris}",
+            "controller.listener.names=INTERNAL_CONTROLLER",
+        ]
 
         return properties
 
@@ -809,7 +807,9 @@ class BalancerConfigManager(CommonConfigManager):
 
         if self.state.peer_cluster.racks:
             if (
-                min([3, len(self.state.peer_cluster.broker_capacities.get("brokerCapacities", []))])
+                min(
+                    [3, len(self.state.peer_cluster.broker_capacities.get("brokerCapacities", []))]
+                )
                 > self.state.peer_cluster.racks
             ):  # replication-factor > racks is not ideal
                 goals = goals + ["RackAwareDistribution"]

--- a/src/workload.py
+++ b/src/workload.py
@@ -184,7 +184,9 @@ class Workload(WorkloadBase):
         command = f"{opts_str} {SNAP_NAME}.{bin_keyword} {bin_str}"
         return self.exec(command)
 
-    def format_storages(self, uuid: str, internal_user_credentials: dict[str, str] | None = None) -> None:
+    def format_storages(
+        self, uuid: str, internal_user_credentials: dict[str, str] | None = None
+    ) -> None:
         """Use a passed uuid to format storages."""
         # NOTE data dirs have changed permissions by storage_attached hook. For some reason
         # storage command bin needs these locations to be root owned. Momentarily raise permissions

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+import os
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from literals import (
+    CONTROLLER_PORT,
+    PEER_CLUSTER_ORCHESTRATOR_RELATION,
+    PEER_CLUSTER_RELATION,
+    SECURITY_PROTOCOL_PORTS,
+)
+
+from .helpers import (
+    APP_NAME,
+    check_socket,
+    get_address,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.kraft
+
+CONTROLLER_APP = "controller"
+PRODUCER_APP = "producer"
+
+
+class TestKRaft:
+
+    deployment_strat: str = os.environ.get("DEPLOYMENT", "multi")
+    controller_app: str = {"single": APP_NAME, "multi": CONTROLLER_APP}[deployment_strat]
+
+    @pytest.mark.abort_on_fail
+    async def test_build_and_deploy(self, ops_test: OpsTest, kafka_charm):
+        await ops_test.model.add_machine(series="jammy")
+        machine_ids = await ops_test.model.get_machines()
+
+        await asyncio.gather(
+            ops_test.model.deploy(
+                kafka_charm,
+                application_name=APP_NAME,
+                num_units=1,
+                series="jammy",
+                to=machine_ids[0],
+                config={
+                    "roles": "broker,controller" if self.controller_app == APP_NAME else "broker",
+                    "profile": "testing",
+                },
+                trust=True,
+            ),
+            ops_test.model.deploy(
+                "kafka-test-app",
+                application_name=PRODUCER_APP,
+                channel="edge",
+                num_units=1,
+                series="jammy",
+                config={
+                    "topic_name": "HOT-TOPIC",
+                    "num_messages": 100000,
+                    "role": "producer",
+                    "partitions": 20,
+                    "replication_factor": "1",
+                },
+                trust=True,
+            ),
+        )
+
+        if self.controller_app != APP_NAME:
+            await ops_test.model.deploy(
+                kafka_charm,
+                application_name=self.controller_app,
+                num_units=1,
+                series="jammy",
+                config={
+                    "roles": self.controller_app,
+                    "profile": "testing",
+                },
+                trust=True,
+            )
+
+        await ops_test.model.wait_for_idle(
+            apps=list({APP_NAME, self.controller_app}),
+            idle_period=30,
+            timeout=1800,
+            raise_on_error=False,
+        )
+        if self.controller_app != APP_NAME:
+            assert ops_test.model.applications[APP_NAME].status == "blocked"
+            assert ops_test.model.applications[self.controller_app].status == "blocked"
+        else:
+            assert ops_test.model.applications[APP_NAME].status == "active"
+
+    @pytest.mark.abort_on_fail
+    async def test_integrate(self, ops_test: OpsTest):
+        if self.controller_app != APP_NAME:
+            await ops_test.model.add_relation(
+                f"{APP_NAME}:{PEER_CLUSTER_ORCHESTRATOR_RELATION}",
+                f"{CONTROLLER_APP}:{PEER_CLUSTER_RELATION}",
+            )
+
+        await ops_test.model.wait_for_idle(
+            apps=list({APP_NAME, self.controller_app}), idle_period=30
+        )
+
+        async with ops_test.fast_forward(fast_interval="40s"):
+            await asyncio.sleep(120)  # ensure update-status adds broker-capacities if missed
+
+        assert ops_test.model.applications[APP_NAME].status == "active"
+        assert ops_test.model.applications[self.controller_app].status == "active"
+
+    @pytest.mark.abort_on_fail
+    async def test_listeners(self, ops_test: OpsTest):
+        address = await get_address(ops_test=ops_test)
+        assert check_socket(
+            address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].internal
+        )  # Internal listener
+
+        # Client listener should not be enabled if there is no relations
+        assert not check_socket(
+            address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
+        )
+
+        # Check controller socket
+        if self.controller_app != APP_NAME:
+            address = await get_address(ops_test=ops_test, app_name=self.controller_app)
+
+        assert check_socket(address, CONTROLLER_PORT)

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -108,7 +108,7 @@ class TestKRaft:
         )
 
         async with ops_test.fast_forward(fast_interval="40s"):
-            await asyncio.sleep(120)  # ensure update-status adds broker-capacities if missed
+            await asyncio.sleep(120)
 
         assert ops_test.model.applications[APP_NAME].status == "active"
         assert ops_test.model.applications[self.controller_app].status == "active"

--- a/tests/unit/scenario/test_kraft.py
+++ b/tests/unit/scenario/test_kraft.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from ops import ActiveStatus
+from scenario import Container, Context, PeerRelation, Relation, State
+
+from charm import KafkaCharm
+from literals import (
+    CONTAINER,
+    PEER,
+    PEER_CLUSTER_ORCHESTRATOR_RELATION,
+    PEER_CLUSTER_RELATION,
+    SUBSTRATE,
+    Status,
+)
+
+pytestmark = pytest.mark.kraft
+
+logger = logging.getLogger(__name__)
+
+
+CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
+ACTIONS = yaml.safe_load(Path("./actions.yaml").read_text())
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+@pytest.fixture()
+def charm_configuration():
+    """Enable direct mutation on configuration dict."""
+    return json.loads(json.dumps(CONFIG))
+
+
+@pytest.fixture()
+def base_state():
+
+    if SUBSTRATE == "k8s":
+        state = State(leader=True, containers=[Container(name=CONTAINER, can_connect=True)])
+
+    else:
+        state = State(leader=True)
+
+    return state
+
+
+def test_ready_to_start_maintenance_no_peer_relation(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    state_in = State(leader=True, relations=[])
+
+    # When
+    state_out = ctx.run("start", state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_PEER_RELATION.value.status
+
+
+def test_ready_to_start_no_peer_cluster(charm_configuration):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    state_in = State(leader=True, relations=[cluster_peer])
+
+    # When
+    state_out = ctx.run("start", state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_PEER_CLUSTER_RELATION.value.status
+
+
+def test_ready_to_start_missing_data_as_controller(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    charm_configuration["options"]["expose-external"]["default"] = "none"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    peer_cluster = Relation(PEER_CLUSTER_RELATION, "peer_cluster")
+    state_in = base_state.replace(relations=[cluster_peer, peer_cluster])
+
+    # When
+    state_out = ctx.run("start", state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_BROKER_DATA.value.status
+
+
+def test_ready_to_start_missing_data_as_broker(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "broker"
+    charm_configuration["options"]["expose-external"]["default"] = "none"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    peer_cluster = Relation(
+        PEER_CLUSTER_ORCHESTRATOR_RELATION, "peer_cluster", remote_app_data={"roles": "controller"}
+    )
+    state_in = base_state.replace(relations=[cluster_peer, peer_cluster])
+
+    # When
+    with patch("workload.KafkaWorkload.run_bin_command", return_value="cluster-uuid-number"):
+        state_out = ctx.run("start", state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_QUORUM_URIS.value.status
+
+
+def test_ready_to_start(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "broker,controller"
+    charm_configuration["options"]["expose-external"]["default"] = "none"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    state_in = base_state.replace(relations=[cluster_peer])
+
+    # When
+    with (
+        patch(
+            "workload.KafkaWorkload.run_bin_command", return_value="cluster-uuid-number"
+        ) as patched_run_bin_command,
+        patch("health.KafkaHealth.machine_configured", return_value=True),
+        patch("workload.KafkaWorkload.start"),
+        patch("charms.operator_libs_linux.v1.snap.SnapCache"),
+    ):
+        state_out = ctx.run("start", state_in)
+
+    # Then
+    # Second call of format will have to pass "cluster-uuid-number" as set above
+    assert "cluster-uuid-number" in patched_run_bin_command.call_args_list[1][1]["bin_args"]
+    assert "cluster-uuid" in state_out.get_relations(PEER)[0].local_app_data
+    assert "controller-quorum-uris" in state_out.get_relations(PEER)[0].local_app_data
+    # Only the internal users should be created.
+    # FIXME: This is a convoluted way to unpack secret contents.
+    # In scenario v7 use "tracked_content" instead to access last revision directly
+    assert all(
+        user in sorted(state_out.secrets[0].contents.items())[-1][1]
+        for user in ("admin-password", "sync-password")
+    )
+    assert state_out.unit_status == ActiveStatus()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -101,12 +101,12 @@ def test_ready_to_start_maintenance_no_peer_relation(harness: Harness[KafkaCharm
     assert harness.charm.unit.status == Status.NO_PEER_RELATION.value.status
 
 
-def test_ready_to_start_blocks_no_zookeeper_relation(harness: Harness[KafkaCharm]):
+def test_ready_to_start_blocks_no_mode(harness: Harness[KafkaCharm]):
     with harness.hooks_disabled():
         harness.add_relation(PEER, CHARM_KEY)
 
     harness.charm.on.start.emit()
-    assert harness.charm.unit.status == Status.ZK_NOT_RELATED.value.status
+    assert harness.charm.unit.status == Status.MISSING_MODE.value.status
 
 
 def test_ready_to_start_waits_no_zookeeper_data(harness: Harness[KafkaCharm]):

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ set_env =
     ha: TEST_FILE=ha/test_ha.py
     balancer-single: DEPLOYMENT=single
     balancer-multi: DEPLOYMENT=multi
+    kraft-single: DEPLOYMENT=single
+    kraft-multi: DEPLOYMENT=multi
 
 pass_env =
     PYTHONPATH
@@ -113,3 +115,16 @@ pass_env =
 commands =
     poetry install --no-root --with integration
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_balancer.py
+
+[testenv:integration-kraft-{single,multi}]
+description = Run KRaft mode tests
+set_env =
+    {[testenv]set_env}
+    # Workaround for https://github.com/python-poetry/poetry/issues/6958
+    POETRY_INSTALLER_PARALLEL = false
+pass_env =
+    {[testenv]pass_env}
+    CI
+commands =
+    poetry install --no-root --with integration
+    poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_kraft.py


### PR DESCRIPTION
### Summary
This PR enables KRaft to be deployed on it's own application. It also extends the `peer_cluster` interface to accommodate controller role.

------
Data flow between "controller" and "broker":

![controller-broker-data](https://github.com/user-attachments/assets/f81960f5-5646-4c53-a86d-a2fe73814c2a)

- If an application is a `controller`, write to own databag/peer_cluster the `controller-quorum-uris` as soon as possible. These uris can be set at any given time, since they only depend on IP and unit id.
- If an application is a `broker`, write to own databag/peer_cluster the `cluster-uuid` as soon as possible. At some point this will be a task for the `cluster_manager` instead of the broker.

### Storage formatting
Formatting the storage before starting the cluster is a needed step on KRaft mode:
```
charmed-kafka.storage format --cluster-id $uuid -c server.properties --add-scram 'SCRAM-SHA-512=[name={user},password={password}]'
```
Running this command requires two things from the charm:
- A well formed `server.properties` file. The command will look at `log.dirs` and `metadata.log.dir` and create the metadata files there. But the rest of the properties need to be, at least, format compliant. This implies that a broker also needs the `controller-quorum-uris` to be set on the file before calling `format storages`. So the `broker` needs to wait for the uris before this step.
- Internal users. The `admin` and `sync` users are added to the metadata at the same time as the format is set. Since the internal users are created on the `broker`, the `controller` side needs to wait for the secret to be passed along.

Once those conditions are met, the service is able to start.

### On unit.id / node.id handling
KRaft mode requires all nodes on the cluster (controller, broker) to have unique id numbers. For the time being, the `node.id` setup will be as follows:
- If I'm running `broker`: `node.id = unit-id`
- If I'm running `controller`: `node.id = unit-id + 100`
  - Controller takes precedence, so running `controller,broker`: `node.id = unit-id + 100`


### Other relevant changes: 
- `jaas.file` has been removed when using KRaft. Users are declared on the properties file, passed at init when formatting storages, or created through the kafka commands.
- Adding the internal users (`admin,sync`) through the ACLS has been removed when running KRaft mode. These users are already on the cluster during formatting.