### PR TITLE
[DPE-7141] JBOD support

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -654,9 +654,9 @@ class KafkaBroker(RelationState):
         return self.k8s.get_node_ip(self.pod_name)
 
     @property
-    def directory_id(self) -> str:
+    def metadata_directory_id(self) -> str:
         """Directory ID of the node as saved in `meta.properties`."""
-        return self.relation_data.get("directory-id", "")
+        return self.relation_data.get("metadata-directory-id", "")
 
     @property
     def added_to_quorum(self) -> bool:

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -44,6 +44,7 @@ from literals import (
 from managers.auth import AuthManager
 from managers.balancer import BalancerManager
 from managers.config import TESTING_OPTIONS, ConfigManager
+from managers.controller import ControllerManager
 from managers.k8s import K8sManager
 from managers.tls import TLSManager
 from workload import KafkaWorkload
@@ -73,6 +74,7 @@ class BrokerOperator(Object):
             substrate=self.charm.substrate,
             config=self.charm.config,
         )
+        self.controller_manager = ControllerManager(self.charm.state, self.workload)
 
         # Fast exit after workload instantiation, but before any event observer
         if not any(role in self.charm.config.roles for role in [BROKER.value, CONTROLLER.value]):
@@ -272,6 +274,11 @@ class BrokerOperator(Object):
 
         if properties_changed:
             if isinstance(event, StorageEvent):  # to get new storages
+                self.controller_manager.format_storages(
+                    uuid=self.charm.state.peer_cluster.cluster_uuid,
+                    internal_user_credentials=self.charm.state.cluster.internal_user_credentials,
+                    initial_controllers=f"{self.charm.state.peer_cluster.bootstrap_unit_id}@{self.charm.state.peer_cluster.bootstrap_controller}:{self.charm.state.peer_cluster.bootstrap_replica_id}",
+                )
                 self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit(
                     callback_override="_disable_enable_restart_broker"
                 )

--- a/src/events/controller.py
+++ b/src/events/controller.py
@@ -160,7 +160,7 @@ class KRaftHandler(Object):
         updated_bootstrap_data = {
             "bootstrap-controller": self.charm.state.bootstrap_controller,
             "bootstrap-unit-id": str(self.charm.state.kraft_unit_id),
-            "bootstrap-replica-id": self.charm.state.unit_broker.directory_id,
+            "bootstrap-replica-id": self.charm.state.unit_broker.metadata_directory_id,
         }
         self.charm.state.cluster.update(updated_bootstrap_data)
 
@@ -179,12 +179,12 @@ class KRaftHandler(Object):
         ):
             return
 
-        directory_id = self.controller_manager.add_controller(
+        metadata_directory_id = self.controller_manager.add_controller(
             self.charm.state.cluster.bootstrap_controller
         )
 
         self.charm.state.unit_broker.update(
-            {"directory-id": directory_id, "added-to-quorum": "true"}
+            {"metadata-directory-id": metadata_directory_id, "added-to-quorum": "true"}
         )
 
     def remove_from_quorum(self) -> None:
@@ -193,15 +193,15 @@ class KRaftHandler(Object):
             return
 
         if self.charm.state.unit_broker.added_to_quorum or self.charm.unit.is_leader():
-            directory_id = (
-                self.charm.state.unit_broker.directory_id
+            metadata_directory_id = (
+                self.charm.state.unit_broker.metadata_directory_id
                 if not self.charm.unit.is_leader()
                 else self.charm.state.cluster.bootstrap_replica_id
             )
             self.charm.state.unit_broker.update({"added-to-quorum": ""})
             self.controller_manager.remove_controller(
                 self.charm.state.kraft_unit_id,
-                directory_id,
+                metadata_directory_id,
                 bootstrap_node=self.charm.state.bootstrap_controller,
             )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -443,7 +443,7 @@ def test_storage_add_defers_if_service_not_healthy(
 
 
 @pytest.mark.skipif(SUBSTRATE == "k8s", reason="multiple storage not supported in K8s")
-def test_storage_add_disableenables_and_starts(
+def test_storage_add(
     ctx: Context, base_state: State, kraft_data: dict[str, str], passwords_data: dict[str, str]
 ) -> None:
     # Given
@@ -462,6 +462,7 @@ def test_storage_add_disableenables_and_starts(
         patch("managers.config.ConfigManager.set_server_properties"),
         patch("managers.config.ConfigManager.set_client_properties"),
         patch("managers.config.ConfigManager.set_environment"),
+        patch("managers.controller.ControllerManager.format_storages") as patched_format_storages,
         patch("workload.KafkaWorkload.read", return_value=["gandalf=grey"]),
         patch("workload.KafkaWorkload.disable_enable") as patched_disable_enable,
         patch("workload.KafkaWorkload.start") as patched_start,
@@ -470,6 +471,7 @@ def test_storage_add_disableenables_and_starts(
         ctx.run(ctx.on.storage_attached(storage), state_in)
 
     # Then
+    assert patched_format_storages.call_count == 1
     assert patched_disable_enable.call_count == 1
     assert patched_start.call_count == 1
     assert patched_defer.call_count == 0

--- a/tests/unit/test_kraft.py
+++ b/tests/unit/test_kraft.py
@@ -178,8 +178,8 @@ def test_remove_controller(charm_configuration, base_state: State):
     cluster_peer = PeerRelation(
         PEER,
         PEER,
-        local_unit_data={"added-to-quorum": "true", "directory-id": "random-uuid"},
-        peers_data={1: {"added-to-quorum": "true", "directory-id": "other-uuid"}},
+        local_unit_data={"added-to-quorum": "true", "metadata-directory-id": "random-uuid"},
+        peers_data={1: {"added-to-quorum": "true", "metadata-directory-id": "other-uuid"}},
     )
     state_in = dataclasses.replace(base_state, relations=[cluster_peer], leader=False)
 
@@ -204,7 +204,7 @@ def test_leader_change(charm_configuration, base_state: State):
     cluster_peer = PeerRelation(
         PEER,
         PEER,
-        local_unit_data={"added-to-quorum": "true", "directory-id": "new-uuid"},
+        local_unit_data={"added-to-quorum": "true", "metadata-directory-id": "new-uuid"},
         local_app_data={
             "bootstrap-controller": previous_controller,
             "bootstrap-replica-id": "old-uuid",


### PR DESCRIPTION
Adds JBOD support to the charm.

- Rename `directory_id` to `metadata_directory_id` as the directory used for the quorum command is specifically the metadata one.
- Adding storage now requires manual formatting.