### PR TITLE
[DPE-6636] - feat: support non-unit/port extra_listeners

### DIFF
--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -287,7 +287,10 @@ class CharmConfig(BaseConfigModel):
 
         ports = []
         for listener in listeners:
-            if ":" not in listener or not listener.split(":")[1].isdigit():
+            if ":" not in listener:
+                continue
+
+            if not listener.split(":")[1].isdigit():
                 raise ValueError("Value for listener does not contain a valid port.")
 
             port = int(listener.split(":")[1])

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -520,7 +520,9 @@ class ConfigManager(CommonConfigManager):
     def extra_listeners(self) -> list[Listener]:
         """Return a list of extra listeners."""
         extra_host_baseports = [
-            tuple(listener.split(":")) for listener in self.config.extra_listeners
+            tuple(listener.split(":"))
+            for listener in self.config.extra_listeners
+            if ":" in listener
         ]
 
         extra_listeners = []

--- a/tests/unit/test_structured_config.py
+++ b/tests/unit/test_structured_config.py
@@ -178,7 +178,6 @@ def test_incorrect_roles():
 
 def test_incorrect_extra_listeners():
     erroneus_values = [
-        "missing.port",
         "low.port:15000",
         "high.port:60000",
         "non.unique:30000,other.non.unique:30000",

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -112,8 +112,8 @@ def test_mtls_added(ctx: Context, base_state: State) -> None:
         ),
         (
             "extra_listeners",
-            "worker{unit}.com:30000,{unit}.example:40000,nonunit.domain.com:45000",
-            ["worker0.com", "0.example", "nonunit.domain.com"],
+            "run{unit}.shadowfax:30000,{unit}.proudfoot:40000,fool.ofa.took:45000,no.port.{unit}.com",
+            ["run0.shadowfax", "0.proudfoot", "fool.ofa.took", "no.port.0.com"],
         ),
     ],
 )


### PR DESCRIPTION
## Changes Made
#### `feat: support non-unit/port extra_listeners`
- `worker-{unit}:30000` --> advertised listeners from 39092+, `worker-0` TLS certificate DN
- `{unit}-foo.com` --> `0-foo.com` TLS certificate DN
- `bananarama.party` --> `bananarama.party` TLS certificate DN