### PR TITLE
chore: Update the documentation badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CharmHub Badge](https://charmhub.io/kafka/badge.svg)](https://charmhub.io/kafka)
 [![Release](https://github.com/canonical/kafka-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/kafka-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/kafka-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/kafka-operator/actions/workflows/ci.yaml?query=branch%3Amain)
-[![Docs](https://github.com/canonical/kafka-operator/actions/workflows/sync_docs.yaml/badge.svg)](https://github.com/canonical/kafka-operator/actions/workflows/sync_docs.yaml)
+[![Docs](https://readthedocs.com/projects/canonical-charmed-kafka/badge/?version=main&style=plastic)](https://app.readthedocs.com/projects/canonical-charmed-kafka/builds/?version__slug=main)
 
 ## Overview
 


### PR DESCRIPTION
Update the badge to show status from ReadTheDocs build for the `main` branch.