### PR TITLE
[DPE-6558] Production Profile should extend socket buffers and low-level thread count

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -116,3 +116,7 @@ options:
     description: "String to determine how to expose the Apache Kafka cluster externally from the Kubernetes cluster. Possible values: 'nodeport', 'none'"
     type: string
     default: "nodeport"
+  buffer_size:
+    description: "Sets socket send, receive and replica socket buffers. Value in bytes. socket.request.max.bytes is set to 1024x this value."
+    type: int
+    default: 102400

--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -80,6 +80,7 @@ class CharmConfig(BaseConfigModel):
     cruisecontrol_balance_threshold: float = Field(default=1.1, validate_default=False, ge=1)
     cruisecontrol_capacity_threshold: float = Field(default=0.8, validate_default=False, le=1)
     expose_external: str | None
+    buffer_size: int
 
     @validator("*", pre=True)
     @classmethod
@@ -172,7 +173,9 @@ class CharmConfig(BaseConfigModel):
             raise ValueError("Value below 1. Accepted value are greater or equal than 1.")
         return int_value
 
-    @validator("replication_quota_window_num", "log_segment_bytes", "message_max_bytes")
+    @validator(
+        "replication_quota_window_num", "log_segment_bytes", "message_max_bytes", "buffer_size"
+    )
     @classmethod
     def greater_than_zero(cls, value: int) -> int | None:
         """Check value greater than zero."""
@@ -199,6 +202,7 @@ class CharmConfig(BaseConfigModel):
         "offsets_topic_num_partitions",
         "transaction_state_log_num_partitions",
         "replication_quota_window_num",
+        "buffer_size",
     )
     @classmethod
     def integer_value(cls, value: int) -> int | None:

--- a/src/literals.py
+++ b/src/literals.py
@@ -214,6 +214,7 @@ MODE_ADD = "add"
 MODE_REMOVE = "remove"
 
 PROFILE_TESTING = "testing"
+PROFILE_PRODUCTION = "production"
 
 
 @dataclass

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -47,6 +47,13 @@ DEFAULT_CONFIG_OPTIONS = """
 sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
 allow.everyone.if.no.acl.found=false
 auto.create.topics.enable=false
+num.network.threads=8
+num.io.threads=8
+num.recovery.threads.per.data.dir=4
+background.threads=25
+replica.socket.receive.buffer.bytes=1024000
+socket.receive.buffer.bytes=1024000
+socket.send.buffer.bytes=1024000
 """
 KAFKA_CRUISE_CONTROL_OPTIONS = """
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -52,11 +52,6 @@ auto.create.topics.enable=false
 KAFKA_CRUISE_CONTROL_OPTIONS = """
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 """
-PRODUCTION_OPTIONS = """
-replica.socket.receive.buffer.bytes=1024000
-socket.receive.buffer.bytes=1024000
-socket.send.buffer.bytes=1024000
-"""
 TESTING_OPTIONS = """
 cruise.control.metrics.reporter.metrics.reporting.interval.ms=6000
 """
@@ -787,11 +782,16 @@ class ConfigManager(CommonConfigManager):
             properties += TESTING_OPTIONS.split("\n")
         elif self.config.profile == PROFILE_PRODUCTION:
             cores = os.cpu_count() or 1
-            properties += ["num.network.threads=" + str(max(cores, 3))]
-            properties += ["num.io.threads=" + str(max(cores, 8))]
-            properties += ["num.recovery.threads.per.data.dir=" + str(max(cores // 2, 1))]
-            properties += ["background.threads=" + str(max(cores * 3, 10))]
-            properties += PRODUCTION_OPTIONS.split("\n")
+            properties += [
+                "num.network.threads=" + str(max(cores, 3)),
+                "num.io.threads=" + str(max(cores, 8)),
+                "num.recovery.threads.per.data.dir=" + str(max(cores // 2, 1)),
+                "background.threads=" + str(max(cores * 3, 10)),
+                "replica.socket.receive.buffer.bytes=" + str(max(self.config.buffer_size, 65536)),
+                "socket.receive.buffer.bytes=" + str(max(self.config.buffer_size, 102400)),
+                "socket.send.buffer.bytes=" + str(max(self.config.buffer_size, 102400)),
+                "socket.request.max.bytes=" + str(max(self.config.buffer_size * 1024, 104857600)),
+            ]
 
         return properties
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -686,6 +686,7 @@ def test_socket_buffer_and_thread_count_properties(
     ):
         charm = cast(KafkaCharm, manager.charm)
         charm.broker.config_manager.config.profile = "production"
+        charm.broker.config_manager.config.buffer_size = 1024000
 
         # Then
         assert "num.network.threads=8" in charm.broker.config_manager.server_properties


### PR DESCRIPTION
This PR is a result of the investigation described in the ticket: [PACLOUD-291](https://warthogs.atlassian.net/browse/PACLOUD-291)

The current production profile only sets the heap options in the JVM. This PR extends that profile option to also include some key configurations such as socket buffers and overall count of threads on the system.

With this PR, the thread count becomes dependent on the number of cores, setting the minimums as defined in the Apache Kafka docs.

[PACLOUD-291]: https://warthogs.atlassian.net/browse/PACLOUD-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ