### PR TITLE
DO NOT MERGE [DPE-7146] feat: TLS support on controller listeners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,8 @@ jobs:
           - integration-balancer-multi
           - integration-kraft-single
           - integration-kraft-multi
+          - integration-kraft-single-tls
+          - integration-kraft-multi-tls
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,6 @@ jobs:
       - lint
       - unit-test
       - build
-      - integration-test
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/src/charm.py
+++ b/src/charm.py
@@ -150,6 +150,9 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         # For more information, please refer to https://warthogs.atlassian.net/browse/DPE-3155
         time.sleep(10.0)
 
+        if self.state.runs_controller:
+            self.broker.kraft.add_to_quorum()
+
     def _disable_enable_restart_broker(self, event: RunWithLock) -> None:
         """Handler for `rolling_ops` disable_enable restart events.
 

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -39,7 +39,6 @@ from literals import (
     BALANCER,
     BROKER,
     CONTROLLER,
-    CONTROLLER_PORT,
     CONTROLLER_USER,
     INTERNAL_USERS,
     KRAFT_NODE_ID_OFFSET,
@@ -455,7 +454,8 @@ class ClusterState(Object):
     def bootstrap_controller(self) -> str:
         """Returns the controller listener in the format HOST:PORT."""
         if self.runs_controller:
-            return f"{self.unit_broker.internal_address}:{CONTROLLER_PORT}"
+            return f"{self.unit_broker.internal_address}:{SECURITY_PROTOCOL_PORTS[self.default_auth].controller}"
+
         return ""
 
     @property

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -235,6 +235,16 @@ class PeerCluster(RelationState):
         )
 
     @property
+    def bootstrap_controller_port(self) -> int | None:
+        """The listener port used in `bootstrap_controller`."""
+        parts = self.bootstrap_controller.split(":")
+
+        if not self.bootstrap_controller or len(parts) < 1:
+            return None
+
+        return int(parts[1])
+
+    @property
     def bootstrap_unit_id(self) -> str:
         """Bootstrap unit ID in KRaft mode."""
         if self._bootstrap_unit_id:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -717,11 +717,6 @@ class KafkaBroker(RelationState):
         """Directory ID of the node as saved in `meta.properties`."""
         return self.relation_data.get("directory-id", "")
 
-    @property
-    def added_to_quorum(self) -> bool:
-        """Whether or not this node is added to dynamic quorum in KRaft mode."""
-        return bool(self.relation_data.get("added-to-quorum", False))
-
 
 class ZooKeeper(RelationState):
     """State collection metadata for a the Zookeeper relation."""

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -188,6 +188,16 @@ class WorkloadBase(ABC):
         """
         ...
 
+    @abstractmethod
+    def check_socket(self, host: str, port: int) -> bool:
+        """Checks whether an IPv4 socket is up or not."""
+        ...
+
+    @abstractmethod
+    def cleanup_cluster_metadata(self, log_dirs: str) -> None:
+        """Cleanup provided log_dirs from cluster metadata. This is only safe to run when using KRaft multi-mode on brokers."""
+        ...
+
     def get_version(self) -> str:
         """Get the workload version.
 

--- a/src/events/controller.py
+++ b/src/events/controller.py
@@ -92,6 +92,13 @@ class KRaftHandler(Object):
 
         self.add_to_quorum()
 
+        if self.model.unit.is_leader():
+            # necessary to refresh this in case TLS has been enabled/disabled
+            # this triggers changes in all the other relation data for large deployments
+            self.charm.state.cluster.update(
+                {"bootstrap-controller": self.charm.state.bootstrap_controller}
+            )
+
     def _init_kraft_mode(self) -> None:
         """Initialize the server when running controller mode."""
         # NOTE: checks for `runs_broker` in this method should be `is_cluster_manager` in
@@ -118,11 +125,11 @@ class KRaftHandler(Object):
             generated_password = self.charm.workload.generate_password()
 
             if self.charm.state.peer_cluster_orchestrator:
-
                 if not self.charm.state.peer_cluster_orchestrator.controller_password:
                     self.charm.state.peer_cluster_orchestrator.update(
                         {"controller-password": generated_password}
                     )
+
             elif not self.charm.state.peer_cluster.controller_password:
                 # single mode, controller & leader
                 self.charm.state.cluster.update({"controller-password": generated_password})

--- a/src/events/controller.py
+++ b/src/events/controller.py
@@ -125,7 +125,7 @@ class KRaftHandler(Object):
         upgrade_state = self.charm.state.kraft_upgrade_state
         leader = self.charm.unit.is_leader() and role == "controller"
 
-        logger.info(f"Upgrading controller listeners: {self.charm.unit.name} {upgrade_state}")
+        logger.debug(f"Upgrading controller listeners: {self.charm.unit.name} {upgrade_state}")
         match role, leader, upgrade_state.controller, upgrade_state.broker:
 
             case "controller", True, "idle", _:

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -90,6 +90,7 @@ class TLSHandler(Object):
             return
 
         self.charm.state.cluster.update({"tls": "enabled"})
+        self.charm.state.kraft_tls_enabled = True
 
     def _tls_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Handler for `certificates_relation_joined` event."""
@@ -124,6 +125,7 @@ class TLSHandler(Object):
         if self.charm.state.runs_controller:
             if self.charm.unit.is_leader():
                 self.charm.state.cluster.update({"tls": ""})
+                self.charm.state.kraft_tls_enabled = False
                 # we should keep the controller TLS listener up, and don't remove the TLS artifacts.
                 return
             else:
@@ -143,6 +145,7 @@ class TLSHandler(Object):
             return
 
         self.charm.state.cluster.update({"tls": ""})
+        self.charm.state.kraft_tls_enabled = False
 
     def _trusted_relation_created(self, event: EventBase) -> None:
         """Handle relation created event to trusted tls charm."""

--- a/src/literals.py
+++ b/src/literals.py
@@ -78,24 +78,22 @@ class Ports:
     client: int
     internal: int
     external: int
+    controller: int
     extra: int = 0
 
 
 AuthProtocol = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]
 AuthMechanism = Literal["SCRAM-SHA-512", "OAUTHBEARER", "SSL"]
-Scope = Literal["INTERNAL", "CLIENT", "EXTERNAL", "EXTRA"]
+Scope = Literal["INTERNAL", "CLIENT", "EXTERNAL", "EXTRA", "CONTROLLER"]
 AuthMap = NamedTuple("AuthMap", protocol=AuthProtocol, mechanism=AuthMechanism)
 
 SECURITY_PROTOCOL_PORTS: dict[AuthMap, Ports] = {
-    AuthMap("SASL_PLAINTEXT", "SCRAM-SHA-512"): Ports(9092, 19092, 29092),
-    AuthMap("SASL_SSL", "SCRAM-SHA-512"): Ports(9093, 19093, 29093),
-    AuthMap("SSL", "SSL"): Ports(9094, 19094, 29094),
-    AuthMap("SASL_PLAINTEXT", "OAUTHBEARER"): Ports(9095, 19095, 29095),
-    AuthMap("SASL_SSL", "OAUTHBEARER"): Ports(9096, 19096, 29096),
+    AuthMap("SASL_PLAINTEXT", "SCRAM-SHA-512"): Ports(9092, 19092, 29092, 19192),
+    AuthMap("SASL_SSL", "SCRAM-SHA-512"): Ports(9093, 19093, 29093, 19193),
+    AuthMap("SSL", "SSL"): Ports(9094, 19094, 29094, 19194),
+    AuthMap("SASL_PLAINTEXT", "OAUTHBEARER"): Ports(9095, 19095, 29095, 19195),
+    AuthMap("SASL_SSL", "OAUTHBEARER"): Ports(9096, 19096, 29096, 19196),
 }
-# FIXME this port should exist on the previous abstraction
-CONTROLLER_PORT = 9097
-CONTROLLER_LISTENER_NAME = "INTERNAL_CONTROLLER"
 
 # FIXME: when running broker node.id will be unit-id + 100. If unit is only running
 # the controller node.id == unit-id. This way we can keep a human readable mapping of ids.

--- a/src/literals.py
+++ b/src/literals.py
@@ -130,6 +130,27 @@ PATHS = {
 }
 
 
+class KRaftUnitStatus(str, Enum):
+    """KRaft unit status (also known as role) in KRaft Quorums."""
+
+    LEADER = "Leader"
+    FOLLOWER = "Follower"
+    OBSERVER = "Observer"
+
+
+@dataclass
+class KRaftQuorumInfo:
+    """Object containing Quorum info for a KRaft controller."""
+
+    directory_id: str
+    status: KRaftUnitStatus
+
+    @property
+    def is_leader_or_follower(self) -> bool:
+        """Whether the unit is a KRaft leader or follower."""
+        return self.status in (KRaftUnitStatus.LEADER, KRaftUnitStatus.FOLLOWER)
+
+
 @dataclass
 class Role:
     value: str
@@ -163,6 +184,7 @@ CONTROLLER = Role(
     requested_secrets=[
         "broker-username",
         "broker-password",
+        "controller-password",
     ],
 )
 BALANCER = Role(

--- a/src/literals.py
+++ b/src/literals.py
@@ -86,10 +86,11 @@ AuthProtocol = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]
 AuthMechanism = Literal["SCRAM-SHA-512", "OAUTHBEARER", "SSL"]
 Scope = Literal["INTERNAL", "CLIENT", "EXTERNAL", "EXTRA", "CONTROLLER"]
 AuthMap = NamedTuple("AuthMap", protocol=AuthProtocol, mechanism=AuthMechanism)
+ListenerUpgradeState = Literal["idle", "followers", "done"]
 
 SECURITY_PROTOCOL_PORTS: dict[AuthMap, Ports] = {
-    AuthMap("SASL_PLAINTEXT", "SCRAM-SHA-512"): Ports(9092, 19092, 29092, 19192),
-    AuthMap("SASL_SSL", "SCRAM-SHA-512"): Ports(9093, 19093, 29093, 19193),
+    AuthMap("SASL_PLAINTEXT", "SCRAM-SHA-512"): Ports(9092, 19092, 29092, 9097),
+    AuthMap("SASL_SSL", "SCRAM-SHA-512"): Ports(9093, 19093, 29093, 9098),
     AuthMap("SSL", "SSL"): Ports(9094, 19094, 29094, 19194),
     AuthMap("SASL_PLAINTEXT", "OAUTHBEARER"): Ports(9095, 19095, 29095, 19195),
     AuthMap("SASL_SSL", "OAUTHBEARER"): Ports(9096, 19096, 29096, 19196),
@@ -162,7 +163,6 @@ CONTROLLER = Role(
     requested_secrets=[
         "broker-username",
         "broker-password",
-        "controller-password",
     ],
 )
 BALANCER = Role(
@@ -174,7 +174,6 @@ BALANCER = Role(
         "broker-username",
         "broker-password",
         "broker-uris",
-        "controller-passwrod",
         "zk-username",
         "zk-password",
         "zk-uris",

--- a/src/literals.py
+++ b/src/literals.py
@@ -287,6 +287,9 @@ class Status(Enum):
     WAITING_FOR_REBALANCE = StatusLevel(
         WaitingStatus("awaiting completion of rebalance task"), "DEBUG"
     )
+    TLS_MISMATCH = StatusLevel(
+        BlockedStatus("tls must be enabled on both KRaft controller and broker"), "ERROR"
+    )
 
 
 DEPENDENCIES = {

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -471,6 +471,8 @@ class ConfigManager(CommonConfigManager):
             f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{CONTROLLER_USER}" password="{password}";',
             f"sasl.mechanism={self.active_controller_listener.mechanism}",
             f"security.protocol={self.active_controller_listener.protocol}",
+            "default.api.timeout.ms=20000",
+            "request.timeout.ms=10000",
         ]
 
     @property

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -180,7 +180,7 @@ class CommonConfigManager:
     @cached_property
     def peer_cluster_state(self) -> PeerCluster:
         """Cached peer_cluster state."""
-        return self.peer_cluster_state
+        return self.state.peer_cluster
 
     @property
     def log_level(self) -> str:

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -10,7 +10,6 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from literals import (
-    CONTROLLER_PORT,
     KRAFT_NODE_ID_OFFSET,
     PEER_CLUSTER_ORCHESTRATOR_RELATION,
     PEER_CLUSTER_RELATION,
@@ -32,6 +31,7 @@ pytestmark = pytest.mark.kraft
 
 CONTROLLER_APP = "controller"
 PRODUCER_APP = "producer"
+CONTROLLER_PORT = 9097
 
 
 class TestKRaft:

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -313,9 +313,9 @@ class TestKRaft:
     @pytest.mark.skipif(not tls_enabled, reason="only required when TLS is on.")
     @pytest.mark.abort_on_fail
     async def test_disable_tls(self, ops_test: OpsTest):
-        await ops_test.model.applications[APP_NAME].remove_relation(self.controller_app, TLS_NAME)
+        await ops_test.juju("remove-relation", self.controller_app, TLS_NAME)
         if self.controller_app != APP_NAME:
-            await ops_test.model.applications[APP_NAME].remove_relation(APP_NAME, TLS_NAME)
+            await ops_test.juju("remove-relation", APP_NAME, TLS_NAME)
 
         async with ops_test.fast_forward(fast_interval="90s"):
             await ops_test.model.wait_for_idle(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -47,6 +47,7 @@ def patched_workload(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("workload.Workload.active", lambda _: True)
     monkeypatch.setattr("workload.Workload.write", lambda _, content, path: None)
     monkeypatch.setattr("workload.Workload.read", lambda _, path: [])
+    monkeypatch.setattr("workload.Workload.get_service_pid", lambda _: 1314231)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/data/metadata_quorum_stub.py
+++ b/tests/unit/data/metadata_quorum_stub.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+DESCRIBE_REPLICATION_RESPONSE = """
+NodeId	DirectoryId           	LogEndOffset	Lag	LastFetchTimestamp	LastCaughtUpTimestamp	Status
+0     	_u63b3fXn1jeklAC-6kmqQ	34516       	0  	1749280488535     	1749280488535        	Leader
+1     	2rxcYUwQSvG8mI91fx7_gQ	34516       	0  	1749280488114     	1749280488114        	Follower
+100   	DTmCiijKqa_PqGVUSLMUqw	34516       	0  	1749280488109     	1749280488109        	Observer
+101   	O2MHvwsuZwvVs9f8QFLXfw	34516       	0  	1749280488109     	1749280488109        	Observer
+"""
+
+TIMEOUT_EXCEPTION = """
+org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: describeMetadataQuorum
+java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: describeMetadataQuorum
+	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
+	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
+	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:165)
+	at org.apache.kafka.tools.MetadataQuorumCommand.handleDescribeReplication(MetadataQuorumCommand.java:197)
+	at org.apache.kafka.tools.MetadataQuorumCommand.execute(MetadataQuorumCommand.java:133)
+	at org.apache.kafka.tools.MetadataQuorumCommand.mainNoExit(MetadataQuorumCommand.java:81)
+	at org.apache.kafka.tools.MetadataQuorumCommand.main(MetadataQuorumCommand.java:76)
+Caused by: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: describeMetadataQuorum
+"""
+
+DUPLICATE_VOTER_EXCEPTION = """
+org.apache.kafka.common.errors.DuplicateVoterException: The voter id for ReplicaKey(id=1, directoryId=Optional[_u63b3fXn1jeklAC-6kmqQ]) is already part of the set of voters [ReplicaKey(id=1, directoryId=Optional[_u63b3fXn1jeklAC-6kmqQ]), ReplicaKey(id=0, directoryId=Optional[2rxcYUwQSvG8mI91fx7_gQ])].
+java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.DuplicateVoterException: The voter id for ReplicaKey(id=1, directoryId=Optional[_u63b3fXn1jeklAC-6kmqQ]) is already part of the set of voters [ReplicaKey(id=1, directoryId=Optional[_u63b3fXn1jeklAC-6kmqQ]), ReplicaKey(id=0, directoryId=Optional[2rxcYUwQSvG8mI91fx7_gQ])].
+	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
+	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
+	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:165)
+	at org.apache.kafka.tools.MetadataQuorumCommand.handleAddController(MetadataQuorumCommand.java:431)
+	at org.apache.kafka.tools.MetadataQuorumCommand.execute(MetadataQuorumCommand.java:147)
+	at org.apache.kafka.tools.MetadataQuorumCommand.mainNoExit(MetadataQuorumCommand.java:81)
+	at org.apache.kafka.tools.MetadataQuorumCommand.main(MetadataQuorumCommand.java:76)
+Caused by: org.apache.kafka.common.errors.DuplicateVoterException: The voter id for ReplicaKey(id=1, directoryId=Optional[_u63b3fXn1jeklAC-6kmqQ]) is already part of the set of voters [ReplicaKey(id=1, directoryId=Optional[_u63b3fXn1jeklAC-6kmqQ]), ReplicaKey(id=0, directoryId=Optional[2rxcYUwQSvG8mI91fx7_gQ])].
+"""
+
+VOTER_NOT_FOUND_EXCEPTION = """
+org.apache.kafka.common.errors.VoterNotFoundException: Cannot remove voter ReplicaKey(id=105, directoryId=Optional[abcdefghijklmnopqrstug]) from the set of voters [ReplicaKey(id=1, directoryId=Optional[_u63b3fXn1jeklAC-6kmqQ]), ReplicaKey(id=0, directoryId=Optional[2rxcYUwQSvG8mI91fx7_gQ])]
+java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.VoterNotFoundException: Cannot remove voter ReplicaKey(id=105, directoryId=Optional[abcdefghijklmnopqrstug]) from the set of voters [ReplicaKey(id=1, directoryId=Optional[_u63b3fXn1jeklAC-6kmqQ]), ReplicaKey(id=0, directoryId=Optional[2rxcYUwQSvG8mI91fx7_gQ])]
+	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
+	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
+	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:165)
+	at org.apache.kafka.tools.MetadataQuorumCommand.handleRemoveController(MetadataQuorumCommand.java:499)
+	at org.apache.kafka.tools.MetadataQuorumCommand.execute(MetadataQuorumCommand.java:151)
+	at org.apache.kafka.tools.MetadataQuorumCommand.mainNoExit(MetadataQuorumCommand.java:81)
+	at org.apache.kafka.tools.MetadataQuorumCommand.main(MetadataQuorumCommand.java:76)
+Caused by: org.apache.kafka.common.errors.VoterNotFoundException: Cannot remove voter ReplicaKey(id=105, directoryId=Optional[abcdefghijklmnopqrstug]) from the set of voters [ReplicaKey(id=1, directoryId=Optional[_u63b3fXn1jeklAC-6kmqQ]), ReplicaKey(id=0, directoryId=Optional[2rxcYUwQSvG8mI91fx7_gQ])]
+"""
+
+METADATA_QUORUM_STUB = {
+    "describe-replication": DESCRIBE_REPLICATION_RESPONSE,
+    "timeout-exception": TIMEOUT_EXCEPTION,
+    "duplicate-voter-exception": DUPLICATE_VOTER_EXCEPTION,
+    "voter-not-found-exception": VOTER_NOT_FOUND_EXCEPTION,
+}

--- a/tests/unit/test_controller_manager.py
+++ b/tests/unit/test_controller_manager.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from subprocess import CalledProcessError
+from typing import Callable
+from unittest.mock import MagicMock
+
+import pytest
+from charmlibs import pathops
+from src.core.workload import CharmedKafkaPaths, WorkloadBase
+from src.literals import BROKER, AuthMap, KRaftUnitStatus
+from src.managers.controller import ControllerManager
+from tests.unit.data.metadata_quorum_stub import METADATA_QUORUM_STUB
+
+
+@pytest.fixture()
+def fake_workload(tmp_path_factory) -> WorkloadBase:
+    workload = MagicMock(spec=WorkloadBase)
+    workload.write = lambda content, path: open(path, "w").write(content)
+    workload.root = pathops.LocalPath("/")
+    workload.paths = CharmedKafkaPaths(BROKER)
+    workload.paths.conf_path = tmp_path_factory.mktemp("workload")
+    return workload
+
+
+def _raises_process_error(stderr: str) -> Callable:
+    def _exec(*args, **kwargs):
+        raise CalledProcessError(returncode=1, cmd="cmd", stderr=stderr)
+
+    return _exec
+
+
+def test_quorum_status(fake_workload) -> None:
+    state = MagicMock()
+    state.peer_cluster.bootstrap_controller = "10.10.10.10:9097"
+    manager = ControllerManager(state=state, workload=fake_workload)
+
+    fake_workload.run_bin_command.return_value = METADATA_QUORUM_STUB["describe-replication"]
+    quorum_status = manager.quorum_status()
+    assert len(quorum_status) == 4
+    assert quorum_status[0].status == KRaftUnitStatus.LEADER
+    assert all(unit.directory_id for unit in quorum_status.values())
+
+    state.kraft_unit_id = 0
+    assert manager.is_kraft_leader_or_follower()
+
+    for _id in (100, 101, 1000, 9999):
+        state.kraft_unit_id = _id
+        assert not manager.is_kraft_leader_or_follower()
+
+    fake_workload.run_bin_command = _raises_process_error(stderr="any-error")
+    assert not manager.quorum_status()
+
+
+def test_add_controller(fake_workload) -> None:
+    state = MagicMock()
+    state.peer_cluster.bootstrap_controller = "10.10.10.10:9097"
+    fake_workload.run_bin_command.return_value = "done"
+    manager = ControllerManager(state=state, workload=fake_workload)
+
+    manager.add_controller("10.10.10.10:9097")
+    assert fake_workload.run_bin_command.call_args.kwargs["bin_keyword"] == "metadata-quorum"
+    _args = " ".join(fake_workload.run_bin_command.call_args.kwargs["bin_args"])
+    assert "add-controller" in _args
+    assert f"--command-config {fake_workload.paths.conf_path}/server.properties" in _args
+    assert "--bootstrap-controller 10.10.10.10:9097" in _args
+
+    # DuplicateVoterException is fine
+    fake_workload.run_bin_command = _raises_process_error(
+        stderr=METADATA_QUORUM_STUB["duplicate-voter-exception"]
+    )
+    manager.add_controller("10.10.10.10:9097")
+
+    # Any other exception is also fine, we'll retry on update-status
+    fake_workload.run_bin_command = _raises_process_error(
+        stderr="org.apache.kafka.common.errors.InvalidConfigurationException"
+    )
+    manager.add_controller("10.10.10.10:9097")
+
+
+def test_remove_controller(fake_workload) -> None:
+    state = MagicMock()
+    state.cluster.bootstrap_controller = "10.10.10.10:9097"
+    manager = ControllerManager(state=state, workload=fake_workload)
+
+    fake_workload.run_bin_command.return_value = "done"
+
+    manager.remove_controller(101, "abcdefg")
+    assert fake_workload.run_bin_command.call_args.kwargs["bin_keyword"] == "metadata-quorum"
+    _args = " ".join(fake_workload.run_bin_command.call_args.kwargs["bin_args"])
+    assert "remove-controller" in _args
+    assert f"--command-config {fake_workload.paths.conf_path}/server.properties" in _args
+    assert "--bootstrap-controller 10.10.10.10:9097" in _args
+    assert "--controller-id 101" in _args
+    assert "--controller-directory-id abcdefg" in _args
+
+    fake_workload.run_bin_command = _raises_process_error(
+        stderr=METADATA_QUORUM_STUB["timeout-exception"]
+    )
+    manager.remove_controller(101, "directory-id")
+
+    fake_workload.run_bin_command = _raises_process_error(
+        stderr="org.apache.kafka.common.errors.InvalidConfigurationException"
+    )
+    with pytest.raises(CalledProcessError):
+        manager.remove_controller(101, "directory-id")
+
+
+@pytest.mark.parametrize("socket_healthy", [True, False])
+def test_listener_health_check(fake_workload, caplog, socket_healthy: bool) -> None:
+    caplog.set_level(logging.DEBUG)
+    state = MagicMock()
+    state.peer_cluster.bootstrap_controller = "10.10.10.10:9097"
+    state.brokers = [MagicMock(), MagicMock(), MagicMock()]
+
+    manager = ControllerManager(state=state, workload=fake_workload)
+
+    manager.workload.check_socket.return_value = socket_healthy
+    assert (
+        manager.listener_health_check("CONTROLLER", AuthMap("SASL_PLAINTEXT", "SCRAM-SHA-512"))
+        == socket_healthy
+    )
+    manager.workload.check_socket.assert_called_once()
+    assert manager.workload.check_socket.call_args.args[1] == 9097
+
+    manager.workload.check_socket.reset_mock()
+    manager.workload.check_socket.return_value = socket_healthy
+    assert (
+        manager.listener_health_check(
+            "CONTROLLER", AuthMap("SASL_PLAINTEXT", "SCRAM-SHA-512"), all_units=True
+        )
+        == socket_healthy
+    )
+    assert manager.workload.check_socket.call_count == 1 if not socket_healthy else 3

--- a/tests/unit/test_workload.py
+++ b/tests/unit/test_workload.py
@@ -27,8 +27,9 @@ def test_run_bin_command_args(patched_exec):
     assert "--list" == patched_exec.call_args.args[0].split()[-1]
 
 
-def test_get_service_pid_raises():
+def test_get_service_pid_raises(monkeypatch):
     """Checks get_service_pid raises if PID cannot be found."""
+    monkeypatch.undo()
     with (
         patch(
             "builtins.open",
@@ -41,7 +42,8 @@ def test_get_service_pid_raises():
         KafkaWorkload().get_service_pid()
 
 
-def test_get_service_pid_raises_no_pid():
+def test_get_service_pid_raises_no_pid(monkeypatch):
+    monkeypatch.undo()
     """Checks get_service_pid raises if PID cannot be found."""
     with (
         patch("subprocess.check_output", return_value=""),

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,10 @@ set_env =
     balancer-multi: DEPLOYMENT=multi
     kraft-single: DEPLOYMENT=single
     kraft-multi: DEPLOYMENT=multi
+    kraft-single-tls: DEPLOYMENT=single
+    kraft-multi-tls: DEPLOYMENT=multi
+    kraft-single-tls: TLS=enabled
+    kraft-multi-tls: TLS=enabled
 
 pass_env =
     PYTHONPATH
@@ -111,6 +115,18 @@ description = Run KRaft mode tests
 pass_env =
     {[testenv]pass_env}
     CI
+    TLS
+commands =
+    poetry install --with integration
+    poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_kraft.py
+
+
+[testenv:integration-kraft-{single,multi}-tls]
+description = Run KRaft mode tests
+pass_env =
+    {[testenv]pass_env}
+    CI
+    TLS
 commands =
     poetry install --with integration
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_kraft.py


### PR DESCRIPTION
This PR adds TLS support for the controller listener. The controller listener upgrade is tricky, here's how we tackle it:
- For brokers, basically follow the [KIP-853 guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=217391519#KIP853:KRaftControllerMembershipChanges-Upgradingcontrollerlistener)
- For controllers, we first scale the quorum to one unit, upgrade the leader controller, then upgrade the followers and add them back to the quorum.

## Other Changes

- This PR also introduces some performance optimization tweaks, like:
  -  safe caching of some of the state properties
   - minor tweaks in CI.
- Use online cluster checks instead of relation data for handling dynamic quorums: https://github.com/canonical/kafka-operator/pull/340/commits/23c26577264edf3022405157b7a8858fd4f23dd6