### PR TITLE
[DPE-6547] fix: KRaft multi-mode scaling bug on broker side

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -200,12 +200,7 @@ class PeerCluster(RelationState):
         if not self.relation or not self.relation.app:
             return ""
 
-        return self.data_interface._fetch_relation_data_with_secrets(
-            component=self.relation.app,
-            req_secret_fields=["controller-password"],
-            relation=self.relation,
-            fields=["controller-password"],
-        ).get("controller-password", "")
+        return self._fetch_from_secrets("controller", "controller-password")
 
     @property
     def cluster_uuid(self) -> str:


### PR DESCRIPTION
This PR fixes a `RelationDataAccessError` bug occurred in KRaft multi-mode on broker side during scale-out. 

## Bugfixes:
-  KRaft multi-mode, broker-side scale-out results in error state. https://github.com/canonical/kafka-operator/issues/305