### PR TITLE
[DPE-5702] chore: Active Controllers alert set to == 0 (#252)

### DIFF
--- a/src/alert_rules/prometheus/kafka_metrics.rules
+++ b/src/alert_rules/prometheus/kafka_metrics.rules
@@ -69,7 +69,7 @@ groups:
   # Controller and Partitions
   # =========================
   - alert: Active Controllers
-    expr: sum(kafka_controller_kafkacontroller_activecontrollercount{juju_charm!=".*"}) != 1
+    expr: sum(kafka_controller_kafkacontroller_activecontrollercount{juju_charm!=".*"}) == 0
     for: 1m
     labels:
       severity: critical

--- a/src/grafana_dashboards/kafka-metrics.json
+++ b/src/grafana_dashboards/kafka-metrics.json
@@ -113,7 +113,7 @@
         "y": 1
       },
       "id": 647,
-      "interval": null,
+      "interval": "30s",
       "links": [],
       "mappingType": 1,
       "mappingTypes": [
@@ -206,7 +206,7 @@
         "y": 1
       },
       "id": 233,
-      "interval": null,
+      "interval": "30s",
       "links": [],
       "mappingType": 1,
       "mappingTypes": [


### PR DESCRIPTION
backport of #252 that landed on `3/stable`