### PR TITLE
[DPE-5553] feat: Don't restart server on keystore/truststore updates

### DIFF
--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -413,6 +413,25 @@ class ClusterState(Object):
         )
 
     @property
+    def bootstrap_server_internal(self) -> str:
+        """Comma-delimited string of `bootstrap-server` command flag for internal access.
+
+        Returns:
+            List of `bootstrap-server` servers
+        """
+        if not self.peer_relation:
+            return ""
+
+        return ",".join(
+            sorted(
+                [
+                    f"{broker.internal_address}:{SECURITY_PROTOCOL_PORTS[self.default_auth].internal}"
+                    for broker in self.brokers
+                ]
+            )
+        )
+
+    @property
     def controller_quorum_uris(self) -> str:
         """The current controller quorum uris when running KRaft mode."""
         # FIXME: when running broker node.id will be unit-id + 100. If unit is only running

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -140,7 +140,7 @@ class TLSHandler(Object):
         if not self.charm.state.cluster.mtls_enabled:
             # Create a "mtls" flag so a new listener (CLIENT_SSL) is created
             self.charm.state.cluster.update({"mtls": "enabled"})
-            self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
+            self.charm.on.config_changed.emit()
 
         self.charm.app.status = ActiveStatus()
 

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -27,7 +27,6 @@ from ops.charm import (
     RelationJoinedEvent,
 )
 from ops.framework import Object
-from ops.model import ActiveStatus
 
 from literals import TLS_RELATION, TRUSTED_CA_RELATION, TRUSTED_CERTIFICATE_RELATION, Status
 
@@ -141,8 +140,6 @@ class TLSHandler(Object):
             # Create a "mtls" flag so a new listener (CLIENT_SSL) is created
             self.charm.state.cluster.update({"mtls": "enabled"})
             self.charm.on.config_changed.emit()
-
-        self.charm.app.status = ActiveStatus()
 
     def _trusted_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Generate a CSR so the tls-certificates operator works as expected."""

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -27,6 +27,7 @@ from ops.charm import (
     RelationJoinedEvent,
 )
 from ops.framework import Object
+from ops.model import ActiveStatus
 
 from literals import TLS_RELATION, TRUSTED_CA_RELATION, TRUSTED_CERTIFICATE_RELATION, Status
 
@@ -136,8 +137,12 @@ class TLSHandler(Object):
             event.defer()
             return
 
-        # Create a "mtls" flag so a new listener (CLIENT_SSL) is created
-        self.charm.state.cluster.update({"mtls": "enabled"})
+        if not self.charm.state.cluster.mtls_enabled:
+            # Create a "mtls" flag so a new listener (CLIENT_SSL) is created
+            self.charm.state.cluster.update({"mtls": "enabled"})
+            self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
+
+        self.charm.app.status = ActiveStatus()
 
     def _trusted_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Generate a CSR so the tls-certificates operator works as expected."""
@@ -208,8 +213,8 @@ class TLSHandler(Object):
         )
         self.charm.broker.tls_manager.import_cert(alias=f"{alias}", filename=filename)
 
-        # ensuring new config gets applied
-        self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
+        # Live reload the truststore
+        self.charm.broker.tls_manager.reload_truststore()
 
     def _trusted_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handle relation broken for a trusted certificate/ca relation."""

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -206,3 +206,16 @@ class TLSManager:
         except (subprocess.CalledProcessError, ExecError) as e:
             logger.error(e.stdout)
             raise e
+
+    def reload_truststore(self) -> None:
+        """Reloads the truststore using `kafka-configs` utility without restarting the broker."""
+        config_tool = "charmed-kafka.configs"
+        cmd = f"{config_tool} --command-config {self.workload.paths.client_properties} --bootstrap-server {self.state.bootstrap_server_internal} --entity-type brokers --entity-name {self.state.unit_broker.unit_id} --alter --add-config listener.name.CLIENT_SSL_SSL.ssl.keystore.location={self.workload.paths.truststore}"
+
+        logger.info(f"Reloading truststore: {cmd}")
+        try:
+            self.workload.exec(cmd, working_dir=self.workload.paths.conf_path)
+        except (subprocess.CalledProcessError, ExecError) as e:
+            # in case this reruns and fails
+            logger.error(e.stdout)
+            raise e

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -209,13 +209,17 @@ class TLSManager:
 
     def reload_truststore(self) -> None:
         """Reloads the truststore using `kafka-configs` utility without restarting the broker."""
-        config_tool = "charmed-kafka.configs"
-        cmd = f"{config_tool} --command-config {self.workload.paths.client_properties} --bootstrap-server {self.state.bootstrap_server_internal} --entity-type brokers --entity-name {self.state.unit_broker.unit_id} --alter --add-config listener.name.CLIENT_SSL_SSL.ssl.keystore.location={self.workload.paths.truststore}"
+        bin_args = [
+            f"--command-config {self.workload.paths.client_properties}",
+            f"--bootstrap-server {self.state.bootstrap_server_internal}",
+            "--entity-type brokers",
+            f"--entity-name {self.state.unit_broker.unit_id}",
+            "--alter",
+            f"--add-config listener.name.CLIENT_SSL_SSL.ssl.truststore.location={self.workload.paths.truststore}",
+        ]
 
-        logger.info(f"Reloading truststore: {cmd}")
-        try:
-            self.workload.exec(cmd, working_dir=self.workload.paths.conf_path)
-        except (subprocess.CalledProcessError, ExecError) as e:
-            # in case this reruns and fails
-            logger.error(e.stdout)
-            raise e
+        logger.info("Reloading truststore")
+        self.workload.run_bin_command(
+            bin_keyword="configs",
+            bin_args=bin_args,
+        )

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -4,7 +4,9 @@
 
 import asyncio
 import base64
+import json
 import logging
+import os
 
 import pytest
 from charms.tls_certificates_interface.v1.tls_certificates import generate_private_key
@@ -22,11 +24,13 @@ from .helpers import (
     APP_NAME,
     REL_NAME_ADMIN,
     check_tls,
+    create_test_topic,
     extract_ca,
     extract_private_key,
     get_active_brokers,
     get_address,
     get_kafka_zk_relation_data,
+    search_secrets,
     set_mtls_client_acls,
     set_tls_private_key,
 )
@@ -37,6 +41,7 @@ logger = logging.getLogger(__name__)
 TLS_NAME = "self-signed-certificates"
 CERTS_NAME = "tls-certificates-operator"
 MTLS_NAME = "mtls"
+TLS_REQUIRER = "tls-certificates-requirer"
 
 
 @pytest.mark.abort_on_fail
@@ -225,6 +230,105 @@ async def test_mtls(ops_test: OpsTest):
     assert topic_name == "TEST-TOPIC"
     assert min_offset == "0"
     assert max_offset == str(num_messages)
+
+
+@pytest.mark.abort_on_fail
+async def test_truststore_live_reload(ops_test: OpsTest):
+    """Tests truststore live reload functionality using kafka-python client."""
+    requirer = "other-req/0"
+    test_msg = {"test": 123456}
+
+    await ops_test.model.deploy(
+        TLS_NAME, channel="stable", series="jammy", application_name="other-ca"
+    )
+    await ops_test.model.deploy(
+        TLS_REQUIRER, channel="stable", series="jammy", application_name="other-req"
+    )
+
+    await ops_test.model.add_relation("other-ca", "other-req")
+
+    await ops_test.model.wait_for_idle(
+        apps=["other-ca", "other-req"], idle_period=60, timeout=2000, status="active"
+    )
+
+    # retrieve required certificates and private key from secrets
+    local_store = {
+        "private_key": search_secrets(ops_test=ops_test, owner=requirer, search_key="private-key"),
+        "cert": search_secrets(ops_test=ops_test, owner=requirer, search_key="certificate"),
+        "ca_cert": search_secrets(ops_test=ops_test, owner=requirer, search_key="ca-certificate"),
+        "broker_ca": extract_ca(ops_test=ops_test, unit_name=f"{APP_NAME}/0"),
+    }
+
+    certs_operator_config = {
+        "generate-self-signed-certificates": "false",
+        "certificate": base64.b64encode(local_store["cert"].encode("utf-8")).decode("utf-8"),
+        "ca-certificate": base64.b64encode(local_store["ca_cert"].encode("utf-8")).decode("utf-8"),
+    }
+
+    await ops_test.model.deploy(
+        CERTS_NAME,
+        channel="stable",
+        series="jammy",
+        application_name="other-op",
+        config=certs_operator_config,
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=["other-op"], idle_period=60, timeout=2000, status="active"
+    )
+
+    # We don't expect a broker restart here because of truststore live reload
+    await ops_test.model.add_relation(f"{APP_NAME}:{TRUSTED_CERTIFICATE_RELATION}", "other-op")
+
+    await ops_test.model.wait_for_idle(
+        apps=["other-op", APP_NAME], idle_period=60, timeout=2000, status="active"
+    )
+
+    for key_, content in local_store.items():
+        with open(f"test_{key_}", "w", encoding="utf-8") as f:
+            f.write(content)
+
+    address = await get_address(ops_test, app_name=APP_NAME)
+    ssl_port = SECURITY_PROTOCOL_PORTS["SSL", "SSL"].client
+    ssl_bootstrap_server = f"{address}:{ssl_port}"
+    sasl_port = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].client
+    sasl_bootstrap_server = f"{address}:{sasl_port}"
+
+    # create `test` topic and set ACLs
+    await create_test_topic(ops_test, bootstrap_server=sasl_bootstrap_server)
+
+    # quickly test the producer and consumer side authentication & authorization
+    client_config = {
+        "bootstrap_servers": ssl_bootstrap_server,
+        "security_protocol": "SSL",
+        "api_version": (0, 10),
+        "ssl_cafile": "test_broker_ca",
+        "ssl_certfile": "test_cert",
+        "ssl_keyfile": "test_private_key",
+        "ssl_check_hostname": False,
+    }
+
+    import kafka
+
+    producer = kafka.KafkaProducer(
+        **client_config,
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+
+    producer.send("test", test_msg)
+
+    consumer = kafka.KafkaConsumer("test", **client_config, auto_offset_reset="earliest")
+
+    msg = next(consumer)
+
+    assert json.loads(msg.value) == test_msg
+
+    # cleanup
+    await ops_test.model.remove_application("other-ca", block_until_done=True)
+    await ops_test.model.remove_application("other-op", block_until_done=True)
+    await ops_test.model.remove_application("other-req", block_until_done=True)
+    for key_ in local_store:
+        os.remove(f"test_{key_}")
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -241,10 +241,10 @@ async def test_truststore_live_reload(ops_test: OpsTest):
     test_msg = {"test": 123456}
 
     await ops_test.model.deploy(
-        TLS_NAME, channel="stable", series="jammy", application_name="other-ca"
+        TLS_NAME, channel="stable", application_name="other-ca", revision=155
     )
     await ops_test.model.deploy(
-        TLS_REQUIRER, channel="stable", series="jammy", application_name="other-req"
+        TLS_REQUIRER, channel="stable", application_name="other-req", revision=102
     )
 
     await ops_test.model.add_relation("other-ca", "other-req")


### PR DESCRIPTION
# Changes 
- Added **truststore dynamic reload** functionality using `kafka-configs` utility to reload truststore without broker restart
- Added integration test for truststore dynamic reload functionality