### PR TITLE
feat: support juju expose by setting listener ports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,13 @@ jobs:
       - name: Run tests
         run: tox run -e unit
 
+  check-libs:
+    if: ${{ github.event_name == 'schedule' }}
+    uses: canonical/charming-actions/check-libraries@2.2.3
+    with:
+      credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
+      github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   sync-docs:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.event.pull_request.head.repo.full_name, 'canonical/') }}
     uses: ./.github/workflows/sync_docs.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.2.3
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   ci-tests:
     needs:

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -13,6 +13,7 @@ from charms.operator_libs_linux.v1.snap import SnapError
 from ops import (
     EventBase,
     InstallEvent,
+    ModelError,
     Object,
     PebbleReadyEvent,
     SecretChangedEvent,
@@ -199,6 +200,12 @@ class BrokerOperator(Object):
         # start kafka service
         self.workload.start()
         logger.info("Kafka service started")
+
+        for port in [listener.port for listener in self.config_manager.all_listeners]:
+            try:
+                self.charm.state.unit_broker.unit.open_port("tcp", port)
+            except ModelError:
+                logger.exception("failed to open port")
 
         # TODO: Update users. Not sure if this is the best place, as cluster might be still
         # stabilizing.

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -201,12 +201,6 @@ class BrokerOperator(Object):
         self.workload.start()
         logger.info("Kafka service started")
 
-        for port in [listener.port for listener in self.config_manager.all_listeners]:
-            try:
-                self.charm.state.unit_broker.unit.open_port("tcp", port)
-            except ModelError:
-                logger.exception("failed to open port")
-
         # TODO: Update users. Not sure if this is the best place, as cluster might be still
         # stabilizing.
         # if self.charm.state.kraft_mode and self.charm.state.runs_broker:
@@ -325,6 +319,11 @@ class BrokerOperator(Object):
         # update these whenever possible
         self.config_manager.set_client_properties()
         self.update_external_services()
+        for port in [listener.port for listener in self.config_manager.all_listeners]:
+            try:
+                self.charm.state.unit_broker.unit.open_port("tcp", port)
+            except ModelError:
+                logger.exception("failed to open port")
 
         # If Kafka is related to client charms, update their information.
         if self.model.relations.get(REL_NAME, None) and self.charm.unit.is_leader():


### PR DESCRIPTION
## Changes Made
#### `cicd: only run check-libs on scheduled ci runs`
- This seemed to be broken, as new Charmcraft version failed rather than warned for local changes to libs, or unpublished libs (in the case of `kafka`
- Now only runs when 'scheduled', not blocking release
#### `feat: support juju expose by setting listener ports`
- This was needed for our charm to work with external clients on Prodstack
- By default, we update all the 'set' ports on `update-status` -> `config-changed` as normal, with values retrieved from all currently enabled listeners