### PR TITLE
[DPE-7526] feat: use multiple TLS interfaces for internal/external

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
       path-to-charm-directory: ${{ matrix.path }}
       cache: false # TODO: fix after added to the charmcraftcache
 
-  integration-test:
+  integration-test-github:
     strategy:
       fail-fast: false
       matrix:
@@ -85,18 +85,11 @@ jobs:
           - integration-password-rotation
           - integration-tls
           #- integration-upgrade
-          - integration-balancer-single
-          - integration-balancer-multi
           - integration-kraft
           - integration-kraft-tls
+          - integration-ha
         kraft-mode:
           - single
-          - multi
-        exclude:
-          - tox-environments: integration-balancer-single
-            kraft-mode: single
-          - tox-environments: integration-balancer-multi
-            kraft-mode: single   
     name: ${{ matrix.tox-environments }} | ${{ matrix.kraft-mode }}
     needs:
       - lint
@@ -134,19 +127,24 @@ jobs:
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
 
-  integration-test-ha:
+  integration-test-self-hosted:
     strategy:
       fail-fast: false
       matrix:
         tox-environments:
+          - integration-charm
+          - integration-provider
+          - integration-password-rotation
+          - integration-tls
+          #- integration-upgrade
+          - integration-balancer-single
+          - integration-balancer-multi
+          - integration-kraft
+          - integration-kraft-tls
           - integration-ha
           - integration-ha-controller
         kraft-mode:
-          - single
           - multi
-        exclude:
-          - tox-environments: integration-ha-controller
-            kraft-mode: single 
     name: ${{ matrix.tox-environments }} | ${{ matrix.kraft-mode }}
     needs:
       - lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,7 @@ jobs:
           - integration-balancer-single
           - integration-balancer-multi
           - integration-kraft
+          - integration-kraft-tls
         kraft-mode:
           - single
           - multi

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1,0 +1,1993 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Charm library for managing TLS certificates (V4).
+
+This library contains the Requires and Provides classes for handling the tls-certificates
+interface.
+
+Pre-requisites:
+  - Juju >= 3.0
+  - cryptography >= 43.0.0
+  - pydantic >= 1.0
+
+Learn more on how-to use the TLS Certificates interface library by reading the documentation:
+- https://charmhub.io/tls-certificates-interface/
+
+"""  # noqa: D214, D405, D411, D416
+
+import copy
+import ipaddress
+import json
+import logging
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import FrozenSet, List, MutableMapping, Optional, Tuple, Union
+
+import pydantic
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtensionOID, NameOID
+from ops import BoundEvent, CharmBase, CharmEvents, Secret, SecretExpiredEvent, SecretRemoveEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+from ops.jujuversion import JujuVersion
+from ops.model import (
+    Application,
+    ModelError,
+    Relation,
+    SecretNotFoundError,
+    Unit,
+)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "afd8c2bccf834997afce12c2706d2ede"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 4
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 19
+
+PYDEPS = [
+    "cryptography>=43.0.0",
+    "pydantic",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class TLSCertificatesError(Exception):
+    """Base class for custom errors raised by this library."""
+
+
+class DataValidationError(TLSCertificatesError):
+    """Raised when data validation fails."""
+
+
+if int(pydantic.version.VERSION.split(".")[0]) < 2:
+
+    class _DatabagModel(pydantic.BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            # ignore any extra fields in the databag
+            extra = "ignore"
+            """Ignore any extra fields in the databag."""
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
+                return databag
+
+            dct = self.dict(by_alias=True, exclude_defaults=True)
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+
+            return databag
+
+else:
+    from pydantic import ConfigDict
+
+    class _DatabagModel(pydantic.BaseModel):
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,  # type: ignore
+        )
+        """Pydantic config."""
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            Args:
+                databag: The databag to write to.
+                clear: Whether to clear the databag before writing.
+
+            Returns:
+                MutableMapping: The databag.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=True)
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+
+            return databag
+
+
+class _Certificate(pydantic.BaseModel):
+    """Certificate model."""
+
+    ca: str
+    certificate_signing_request: str
+    certificate: str
+    chain: Optional[List[str]] = None
+    revoked: Optional[bool] = None
+
+    def to_provider_certificate(self, relation_id: int) -> "ProviderCertificate":
+        """Convert to a ProviderCertificate."""
+        return ProviderCertificate(
+            relation_id=relation_id,
+            certificate=Certificate.from_string(self.certificate),
+            certificate_signing_request=CertificateSigningRequest.from_string(
+                self.certificate_signing_request
+            ),
+            ca=Certificate.from_string(self.ca),
+            chain=[Certificate.from_string(certificate) for certificate in self.chain]
+            if self.chain
+            else [],
+            revoked=self.revoked,
+        )
+
+
+class _CertificateSigningRequest(pydantic.BaseModel):
+    """Certificate signing request model."""
+
+    certificate_signing_request: str
+    ca: Optional[bool]
+
+
+class _ProviderApplicationData(_DatabagModel):
+    """Provider application data model."""
+
+    certificates: List[_Certificate] = []
+
+
+class _RequirerData(_DatabagModel):
+    """Requirer data model.
+
+    The same model is used for the unit and application data.
+    """
+
+    certificate_signing_requests: List[_CertificateSigningRequest] = []
+
+
+class Mode(Enum):
+    """Enum representing the mode of the certificate request.
+
+    UNIT (default): Request a certificate for the unit.
+        Each unit will manage its private key,
+        certificate signing request and certificate.
+    APP: Request a certificate for the application.
+        Only the leader unit will manage the private key, certificate signing request
+        and certificate.
+    """
+
+    UNIT = 1
+    APP = 2
+
+
+@dataclass(frozen=True)
+class PrivateKey:
+    """This class represents a private key."""
+
+    raw: str
+
+    def __str__(self):
+        """Return the private key as a string."""
+        return self.raw
+
+    @classmethod
+    def from_string(cls, private_key: str) -> "PrivateKey":
+        """Create a PrivateKey object from a private key."""
+        return cls(raw=private_key.strip())
+
+    def is_valid(self) -> bool:
+        """Validate that the private key is PEM-formatted, RSA, and at least 2048 bits."""
+        try:
+            key = serialization.load_pem_private_key(
+                self.raw.encode(),
+                password=None,
+            )
+
+            if not isinstance(key, rsa.RSAPrivateKey):
+                logger.warning("Private key is not an RSA key")
+                return False
+
+            if key.key_size < 2048:
+                logger.warning("RSA key size is less than 2048 bits")
+                return False
+
+            return True
+        except ValueError:
+            logger.warning("Invalid private key format")
+            return False
+
+
+@dataclass(frozen=True)
+class Certificate:
+    """This class represents a certificate."""
+
+    raw: str
+    common_name: str
+    expiry_time: datetime
+    validity_start_time: datetime
+    is_ca: bool = False
+    sans_dns: Optional[FrozenSet[str]] = frozenset()
+    sans_ip: Optional[FrozenSet[str]] = frozenset()
+    sans_oid: Optional[FrozenSet[str]] = frozenset()
+    email_address: Optional[str] = None
+    organization: Optional[str] = None
+    organizational_unit: Optional[str] = None
+    country_name: Optional[str] = None
+    state_or_province_name: Optional[str] = None
+    locality_name: Optional[str] = None
+
+    def __str__(self) -> str:
+        """Return the certificate as a string."""
+        return self.raw
+
+    @classmethod
+    def from_string(cls, certificate: str) -> "Certificate":
+        """Create a Certificate object from a certificate."""
+        try:
+            certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
+        except ValueError as e:
+            logger.error("Could not load certificate: %s", e)
+            raise TLSCertificatesError("Could not load certificate")
+
+        common_name = certificate_object.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        country_name = certificate_object.subject.get_attributes_for_oid(NameOID.COUNTRY_NAME)
+        state_or_province_name = certificate_object.subject.get_attributes_for_oid(
+            NameOID.STATE_OR_PROVINCE_NAME
+        )
+        locality_name = certificate_object.subject.get_attributes_for_oid(NameOID.LOCALITY_NAME)
+        organization_name = certificate_object.subject.get_attributes_for_oid(
+            NameOID.ORGANIZATION_NAME
+        )
+        organizational_unit = certificate_object.subject.get_attributes_for_oid(
+            NameOID.ORGANIZATIONAL_UNIT_NAME
+        )
+        email_address = certificate_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
+        sans_dns: List[str] = []
+        sans_ip: List[str] = []
+        sans_oid: List[str] = []
+        try:
+            sans = certificate_object.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            ).value
+            for san in sans:
+                if isinstance(san, x509.DNSName):
+                    sans_dns.append(san.value)
+                if isinstance(san, x509.IPAddress):
+                    sans_ip.append(str(san.value))
+                if isinstance(san, x509.RegisteredID):
+                    sans_oid.append(str(san.value))
+        except x509.ExtensionNotFound:
+            logger.debug("No SANs found in certificate")
+            sans_dns = []
+            sans_ip = []
+            sans_oid = []
+        expiry_time = certificate_object.not_valid_after_utc
+        validity_start_time = certificate_object.not_valid_before_utc
+        is_ca = False
+        try:
+            is_ca = certificate_object.extensions.get_extension_for_oid(
+                ExtensionOID.BASIC_CONSTRAINTS
+            ).value.ca  # type: ignore[reportAttributeAccessIssue]
+        except x509.ExtensionNotFound:
+            pass
+
+        return cls(
+            raw=certificate.strip(),
+            common_name=str(common_name[0].value),
+            is_ca=is_ca,
+            country_name=str(country_name[0].value) if country_name else None,
+            state_or_province_name=str(state_or_province_name[0].value)
+            if state_or_province_name
+            else None,
+            locality_name=str(locality_name[0].value) if locality_name else None,
+            organization=str(organization_name[0].value) if organization_name else None,
+            organizational_unit=str(organizational_unit[0].value) if organizational_unit else None,
+            email_address=str(email_address[0].value) if email_address else None,
+            sans_dns=frozenset(sans_dns),
+            sans_ip=frozenset(sans_ip),
+            sans_oid=frozenset(sans_oid),
+            expiry_time=expiry_time,
+            validity_start_time=validity_start_time,
+        )
+
+    def matches_private_key(self, private_key: PrivateKey) -> bool:
+        """Check if this certificate matches a given private key.
+
+        Args:
+            private_key (PrivateKey): The private key to validate against.
+
+        Returns:
+            bool: True if the certificate matches the private key, False otherwise.
+        """
+        try:
+            cert_object = x509.load_pem_x509_certificate(self.raw.encode())
+            key_object = serialization.load_pem_private_key(
+                private_key.raw.encode(), password=None
+            )
+
+            cert_public_key = cert_object.public_key()
+            key_public_key = key_object.public_key()
+
+            if not isinstance(cert_public_key, rsa.RSAPublicKey):
+                logger.warning("Certificate does not use RSA public key")
+                return False
+
+            if not isinstance(key_public_key, rsa.RSAPublicKey):
+                logger.warning("Private key is not an RSA key")
+                return False
+
+            return cert_public_key.public_numbers() == key_public_key.public_numbers()
+        except Exception as e:
+            logger.warning("Failed to validate certificate and private key match: %s", e)
+            return False
+
+
+@dataclass(frozen=True)
+class CertificateSigningRequest:
+    """This class represents a certificate signing request."""
+
+    raw: str
+    common_name: str
+    sans_dns: Optional[FrozenSet[str]] = None
+    sans_ip: Optional[FrozenSet[str]] = None
+    sans_oid: Optional[FrozenSet[str]] = None
+    email_address: Optional[str] = None
+    organization: Optional[str] = None
+    organizational_unit: Optional[str] = None
+    country_name: Optional[str] = None
+    state_or_province_name: Optional[str] = None
+    locality_name: Optional[str] = None
+    has_unique_identifier: bool = False
+
+    def __eq__(self, other: object) -> bool:
+        """Check if two CertificateSigningRequest objects are equal."""
+        if not isinstance(other, CertificateSigningRequest):
+            return NotImplemented
+        return self.raw.strip() == other.raw.strip()
+
+    def __str__(self) -> str:
+        """Return the CSR as a string."""
+        return self.raw
+
+    @classmethod
+    def from_string(cls, csr: str) -> "CertificateSigningRequest":
+        """Create a CertificateSigningRequest object from a CSR."""
+        try:
+            csr_object = x509.load_pem_x509_csr(csr.encode())
+        except ValueError as e:
+            logger.error("Could not load CSR: %s", e)
+            raise TLSCertificatesError("Could not load CSR")
+        common_name = csr_object.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        country_name = csr_object.subject.get_attributes_for_oid(NameOID.COUNTRY_NAME)
+        state_or_province_name = csr_object.subject.get_attributes_for_oid(
+            NameOID.STATE_OR_PROVINCE_NAME
+        )
+        locality_name = csr_object.subject.get_attributes_for_oid(NameOID.LOCALITY_NAME)
+        organization_name = csr_object.subject.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)
+        organizational_unit = csr_object.subject.get_attributes_for_oid(
+            NameOID.ORGANIZATIONAL_UNIT_NAME
+        )
+        email_address = csr_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
+        unique_identifier = csr_object.subject.get_attributes_for_oid(
+            NameOID.X500_UNIQUE_IDENTIFIER
+        )
+        try:
+            sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+            sans_dns = frozenset(sans.get_values_for_type(x509.DNSName))
+            sans_ip = frozenset([str(san) for san in sans.get_values_for_type(x509.IPAddress)])
+            sans_oid = frozenset(
+                [san.dotted_string for san in sans.get_values_for_type(x509.RegisteredID)]
+            )
+        except x509.ExtensionNotFound:
+            sans = frozenset()
+            sans_dns = frozenset()
+            sans_ip = frozenset()
+            sans_oid = frozenset()
+        return cls(
+            raw=csr.strip(),
+            common_name=str(common_name[0].value),
+            country_name=str(country_name[0].value) if country_name else None,
+            state_or_province_name=str(state_or_province_name[0].value)
+            if state_or_province_name
+            else None,
+            locality_name=str(locality_name[0].value) if locality_name else None,
+            organization=str(organization_name[0].value) if organization_name else None,
+            organizational_unit=str(organizational_unit[0].value) if organizational_unit else None,
+            email_address=str(email_address[0].value) if email_address else None,
+            sans_dns=sans_dns,
+            sans_ip=sans_ip,
+            sans_oid=sans_oid,
+            has_unique_identifier=bool(unique_identifier),
+        )
+
+    def matches_private_key(self, key: PrivateKey) -> bool:
+        """Check if a CSR matches a private key.
+
+        This function only works with RSA keys.
+
+        Args:
+            key (PrivateKey): Private key
+        Returns:
+            bool: True/False depending on whether the CSR matches the private key.
+        """
+        try:
+            csr_object = x509.load_pem_x509_csr(self.raw.encode("utf-8"))
+            key_object = serialization.load_pem_private_key(
+                data=key.raw.encode("utf-8"), password=None
+            )
+            key_object_public_key = key_object.public_key()
+            csr_object_public_key = csr_object.public_key()
+            if not isinstance(key_object_public_key, rsa.RSAPublicKey):
+                logger.warning("Key is not an RSA key")
+                return False
+            if not isinstance(csr_object_public_key, rsa.RSAPublicKey):
+                logger.warning("CSR is not an RSA key")
+                return False
+            if (
+                csr_object_public_key.public_numbers().n
+                != key_object_public_key.public_numbers().n
+            ):
+                logger.warning("Public key numbers between CSR and key do not match")
+                return False
+        except ValueError:
+            logger.warning("Could not load certificate or CSR.")
+            return False
+        return True
+
+    def matches_certificate(self, certificate: Certificate) -> bool:
+        """Check if a CSR matches a certificate.
+
+        Args:
+            certificate (Certificate): Certificate
+        Returns:
+            bool: True/False depending on whether the CSR matches the certificate.
+        """
+        csr_object = x509.load_pem_x509_csr(self.raw.encode("utf-8"))
+        cert_object = x509.load_pem_x509_certificate(certificate.raw.encode("utf-8"))
+        return csr_object.public_key() == cert_object.public_key()
+
+    def get_sha256_hex(self) -> str:
+        """Calculate the hash of the provided data and return the hexadecimal representation."""
+        digest = hashes.Hash(hashes.SHA256())
+        digest.update(self.raw.encode())
+        return digest.finalize().hex()
+
+
+@dataclass(frozen=True)
+class CertificateRequestAttributes:
+    """A representation of the certificate request attributes.
+
+    This class should be used inside the requirer charm to specify the requested
+    attributes for the certificate.
+    """
+
+    common_name: str
+    sans_dns: Optional[FrozenSet[str]] = frozenset()
+    sans_ip: Optional[FrozenSet[str]] = frozenset()
+    sans_oid: Optional[FrozenSet[str]] = frozenset()
+    email_address: Optional[str] = None
+    organization: Optional[str] = None
+    organizational_unit: Optional[str] = None
+    country_name: Optional[str] = None
+    state_or_province_name: Optional[str] = None
+    locality_name: Optional[str] = None
+    is_ca: bool = False
+    add_unique_id_to_subject_name: bool = True
+
+    def is_valid(self) -> bool:
+        """Check whether the certificate request is valid."""
+        if not self.common_name:
+            return False
+        return True
+
+    def generate_csr(
+        self,
+        private_key: PrivateKey,
+    ) -> CertificateSigningRequest:
+        """Generate a CSR using private key and subject.
+
+        Args:
+            private_key (PrivateKey): Private key
+
+        Returns:
+            CertificateSigningRequest: CSR
+        """
+        return generate_csr(
+            private_key=private_key,
+            common_name=self.common_name,
+            sans_dns=self.sans_dns,
+            sans_ip=self.sans_ip,
+            sans_oid=self.sans_oid,
+            email_address=self.email_address,
+            organization=self.organization,
+            organizational_unit=self.organizational_unit,
+            country_name=self.country_name,
+            state_or_province_name=self.state_or_province_name,
+            locality_name=self.locality_name,
+            add_unique_id_to_subject_name=self.add_unique_id_to_subject_name,
+        )
+
+    @classmethod
+    def from_csr(cls, csr: CertificateSigningRequest, is_ca: bool):
+        """Create a CertificateRequestAttributes object from a CSR."""
+        return cls(
+            common_name=csr.common_name,
+            sans_dns=csr.sans_dns,
+            sans_ip=csr.sans_ip,
+            sans_oid=csr.sans_oid,
+            email_address=csr.email_address,
+            organization=csr.organization,
+            organizational_unit=csr.organizational_unit,
+            country_name=csr.country_name,
+            state_or_province_name=csr.state_or_province_name,
+            locality_name=csr.locality_name,
+            is_ca=is_ca,
+            add_unique_id_to_subject_name=csr.has_unique_identifier,
+        )
+
+
+@dataclass(frozen=True)
+class ProviderCertificate:
+    """This class represents a certificate provided by the TLS provider."""
+
+    relation_id: int
+    certificate: Certificate
+    certificate_signing_request: CertificateSigningRequest
+    ca: Certificate
+    chain: List[Certificate]
+    revoked: Optional[bool] = None
+
+    def to_json(self) -> str:
+        """Return the object as a JSON string.
+
+        Returns:
+            str: JSON representation of the object
+        """
+        return json.dumps(
+            {
+                "csr": str(self.certificate_signing_request),
+                "certificate": str(self.certificate),
+                "ca": str(self.ca),
+                "chain": [str(cert) for cert in self.chain],
+                "revoked": self.revoked,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class RequirerCertificateRequest:
+    """This class represents a certificate signing request requested by a specific TLS requirer."""
+
+    relation_id: int
+    certificate_signing_request: CertificateSigningRequest
+    is_ca: bool
+
+
+class CertificateAvailableEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is available."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: Certificate,
+        certificate_signing_request: CertificateSigningRequest,
+        ca: Certificate,
+        chain: List[Certificate],
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.certificate_signing_request = certificate_signing_request
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "certificate": str(self.certificate),
+            "certificate_signing_request": str(self.certificate_signing_request),
+            "ca": str(self.ca),
+            "chain": json.dumps([str(certificate) for certificate in self.chain]),
+        }
+
+    def restore(self, snapshot: dict):
+        """Restore snapshot."""
+        self.certificate = Certificate.from_string(snapshot["certificate"])
+        self.certificate_signing_request = CertificateSigningRequest.from_string(
+            snapshot["certificate_signing_request"]
+        )
+        self.ca = Certificate.from_string(snapshot["ca"])
+        chain_strs = json.loads(snapshot["chain"])
+        self.chain = [Certificate.from_string(chain_str) for chain_str in chain_strs]
+
+    def chain_as_pem(self) -> str:
+        """Return full certificate chain as a PEM string."""
+        return "\n\n".join([str(cert) for cert in self.chain])
+
+
+def generate_private_key(
+    key_size: int = 2048,
+    public_exponent: int = 65537,
+) -> PrivateKey:
+    """Generate a private key with the RSA algorithm.
+
+    Args:
+        key_size (int): Key size in bits, must be at least 2048 bits
+        public_exponent: Public exponent.
+
+    Returns:
+        PrivateKey: Private Key
+    """
+    if key_size < 2048:
+        raise ValueError("Key size must be at least 2048 bits for RSA security")
+    private_key = rsa.generate_private_key(
+        public_exponent=public_exponent,
+        key_size=key_size,
+    )
+    key_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return PrivateKey.from_string(key_bytes.decode())
+
+
+def calculate_relative_datetime(target_time: datetime, fraction: float) -> datetime:
+    """Calculate a datetime that is a given percentage from now to a target time.
+
+    Args:
+        target_time (datetime): The future datetime to interpolate towards.
+        fraction (float): Fraction of the interval from now to target_time (0.0-1.0).
+            1.0 means return target_time,
+            0.9 means return the time after 90% of the interval has passed,
+            and 0.0 means return now.
+    """
+    if fraction <= 0.0 or fraction > 1.0:
+        raise ValueError("Invalid fraction. Must be between 0.0 and 1.0")
+    now = datetime.now(timezone.utc)
+    time_until_target = target_time - now
+    return now + time_until_target * fraction
+
+
+def chain_has_valid_order(chain: List[str]) -> bool:
+    """Check if the chain has a valid order.
+
+    Validates that each certificate in the chain is properly signed by the next certificate.
+    The chain should be ordered from leaf to root, where each certificate is signed by
+    the next one in the chain.
+
+    Args:
+        chain (List[str]): List of certificates in PEM format, ordered from leaf to root
+
+    Returns:
+        bool: True if the chain has a valid order, False otherwise.
+    """
+    if len(chain) < 2:
+        return True
+
+    try:
+        for i in range(len(chain) - 1):
+            cert = x509.load_pem_x509_certificate(chain[i].encode())
+            issuer = x509.load_pem_x509_certificate(chain[i + 1].encode())
+            cert.verify_directly_issued_by(issuer)
+        return True
+    except (ValueError, TypeError, InvalidSignature):
+        return False
+
+
+def generate_csr(  # noqa: C901
+    private_key: PrivateKey,
+    common_name: str,
+    sans_dns: Optional[FrozenSet[str]] = frozenset(),
+    sans_ip: Optional[FrozenSet[str]] = frozenset(),
+    sans_oid: Optional[FrozenSet[str]] = frozenset(),
+    organization: Optional[str] = None,
+    organizational_unit: Optional[str] = None,
+    email_address: Optional[str] = None,
+    country_name: Optional[str] = None,
+    locality_name: Optional[str] = None,
+    state_or_province_name: Optional[str] = None,
+    add_unique_id_to_subject_name: bool = True,
+) -> CertificateSigningRequest:
+    """Generate a CSR using private key and subject.
+
+    Args:
+        private_key (PrivateKey): Private key
+        common_name (str): Common name
+        sans_dns (FrozenSet[str]): DNS Subject Alternative Names
+        sans_ip (FrozenSet[str]): IP Subject Alternative Names
+        sans_oid (FrozenSet[str]): OID Subject Alternative Names
+        organization (Optional[str]): Organization name
+        organizational_unit (Optional[str]): Organizational unit name
+        email_address (Optional[str]): Email address
+        country_name (Optional[str]): Country name
+        state_or_province_name (Optional[str]): State or province name
+        locality_name (Optional[str]): Locality name
+        add_unique_id_to_subject_name (bool): Whether a unique ID must be added to the CSR's
+            subject name. Always leave to "True" when the CSR is used to request certificates
+            using the tls-certificates relation.
+
+    Returns:
+        CertificateSigningRequest: CSR
+    """
+    signing_key = serialization.load_pem_private_key(str(private_key).encode(), password=None)
+    subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name)]
+    if add_unique_id_to_subject_name:
+        unique_identifier = uuid.uuid4()
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.X500_UNIQUE_IDENTIFIER, str(unique_identifier))
+        )
+    if organization:
+        subject_name.append(x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organization))
+    if organizational_unit:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit)
+        )
+    if email_address:
+        subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
+    if country_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    if state_or_province_name:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state_or_province_name)
+        )
+    if locality_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, locality_name))
+    csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
+
+    _sans: List[x509.GeneralName] = []
+    if sans_oid:
+        _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
+    if sans_ip:
+        _sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in sans_ip])
+    if sans_dns:
+        _sans.extend([x509.DNSName(san) for san in sans_dns])
+    if _sans:
+        csr = csr.add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
+    signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
+    csr_str = signed_certificate.public_bytes(serialization.Encoding.PEM).decode()
+    return CertificateSigningRequest.from_string(csr_str)
+
+
+def generate_ca(
+    private_key: PrivateKey,
+    validity: timedelta,
+    common_name: str,
+    sans_dns: Optional[FrozenSet[str]] = frozenset(),
+    sans_ip: Optional[FrozenSet[str]] = frozenset(),
+    sans_oid: Optional[FrozenSet[str]] = frozenset(),
+    organization: Optional[str] = None,
+    organizational_unit: Optional[str] = None,
+    email_address: Optional[str] = None,
+    country_name: Optional[str] = None,
+    state_or_province_name: Optional[str] = None,
+    locality_name: Optional[str] = None,
+) -> Certificate:
+    """Generate a self signed CA Certificate.
+
+    Args:
+        private_key (PrivateKey): Private key
+        validity (timedelta): Certificate validity time
+        common_name (str): Common Name that can be an IP or a Full Qualified Domain Name (FQDN).
+        sans_dns (FrozenSet[str]): DNS Subject Alternative Names
+        sans_ip (FrozenSet[str]): IP Subject Alternative Names
+        sans_oid (FrozenSet[str]): OID Subject Alternative Names
+        organization (Optional[str]): Organization name
+        organizational_unit (Optional[str]): Organizational unit name
+        email_address (Optional[str]): Email address
+        country_name (str): Certificate Issuing country
+        state_or_province_name (str): Certificate Issuing state or province
+        locality_name (str): Certificate Issuing locality
+
+    Returns:
+        Certificate: CA Certificate.
+    """
+    private_key_object = serialization.load_pem_private_key(
+        str(private_key).encode(), password=None
+    )
+    assert isinstance(private_key_object, rsa.RSAPrivateKey)
+    subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name)]
+    if organization:
+        subject_name.append(x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organization))
+    if organizational_unit:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit)
+        )
+    if email_address:
+        subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
+    if country_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    if state_or_province_name:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state_or_province_name)
+        )
+    if locality_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, locality_name))
+
+    subject_identifier_object = x509.SubjectKeyIdentifier.from_public_key(
+        private_key_object.public_key()
+    )
+    subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    key_usage = x509.KeyUsage(
+        digital_signature=True,
+        key_encipherment=True,
+        key_cert_sign=True,
+        key_agreement=False,
+        content_commitment=False,
+        data_encipherment=False,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False,
+    )
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name(subject_name))
+        .issuer_name(x509.Name(subject_name))
+        .public_key(private_key_object.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + validity)
+        .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier(
+                key_identifier=key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        )
+        .add_extension(key_usage, critical=True)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+    )
+    san_extension = _san_extension(
+        email_address=email_address,
+        sans_dns=sans_dns,
+        sans_ip=sans_ip,
+        sans_oid=sans_oid,
+    )
+    if san_extension:
+        builder = builder.add_extension(san_extension, critical=False)
+    cert = builder.sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
+    ca_cert_str = cert.public_bytes(serialization.Encoding.PEM).decode().strip()
+    return Certificate.from_string(ca_cert_str)
+
+
+def _san_extension(
+    email_address: Optional[str] = None,
+    sans_dns: Optional[FrozenSet[str]] = frozenset(),
+    sans_ip: Optional[FrozenSet[str]] = frozenset(),
+    sans_oid: Optional[FrozenSet[str]] = frozenset(),
+) -> Optional[x509.SubjectAlternativeName]:
+    sans: List[x509.GeneralName] = []
+    if email_address:
+        # If an e-mail address was provided, it should always be in the SAN
+        sans.append(x509.RFC822Name(email_address))
+    if sans_dns:
+        sans.extend([x509.DNSName(san) for san in sans_dns])
+    if sans_ip:
+        sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in sans_ip])
+    if sans_oid:
+        sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
+    if not sans:
+        return None
+    return x509.SubjectAlternativeName(sans)
+
+
+def generate_certificate(
+    csr: CertificateSigningRequest,
+    ca: Certificate,
+    ca_private_key: PrivateKey,
+    validity: timedelta,
+    is_ca: bool = False,
+) -> Certificate:
+    """Generate a TLS certificate based on a CSR.
+
+    Args:
+        csr (CertificateSigningRequest): CSR
+        ca (Certificate): CA Certificate
+        ca_private_key (PrivateKey): CA private key
+        validity (timedelta): Certificate validity time
+        is_ca (bool): Whether the certificate is a CA certificate
+
+    Returns:
+        Certificate: Certificate
+    """
+    csr_object = x509.load_pem_x509_csr(str(csr).encode())
+    subject = csr_object.subject
+    ca_pem = x509.load_pem_x509_certificate(str(ca).encode())
+    issuer = ca_pem.issuer
+    private_key = serialization.load_pem_private_key(str(ca_private_key).encode(), password=None)
+
+    certificate_builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(csr_object.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + validity)
+    )
+    extensions = _generate_certificate_request_extensions(
+        authority_key_identifier=ca_pem.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier
+        ).value.key_identifier,
+        csr=csr_object,
+        is_ca=is_ca,
+    )
+    for extension in extensions:
+        try:
+            certificate_builder = certificate_builder.add_extension(
+                extval=extension.value,
+                critical=extension.critical,
+            )
+        except ValueError as e:
+            logger.warning("Failed to add extension %s: %s", extension.oid, e)
+
+    cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
+    cert_bytes = cert.public_bytes(serialization.Encoding.PEM)
+    return Certificate.from_string(cert_bytes.decode().strip())
+
+
+def _generate_certificate_request_extensions(
+    authority_key_identifier: bytes,
+    csr: x509.CertificateSigningRequest,
+    is_ca: bool,
+) -> List[x509.Extension]:
+    """Generate a list of certificate extensions from a CSR and other known information.
+
+    Args:
+        authority_key_identifier (bytes): Authority key identifier
+        csr (x509.CertificateSigningRequest): CSR
+        is_ca (bool): Whether the certificate is a CA certificate
+
+    Returns:
+        List[x509.Extension]: List of extensions
+    """
+    cert_extensions_list: List[x509.Extension] = [
+        x509.Extension(
+            oid=ExtensionOID.AUTHORITY_KEY_IDENTIFIER,
+            value=x509.AuthorityKeyIdentifier(
+                key_identifier=authority_key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        ),
+        x509.Extension(
+            oid=ExtensionOID.SUBJECT_KEY_IDENTIFIER,
+            value=x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
+            critical=False,
+        ),
+        x509.Extension(
+            oid=ExtensionOID.BASIC_CONSTRAINTS,
+            critical=True,
+            value=x509.BasicConstraints(ca=is_ca, path_length=None),
+        ),
+    ]
+    if sans := _generate_subject_alternative_name_extension(csr):
+        cert_extensions_list.append(sans)
+
+    if is_ca:
+        cert_extensions_list.append(
+            x509.Extension(
+                ExtensionOID.KEY_USAGE,
+                critical=True,
+                value=x509.KeyUsage(
+                    digital_signature=False,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+            )
+        )
+
+    existing_oids = {ext.oid for ext in cert_extensions_list}
+    for extension in csr.extensions:
+        if extension.oid == ExtensionOID.SUBJECT_ALTERNATIVE_NAME:
+            continue
+        if extension.oid in existing_oids:
+            logger.warning("Extension %s is managed by the TLS provider, ignoring.", extension.oid)
+            continue
+        cert_extensions_list.append(extension)
+
+    return cert_extensions_list
+
+
+def _generate_subject_alternative_name_extension(
+    csr: x509.CertificateSigningRequest,
+) -> Optional[x509.Extension]:
+    sans: List[x509.GeneralName] = []
+    try:
+        loaded_san_ext = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        sans.extend(
+            [x509.DNSName(name) for name in loaded_san_ext.value.get_values_for_type(x509.DNSName)]
+        )
+        sans.extend(
+            [x509.IPAddress(ip) for ip in loaded_san_ext.value.get_values_for_type(x509.IPAddress)]
+        )
+        sans.extend(
+            [
+                x509.RegisteredID(oid)
+                for oid in loaded_san_ext.value.get_values_for_type(x509.RegisteredID)
+            ]
+        )
+        sans.extend(
+            [
+                x509.RFC822Name(name)
+                for name in loaded_san_ext.value.get_values_for_type(x509.RFC822Name)
+            ]
+        )
+    except x509.ExtensionNotFound:
+        pass
+    # If email is present in the CSR Subject, make sure it is also in the SANS
+    # to conform to RFC 5280.
+    email = csr.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
+    if email:
+        email_rfc822 = x509.RFC822Name(str(email[0].value))
+        if email_rfc822 not in sans:
+            sans.append(email_rfc822)
+
+    return (
+        x509.Extension(
+            oid=ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
+            critical=False,
+            value=x509.SubjectAlternativeName(sans),
+        )
+        if sans
+        else None
+    )
+
+
+class CertificatesRequirerCharmEvents(CharmEvents):
+    """List of events that the TLS Certificates requirer charm can leverage."""
+
+    certificate_available = EventSource(CertificateAvailableEvent)
+
+
+class TLSCertificatesRequiresV4(Object):
+    """A class to manage the TLS certificates interface for a unit or app."""
+
+    on = CertificatesRequirerCharmEvents()  # type: ignore[reportAssignmentType]
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relationship_name: str,
+        certificate_requests: List[CertificateRequestAttributes],
+        mode: Mode = Mode.UNIT,
+        refresh_events: List[BoundEvent] = [],
+        private_key: Optional[PrivateKey] = None,
+        renewal_relative_time: float = 0.9,
+    ):
+        """Create a new instance of the TLSCertificatesRequiresV4 class.
+
+        Args:
+            charm (CharmBase): The charm instance to relate to.
+            relationship_name (str): The name of the relation that provides the certificates.
+            certificate_requests (List[CertificateRequestAttributes]):
+                A list with the attributes of the certificate requests.
+            mode (Mode): Whether to use unit or app certificates mode. Default is Mode.UNIT.
+                In UNIT mode the requirer will place the csr in the unit relation data.
+                Each unit will manage its private key,
+                certificate signing request and certificate.
+                UNIT mode is for use cases where each unit has its own identity.
+                If you don't know which mode to use, you likely need UNIT.
+                In APP mode the leader unit will place the csr in the app relation databag.
+                APP mode is for use cases where the underlying application needs the certificate
+                for example using it as an intermediate CA to sign other certificates.
+                The certificate can only be accessed by the leader unit.
+            refresh_events (List[BoundEvent]): A list of events to trigger a refresh of
+              the certificates.
+            private_key (Optional[PrivateKey]): The private key to use for the certificates.
+                If provided, it will be used instead of generating a new one.
+                If the key is not valid an exception will be raised.
+                Using this parameter is discouraged,
+                having to pass around private keys manually can be a security concern.
+                Allowing the library to generate and manage the key is the more secure approach.
+            renewal_relative_time (float): The time to renew the certificate relative to its
+                expiry.
+                Default is 0.9, meaning 90% of the validity period.
+                The minimum value is 0.5, meaning 50% of the validity period.
+                If an invalid value is provided, an exception will be raised.
+        """
+        super().__init__(charm, relationship_name)
+        if not JujuVersion.from_environ().has_secrets:
+            logger.warning("This version of the TLS library requires Juju secrets (Juju >= 3.0)")
+        if not self._mode_is_valid(mode):
+            raise TLSCertificatesError("Invalid mode. Must be Mode.UNIT or Mode.APP")
+        for certificate_request in certificate_requests:
+            if not certificate_request.is_valid():
+                raise TLSCertificatesError("Invalid certificate request")
+        self.charm = charm
+        self.relationship_name = relationship_name
+        self.certificate_requests = certificate_requests
+        self.mode = mode
+        if private_key and not private_key.is_valid():
+            raise TLSCertificatesError("Invalid private key")
+        if renewal_relative_time <= 0.5 or renewal_relative_time > 1.0:
+            raise TLSCertificatesError(
+                "Invalid renewal relative time. Must be between 0.0 and 1.0"
+            )
+        self._private_key = private_key
+        self.renewal_relative_time = renewal_relative_time
+        self.framework.observe(charm.on[relationship_name].relation_created, self._configure)
+        self.framework.observe(charm.on[relationship_name].relation_changed, self._configure)
+        self.framework.observe(charm.on.secret_expired, self._on_secret_expired)
+        self.framework.observe(charm.on.secret_remove, self._on_secret_remove)
+        for event in refresh_events:
+            self.framework.observe(event, self._configure)
+
+    def _configure(self, _: EventBase):
+        """Handle TLS Certificates Relation Data.
+
+        This method is called during any TLS relation event.
+        It will generate a private key if it doesn't exist yet.
+        It will send certificate requests if they haven't been sent yet.
+        It will find available certificates and emit events.
+        """
+        if not self._tls_relation_created():
+            logger.debug("TLS relation not created yet.")
+            return
+        self._ensure_private_key()
+        self._cleanup_certificate_requests()
+        self._send_certificate_requests()
+        self._find_available_certificates()
+
+    def _mode_is_valid(self, mode: Mode) -> bool:
+        return mode in [Mode.UNIT, Mode.APP]
+
+    def _validate_secret_exists(self, secret: Secret) -> None:
+        secret.get_info()  # Will raise `SecretNotFoundError` if the secret does not exist
+
+    def _on_secret_remove(self, event: SecretRemoveEvent) -> None:
+        """Handle Secret Removed Event."""
+        try:
+            # Ensure the secret exists before trying to remove it, otherwise
+            # the unit could be stuck in an error state. See the docstring of
+            # `remove_revision` and the below issue for more information.
+            # https://github.com/juju/juju/issues/19036
+            self._validate_secret_exists(event.secret)
+            event.secret.remove_revision(event.revision)
+        except SecretNotFoundError:
+            logger.warning(
+                "No such secret %s, nothing to remove",
+                event.secret.label or event.secret.id,
+            )
+            return
+
+    def _on_secret_expired(self, event: SecretExpiredEvent) -> None:
+        """Handle Secret Expired Event.
+
+        Renews certificate requests and removes the expired secret.
+        """
+        if not event.secret.label or not event.secret.label.startswith(f"{LIBID}-certificate"):
+            return
+        try:
+            csr_str = event.secret.get_content(refresh=True)["csr"]
+        except ModelError:
+            logger.error("Failed to get CSR from secret - Skipping")
+            return
+        csr = CertificateSigningRequest.from_string(csr_str)
+        self._renew_certificate_request(csr)
+        event.secret.remove_all_revisions()
+
+    def renew_certificate(self, certificate: ProviderCertificate) -> None:
+        """Request the renewal of the provided certificate."""
+        certificate_signing_request = certificate.certificate_signing_request
+        secret_label = self._get_csr_secret_label(certificate_signing_request)
+        try:
+            secret = self.model.get_secret(label=secret_label)
+        except SecretNotFoundError:
+            logger.warning("No matching secret found - Skipping renewal")
+            return
+        current_csr = secret.get_content(refresh=True).get("csr", "")
+        if current_csr != str(certificate_signing_request):
+            logger.warning("No matching CSR found - Skipping renewal")
+            return
+        self._renew_certificate_request(certificate_signing_request)
+        secret.remove_all_revisions()
+
+    def _renew_certificate_request(self, csr: CertificateSigningRequest):
+        """Remove existing CSR from relation data and create a new one."""
+        self._remove_requirer_csr_from_relation_data(csr)
+        self._send_certificate_requests()
+        logger.info("Renewed certificate request")
+
+    def _remove_requirer_csr_from_relation_data(self, csr: CertificateSigningRequest) -> None:
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            logger.debug("No relation: %s", self.relationship_name)
+            return
+        if not self.get_csrs_from_requirer_relation_data():
+            logger.info("No CSRs in relation data - Doing nothing")
+            return
+        app_or_unit = self._get_app_or_unit()
+        try:
+            requirer_relation_data = _RequirerData.load(relation.data[app_or_unit])
+        except DataValidationError:
+            logger.warning("Invalid relation data - Skipping removal of CSR")
+            return
+        new_relation_data = copy.deepcopy(requirer_relation_data.certificate_signing_requests)
+        for requirer_csr in new_relation_data:
+            if requirer_csr.certificate_signing_request.strip() == str(csr).strip():
+                new_relation_data.remove(requirer_csr)
+        try:
+            _RequirerData(certificate_signing_requests=new_relation_data).dump(
+                relation.data[app_or_unit]
+            )
+            logger.info("Removed CSR from relation data")
+        except ModelError:
+            logger.warning("Failed to update relation data")
+
+    def _get_app_or_unit(self) -> Union[Application, Unit]:
+        """Return the unit or app object based on the mode."""
+        if self.mode == Mode.UNIT:
+            return self.model.unit
+        elif self.mode == Mode.APP:
+            return self.model.app
+        raise TLSCertificatesError("Invalid mode")
+
+    @property
+    def private_key(self) -> Optional[PrivateKey]:
+        """Return the private key."""
+        if self._private_key:
+            return self._private_key
+        if not self._private_key_generated():
+            return None
+        secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
+        private_key = secret.get_content(refresh=True)["private-key"]
+        return PrivateKey.from_string(private_key)
+
+    def _ensure_private_key(self) -> None:
+        """Make sure there is a private key to be used.
+
+        It will make sure there is a private key passed by the charm using the private_key
+        parameter or generate a new one otherwise.
+        """
+        # Remove the generated private key
+        # if one has been passed by the charm using the private_key parameter
+        if self._private_key:
+            self._remove_private_key_secret()
+            return
+        if self._private_key_generated():
+            logger.debug("Private key already generated")
+            return
+        self._generate_private_key()
+
+    def regenerate_private_key(self) -> None:
+        """Regenerate the private key.
+
+        Generate a new private key, remove old certificate requests and send new ones.
+
+        Raises:
+            TLSCertificatesError: If the private key is passed by the charm using the
+                private_key parameter.
+        """
+        if self._private_key:
+            raise TLSCertificatesError(
+                "Private key is passed by the charm through the private_key parameter, "
+                "this function can't be used"
+            )
+        if not self._private_key_generated():
+            logger.warning("No private key to regenerate")
+            return
+        self._generate_private_key()
+        self._cleanup_certificate_requests()
+        self._send_certificate_requests()
+
+    def _generate_private_key(self) -> None:
+        """Generate a new private key and store it in a secret.
+
+        This is the case when the private key used is generated by the library.
+            and not passed by the charm using the private_key parameter.
+        """
+        self._store_private_key_in_secret(generate_private_key())
+        logger.info("Private key generated")
+
+    def _private_key_generated(self) -> bool:
+        """Check if a private key is stored in a secret.
+
+        This is the case when the private key used is generated by the library.
+        This should not exist when the private key used
+            is passed by the charm using the private_key parameter.
+        """
+        try:
+            secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
+            secret.get_content(refresh=True)
+            return True
+        except SecretNotFoundError:
+            return False
+
+    def _store_private_key_in_secret(self, private_key: PrivateKey) -> None:
+        try:
+            secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
+            secret.set_content({"private-key": str(private_key)})
+            secret.get_content(refresh=True)
+        except SecretNotFoundError:
+            self.charm.unit.add_secret(
+                content={"private-key": str(private_key)},
+                label=self._get_private_key_secret_label(),
+            )
+
+    def _remove_private_key_secret(self) -> None:
+        """Remove the private key secret."""
+        try:
+            secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
+            secret.remove_all_revisions()
+        except SecretNotFoundError:
+            logger.warning("Private key secret not found, nothing to remove")
+
+    def _csr_matches_certificate_request(
+        self, certificate_signing_request: CertificateSigningRequest, is_ca: bool
+    ) -> bool:
+        for certificate_request in self.certificate_requests:
+            if certificate_request == CertificateRequestAttributes.from_csr(
+                certificate_signing_request,
+                is_ca,
+            ):
+                return True
+        return False
+
+    def _certificate_requested(self, certificate_request: CertificateRequestAttributes) -> bool:
+        if not self.private_key:
+            return False
+        csr = self._certificate_requested_for_attributes(certificate_request)
+        if not csr:
+            return False
+        if not csr.certificate_signing_request.matches_private_key(key=self.private_key):
+            return False
+        return True
+
+    def _certificate_requested_for_attributes(
+        self,
+        certificate_request: CertificateRequestAttributes,
+    ) -> Optional[RequirerCertificateRequest]:
+        for requirer_csr in self.get_csrs_from_requirer_relation_data():
+            if certificate_request == CertificateRequestAttributes.from_csr(
+                requirer_csr.certificate_signing_request,
+                requirer_csr.is_ca,
+            ):
+                return requirer_csr
+        return None
+
+    def get_csrs_from_requirer_relation_data(self) -> List[RequirerCertificateRequest]:
+        """Return list of requirer's CSRs from relation data."""
+        if self.mode == Mode.APP and not self.model.unit.is_leader():
+            logger.debug("Not a leader unit - Skipping")
+            return []
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            logger.debug("No relation: %s", self.relationship_name)
+            return []
+        app_or_unit = self._get_app_or_unit()
+        try:
+            requirer_relation_data = _RequirerData.load(relation.data[app_or_unit])
+        except DataValidationError:
+            logger.warning("Invalid relation data")
+            return []
+        requirer_csrs = []
+        for csr in requirer_relation_data.certificate_signing_requests:
+            requirer_csrs.append(
+                RequirerCertificateRequest(
+                    relation_id=relation.id,
+                    certificate_signing_request=CertificateSigningRequest.from_string(
+                        csr.certificate_signing_request
+                    ),
+                    is_ca=csr.ca if csr.ca else False,
+                )
+            )
+        return requirer_csrs
+
+    def get_provider_certificates(self) -> List[ProviderCertificate]:
+        """Return list of certificates from the provider's relation data."""
+        return self._load_provider_certificates()
+
+    def _load_provider_certificates(self) -> List[ProviderCertificate]:
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            logger.debug("No relation: %s", self.relationship_name)
+            return []
+        if not relation.app:
+            logger.debug("No remote app in relation: %s", self.relationship_name)
+            return []
+        try:
+            provider_relation_data = _ProviderApplicationData.load(relation.data[relation.app])
+        except DataValidationError:
+            logger.warning("Invalid relation data")
+            return []
+        return [
+            certificate.to_provider_certificate(relation_id=relation.id)
+            for certificate in provider_relation_data.certificates
+        ]
+
+    def _request_certificate(self, csr: CertificateSigningRequest, is_ca: bool) -> None:
+        """Add CSR to relation data."""
+        if self.mode == Mode.APP and not self.model.unit.is_leader():
+            logger.debug("Not a leader unit - Skipping")
+            return
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            logger.debug("No relation: %s", self.relationship_name)
+            return
+        new_csr = _CertificateSigningRequest(
+            certificate_signing_request=str(csr).strip(), ca=is_ca
+        )
+        app_or_unit = self._get_app_or_unit()
+        try:
+            requirer_relation_data = _RequirerData.load(relation.data[app_or_unit])
+        except DataValidationError:
+            requirer_relation_data = _RequirerData(
+                certificate_signing_requests=[],
+            )
+        new_relation_data = copy.deepcopy(requirer_relation_data.certificate_signing_requests)
+        new_relation_data.append(new_csr)
+        try:
+            _RequirerData(certificate_signing_requests=new_relation_data).dump(
+                relation.data[app_or_unit]
+            )
+            logger.info("Certificate signing request added to relation data.")
+        except ModelError:
+            logger.warning("Failed to update relation data")
+
+    def _send_certificate_requests(self):
+        if not self.private_key:
+            logger.debug("Private key not generated yet.")
+            return
+        for certificate_request in self.certificate_requests:
+            if not self._certificate_requested(certificate_request):
+                csr = certificate_request.generate_csr(
+                    private_key=self.private_key,
+                )
+                if not csr:
+                    logger.warning("Failed to generate CSR")
+                    continue
+                self._request_certificate(csr=csr, is_ca=certificate_request.is_ca)
+
+    def get_assigned_certificate(
+        self, certificate_request: CertificateRequestAttributes
+    ) -> Tuple[Optional[ProviderCertificate], Optional[PrivateKey]]:
+        """Get the certificate that was assigned to the given certificate request."""
+        for requirer_csr in self.get_csrs_from_requirer_relation_data():
+            if certificate_request == CertificateRequestAttributes.from_csr(
+                requirer_csr.certificate_signing_request,
+                requirer_csr.is_ca,
+            ):
+                return self._find_certificate_in_relation_data(requirer_csr), self.private_key
+        return None, None
+
+    def get_assigned_certificates(
+        self,
+    ) -> Tuple[List[ProviderCertificate], Optional[PrivateKey]]:
+        """Get a list of certificates that were assigned to this or app."""
+        assigned_certificates = []
+        for requirer_csr in self.get_csrs_from_requirer_relation_data():
+            if cert := self._find_certificate_in_relation_data(requirer_csr):
+                assigned_certificates.append(cert)
+        return assigned_certificates, self.private_key
+
+    def _find_certificate_in_relation_data(
+        self, csr: RequirerCertificateRequest
+    ) -> Optional[ProviderCertificate]:
+        """Return the certificate that matches the given CSR, validated against the private key."""
+        if not self.private_key:
+            return None
+        for provider_certificate in self.get_provider_certificates():
+            if provider_certificate.certificate_signing_request == csr.certificate_signing_request:
+                if provider_certificate.certificate.is_ca and not csr.is_ca:
+                    logger.warning("Non CA certificate requested, got a CA certificate, ignoring")
+                    continue
+                elif not provider_certificate.certificate.is_ca and csr.is_ca:
+                    logger.warning("CA certificate requested, got a non CA certificate, ignoring")
+                    continue
+                if not provider_certificate.certificate.matches_private_key(self.private_key):
+                    logger.warning(
+                        "Certificate does not match the private key. Ignoring invalid certificate."
+                    )
+                    continue
+                return provider_certificate
+        return None
+
+    def _find_available_certificates(self):
+        """Find available certificates and emit events.
+
+        This method will find certificates that are available for the requirer's CSRs.
+        If a certificate is found, it will be set as a secret and an event will be emitted.
+        If a certificate is revoked, the secret will be removed and an event will be emitted.
+        """
+        requirer_csrs = self.get_csrs_from_requirer_relation_data()
+        csrs = [csr.certificate_signing_request for csr in requirer_csrs]
+        provider_certificates = self.get_provider_certificates()
+        for provider_certificate in provider_certificates:
+            if provider_certificate.certificate_signing_request in csrs:
+                secret_label = self._get_csr_secret_label(
+                    provider_certificate.certificate_signing_request
+                )
+                if provider_certificate.revoked:
+                    with suppress(SecretNotFoundError):
+                        logger.debug(
+                            "Removing secret with label %s",
+                            secret_label,
+                        )
+                        secret = self.model.get_secret(label=secret_label)
+                        secret.remove_all_revisions()
+                else:
+                    if not self._csr_matches_certificate_request(
+                        certificate_signing_request=provider_certificate.certificate_signing_request,
+                        is_ca=provider_certificate.certificate.is_ca,
+                    ):
+                        logger.debug("Certificate requested for different attributes - Skipping")
+                        continue
+                    try:
+                        secret = self.model.get_secret(label=secret_label)
+                        logger.debug("Setting secret with label %s", secret_label)
+                        # Juju < 3.6 will create a new revision even if the content is the same
+                        if secret.get_content(refresh=True).get("certificate", "") == str(
+                            provider_certificate.certificate
+                        ):
+                            logger.debug(
+                                "Secret %s with correct certificate already exists", secret_label
+                            )
+                            continue
+                        secret.set_content(
+                            content={
+                                "certificate": str(provider_certificate.certificate),
+                                "csr": str(provider_certificate.certificate_signing_request),
+                            }
+                        )
+                        secret.set_info(
+                            expire=provider_certificate.certificate.expiry_time,
+                        )
+                        secret.get_content(refresh=True)
+                    except SecretNotFoundError:
+                        logger.debug("Creating new secret with label %s", secret_label)
+                        secret = self.charm.unit.add_secret(
+                            content={
+                                "certificate": str(provider_certificate.certificate),
+                                "csr": str(provider_certificate.certificate_signing_request),
+                            },
+                            label=secret_label,
+                            expire=calculate_relative_datetime(
+                                target_time=provider_certificate.certificate.expiry_time,
+                                fraction=self.renewal_relative_time,
+                            ),
+                        )
+                    self.on.certificate_available.emit(
+                        certificate_signing_request=provider_certificate.certificate_signing_request,
+                        certificate=provider_certificate.certificate,
+                        ca=provider_certificate.ca,
+                        chain=provider_certificate.chain,
+                    )
+
+    def _cleanup_certificate_requests(self):
+        """Clean up certificate requests.
+
+        Remove any certificate requests that falls into one of the following categories:
+        - The CSR attributes do not match any of the certificate requests defined in
+        the charm's certificate_requests attribute.
+        - The CSR public key does not match the private key.
+        """
+        for requirer_csr in self.get_csrs_from_requirer_relation_data():
+            if not self._csr_matches_certificate_request(
+                certificate_signing_request=requirer_csr.certificate_signing_request,
+                is_ca=requirer_csr.is_ca,
+            ):
+                self._remove_requirer_csr_from_relation_data(
+                    requirer_csr.certificate_signing_request
+                )
+                logger.info(
+                    "Removed CSR from relation data because it did not match any certificate request"  # noqa: E501
+                )
+            elif (
+                self.private_key
+                and not requirer_csr.certificate_signing_request.matches_private_key(
+                    self.private_key
+                )
+            ):
+                self._remove_requirer_csr_from_relation_data(
+                    requirer_csr.certificate_signing_request
+                )
+                logger.info(
+                    "Removed CSR from relation data because it did not match the private key"  # noqa: E501
+                )
+
+    def _tls_relation_created(self) -> bool:
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            return False
+        return True
+
+    def _get_private_key_secret_label(self) -> str:
+        if self.mode == Mode.UNIT:
+            return f"{LIBID}-private-key-{self._get_unit_number()}-{self.relationship_name}"
+        elif self.mode == Mode.APP:
+            return f"{LIBID}-private-key-{self.relationship_name}"
+        else:
+            raise TLSCertificatesError("Invalid mode. Must be Mode.UNIT or Mode.APP.")
+
+    def _get_csr_secret_label(self, csr: CertificateSigningRequest) -> str:
+        csr_in_sha256_hex = csr.get_sha256_hex()
+        if self.mode == Mode.UNIT:
+            return f"{LIBID}-certificate-{self._get_unit_number()}-{csr_in_sha256_hex}"
+        elif self.mode == Mode.APP:
+            return f"{LIBID}-certificate-{csr_in_sha256_hex}"
+        else:
+            raise TLSCertificatesError("Invalid mode. Must be Mode.UNIT or Mode.APP.")
+
+    def _get_unit_number(self) -> str:
+        return self.model.unit.name.split("/")[1]
+
+
+class TLSCertificatesProvidesV4(Object):
+    """TLS certificates provider class to be instantiated by TLS certificates providers."""
+
+    def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name)
+        self.framework.observe(charm.on[relationship_name].relation_joined, self._configure)
+        self.framework.observe(charm.on[relationship_name].relation_changed, self._configure)
+        self.framework.observe(charm.on.update_status, self._configure)
+        self.charm = charm
+        self.relationship_name = relationship_name
+
+    def _configure(self, _: EventBase) -> None:
+        """Handle update status and tls relation changed events.
+
+        This is a common hook triggered on a regular basis.
+
+        Revoke certificates for which no csr exists
+        """
+        if not self.model.unit.is_leader():
+            return
+        self._remove_certificates_for_which_no_csr_exists()
+
+    def _remove_certificates_for_which_no_csr_exists(self) -> None:
+        provider_certificates = self.get_provider_certificates()
+        requirer_csrs = [
+            request.certificate_signing_request for request in self.get_certificate_requests()
+        ]
+        for provider_certificate in provider_certificates:
+            if provider_certificate.certificate_signing_request not in requirer_csrs:
+                tls_relation = self._get_tls_relations(
+                    relation_id=provider_certificate.relation_id
+                )
+                self._remove_provider_certificate(
+                    certificate=provider_certificate.certificate,
+                    relation=tls_relation[0],
+                )
+
+    def _get_tls_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        return (
+            [
+                relation
+                for relation in self.model.relations[self.relationship_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
+            else self.model.relations.get(self.relationship_name, [])
+        )
+
+    def get_certificate_requests(
+        self, relation_id: Optional[int] = None
+    ) -> List[RequirerCertificateRequest]:
+        """Load certificate requests from the relation data."""
+        relations = self._get_tls_relations(relation_id)
+        requirer_csrs: List[RequirerCertificateRequest] = []
+        for relation in relations:
+            for unit in relation.units:
+                requirer_csrs.extend(self._load_requirer_databag(relation, unit))
+            requirer_csrs.extend(self._load_requirer_databag(relation, relation.app))
+        return requirer_csrs
+
+    def _load_requirer_databag(
+        self, relation: Relation, unit_or_app: Union[Application, Unit]
+    ) -> List[RequirerCertificateRequest]:
+        try:
+            requirer_relation_data = _RequirerData.load(relation.data[unit_or_app])
+        except DataValidationError:
+            logger.debug("Invalid requirer relation data for %s", unit_or_app.name)
+            return []
+        return [
+            RequirerCertificateRequest(
+                relation_id=relation.id,
+                certificate_signing_request=CertificateSigningRequest.from_string(
+                    csr.certificate_signing_request
+                ),
+                is_ca=csr.ca if csr.ca else False,
+            )
+            for csr in requirer_relation_data.certificate_signing_requests
+        ]
+
+    def _add_provider_certificate(
+        self,
+        relation: Relation,
+        provider_certificate: ProviderCertificate,
+    ) -> None:
+        chain = [str(certificate) for certificate in provider_certificate.chain]
+        if chain[0] != str(provider_certificate.certificate):
+            logger.warning(
+                "The order of the chain from the TLS Certificates Provider is incorrect. "
+                "The leaf certificate should be the first element of the chain."
+            )
+        elif not chain_has_valid_order(chain):
+            logger.warning(
+                "The order of the chain from the TLS Certificates Provider is partially incorrect."
+            )
+        new_certificate = _Certificate(
+            certificate=str(provider_certificate.certificate),
+            certificate_signing_request=str(provider_certificate.certificate_signing_request),
+            ca=str(provider_certificate.ca),
+            chain=chain,
+        )
+        provider_certificates = self._load_provider_certificates(relation)
+        if new_certificate in provider_certificates:
+            logger.info("Certificate already in relation data - Doing nothing")
+            return
+        provider_certificates.append(new_certificate)
+        self._dump_provider_certificates(relation=relation, certificates=provider_certificates)
+
+    def _load_provider_certificates(self, relation: Relation) -> List[_Certificate]:
+        try:
+            provider_relation_data = _ProviderApplicationData.load(relation.data[self.charm.app])
+        except DataValidationError:
+            logger.debug("Invalid provider relation data")
+            return []
+        return copy.deepcopy(provider_relation_data.certificates)
+
+    def _dump_provider_certificates(self, relation: Relation, certificates: List[_Certificate]):
+        try:
+            _ProviderApplicationData(certificates=certificates).dump(relation.data[self.model.app])
+            logger.info("Certificate relation data updated")
+        except ModelError:
+            logger.warning("Failed to update relation data")
+
+    def _remove_provider_certificate(
+        self,
+        relation: Relation,
+        certificate: Optional[Certificate] = None,
+        certificate_signing_request: Optional[CertificateSigningRequest] = None,
+    ) -> None:
+        """Remove certificate based on certificate or certificate signing request."""
+        provider_certificates = self._load_provider_certificates(relation)
+        for provider_certificate in provider_certificates:
+            if certificate and provider_certificate.certificate == str(certificate):
+                provider_certificates.remove(provider_certificate)
+            if (
+                certificate_signing_request
+                and provider_certificate.certificate_signing_request
+                == str(certificate_signing_request)
+            ):
+                provider_certificates.remove(provider_certificate)
+        self._dump_provider_certificates(relation=relation, certificates=provider_certificates)
+
+    def revoke_all_certificates(self) -> None:
+        """Revoke all certificates of this provider.
+
+        This method is meant to be used when the Root CA has changed.
+        """
+        if not self.model.unit.is_leader():
+            logger.warning("Unit is not a leader - will not set relation data")
+            return
+        relations = self._get_tls_relations()
+        for relation in relations:
+            provider_certificates = self._load_provider_certificates(relation)
+            for certificate in provider_certificates:
+                certificate.revoked = True
+            self._dump_provider_certificates(relation=relation, certificates=provider_certificates)
+
+    def set_relation_certificate(
+        self,
+        provider_certificate: ProviderCertificate,
+    ) -> None:
+        """Add certificates to relation data.
+
+        Args:
+            provider_certificate (ProviderCertificate): ProviderCertificate object
+
+        Returns:
+            None
+        """
+        if not self.model.unit.is_leader():
+            logger.warning("Unit is not a leader - will not set relation data")
+            return
+        certificates_relation = self.model.get_relation(
+            relation_name=self.relationship_name, relation_id=provider_certificate.relation_id
+        )
+        if not certificates_relation:
+            raise TLSCertificatesError(f"Relation {self.relationship_name} does not exist")
+        self._remove_provider_certificate(
+            relation=certificates_relation,
+            certificate_signing_request=provider_certificate.certificate_signing_request,
+        )
+        self._add_provider_certificate(
+            relation=certificates_relation,
+            provider_certificate=provider_certificate,
+        )
+
+    def get_issued_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return a List of issued (non revoked) certificates.
+
+        Returns:
+            List: List of ProviderCertificate objects
+        """
+        if not self.model.unit.is_leader():
+            logger.warning("Unit is not a leader - will not read relation data")
+            return []
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
+        return [certificate for certificate in provider_certificates if not certificate.revoked]
+
+    def get_provider_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return a List of issued certificates."""
+        certificates: List[ProviderCertificate] = []
+        relations = self._get_tls_relations(relation_id)
+        for relation in relations:
+            if not relation.app:
+                logger.warning("Relation %s does not have an application", relation.id)
+                continue
+            for certificate in self._load_provider_certificates(relation):
+                certificates.append(certificate.to_provider_certificate(relation_id=relation.id))
+        return certificates
+
+    def get_unsolicited_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return provider certificates for which no certificate requests exists.
+
+        Those certificates should be revoked.
+        """
+        unsolicited_certificates: List[ProviderCertificate] = []
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
+        requirer_csrs = self.get_certificate_requests(relation_id=relation_id)
+        list_of_csrs = [csr.certificate_signing_request for csr in requirer_csrs]
+        for certificate in provider_certificates:
+            if certificate.certificate_signing_request not in list_of_csrs:
+                unsolicited_certificates.append(certificate)
+        return unsolicited_certificates
+
+    def get_outstanding_certificate_requests(
+        self, relation_id: Optional[int] = None
+    ) -> List[RequirerCertificateRequest]:
+        """Return CSR's for which no certificate has been issued.
+
+        Args:
+            relation_id (int): Relation id
+
+        Returns:
+            list: List of RequirerCertificateRequest objects.
+        """
+        requirer_csrs = self.get_certificate_requests(relation_id=relation_id)
+        outstanding_csrs: List[RequirerCertificateRequest] = []
+        for relation_csr in requirer_csrs:
+            if not self._certificate_issued_for_csr(
+                csr=relation_csr.certificate_signing_request,
+                relation_id=relation_id,
+            ):
+                outstanding_csrs.append(relation_csr)
+        return outstanding_csrs
+
+    def _certificate_issued_for_csr(
+        self, csr: CertificateSigningRequest, relation_id: Optional[int]
+    ) -> bool:
+        """Check whether a certificate has been issued for a given CSR."""
+        issued_certificates_per_csr = self.get_issued_certificates(relation_id=relation_id)
+        for issued_certificate in issued_certificates_per_csr:
+            if issued_certificate.certificate_signing_request == csr:
+                return csr.matches_certificate(issued_certificate.certificate)
+        return False

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -48,6 +48,10 @@ requires:
     interface: tls-certificates
     limit: 1
     optional: true
+  peer-certificates:
+    interface: tls-certificates
+    limit: 1
+    optional: true
   client-cas:
     interface: certificate_transfer
     optional: true

--- a/src/charm.py
+++ b/src/charm.py
@@ -171,7 +171,7 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
             return
 
     def _on_collect_status(self, event: CollectStatusEvent):
-        for status in self.pending_inactive_statuses + [Status.ACTIVE]:
+        for status in self.pending_inactive_statuses + [self.state.ready_to_start]:
             event.add_status(status.value.status)
 
 

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -679,3 +679,28 @@ class ClusterState(Object):
             self.kraft_cluster.update({"broker-ca": _value})
         elif self.runs_controller_only:
             self.kraft_cluster.update({"controller-ca": _value})
+
+    @property
+    def tls_rotation(self) -> bool:
+        """Returns True if TLS rotation is in progress, False otherwise."""
+        return any(
+            [
+                self.unit_broker.client_tls.rotation,
+                self.unit_broker.peer_tls.rotation,
+            ]
+        )
+
+    @tls_rotation.setter
+    def tls_rotation(self, value: bool) -> None:
+        self.unit_broker.client_tls.rotation = value
+        self.unit_broker.peer_tls.rotation = value
+
+    @property
+    def balancer_tls_rotation(self) -> bool:
+        """Returns True if TLS rotation is in progress, False otherwise."""
+        return bool(self.cluster.relation_data.get("balancer-rotation", ""))
+
+    @balancer_tls_rotation.setter
+    def balancer_tls_rotation(self, value: bool) -> None:
+        _value = "" if not value else "true"
+        self.cluster.update({"balancer-rotation": _value})

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -638,7 +638,7 @@ class ClusterState(Object):
         ca = self.cluster.relation_data.get("internal-ca", "")
         ca_key = self.internal_ca_key
 
-        if ca_key is None or not ca:
+        if not all([ca_key, ca]):
             return None
 
         return Certificate.from_string(ca)

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -357,15 +357,13 @@ class ClusterState(Object):
 
     @property
     def default_auth(self) -> AuthMap:
-        """The current enabled auth.protocol for bootstrap."""
+        """The current enabled auth.protocol for clients."""
         auth_protocol = (
             "SASL_SSL"
             if self.cluster.tls_enabled and self.unit_broker.client_certs.certificate
             else "SASL_PLAINTEXT"
         )
 
-        # FIXME: will need updating when we support multiple concurrent security.protocols
-        # as this is what is sent across the relation, currently SASL only
         return AuthMap(auth_protocol, "SCRAM-SHA-512")
 
     @property

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -629,7 +629,7 @@ class ClusterState(Object):
 
     @property
     def use_internal_tls(self) -> bool:
-        """..."""
+        """Whether internal TLS is being used or not."""
         return not bool(self.model.get_relation(INTERNAL_TLS_RELATION))
 
     @property

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -19,6 +19,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
     ProviderData,
     RequirerData,
 )
+from charms.tls_certificates_interface.v4.tls_certificates import Certificate, PrivateKey
 from lightkube.core.exceptions import ApiError as LightKubeApiError
 from ops import Object, Relation
 from ops.model import Unit
@@ -38,7 +39,6 @@ from literals import (
     BROKER,
     CERTIFICATE_TRANSFER_RELATION,
     CONTROLLER,
-    CONTROLLER_PORT,
     CONTROLLER_USER,
     INTERNAL_USERS,
     KRAFT_NODE_ID_OFFSET,
@@ -196,7 +196,7 @@ class ClusterState(Object):
                 ),
                 broker_username=ADMIN_USER,
                 broker_password=self.cluster.internal_user_credentials.get(ADMIN_USER, ""),
-                broker_uris=self.bootstrap_server,
+                broker_uris=self.bootstrap_server_internal,
                 cluster_uuid=self.cluster.cluster_uuid,
                 racks=self.racks,
                 broker_capacities=self.broker_capacities,
@@ -358,13 +358,18 @@ class ClusterState(Object):
         """The current enabled auth.protocol for bootstrap."""
         auth_protocol = (
             "SASL_SSL"
-            if self.cluster.tls_enabled and self.unit_broker.certificate
+            if self.cluster.tls_enabled and self.unit_broker.client_tls.certificate
             else "SASL_PLAINTEXT"
         )
 
         # FIXME: will need updating when we support multiple concurrent security.protocols
         # as this is what is sent across the relation, currently SASL only
         return AuthMap(auth_protocol, "SCRAM-SHA-512")
+
+    @property
+    def internal_auth(self) -> AuthMap:
+        """The current enabled auth.protocol for internal peer communications."""
+        return AuthMap("SASL_SSL", "SCRAM-SHA-512")
 
     @property
     def enabled_auth(self) -> list[AuthMap]:
@@ -441,7 +446,7 @@ class ClusterState(Object):
         return ",".join(
             sorted(
                 [
-                    f"{broker.internal_address}:{SECURITY_PROTOCOL_PORTS[self.default_auth].internal}"
+                    f"{broker.internal_address}:{SECURITY_PROTOCOL_PORTS[self.internal_auth].internal}"
                     for broker in self.brokers
                 ]
             )
@@ -451,7 +456,7 @@ class ClusterState(Object):
     def bootstrap_controller(self) -> str:
         """Returns the controller listener in the format HOST:PORT."""
         if self.runs_controller:
-            return f"{self.unit_broker.internal_address}:{CONTROLLER_PORT}"
+            return f"{self.unit_broker.internal_address}:{SECURITY_PROTOCOL_PORTS[self.internal_auth].controller}"
         return ""
 
     @property
@@ -509,6 +514,9 @@ class ClusterState(Object):
         if self.runs_broker_only and not self.peer_cluster_orchestrator_relation:
             return Status.MISSING_MODE
 
+        if not self.unit_broker.peer_tls.ready and not self.internal_ca:
+            return Status.NO_INTERNAL_TLS
+
         for status in [self._broker_status, self._controller_status]:
             if status != Status.ACTIVE:
                 return status
@@ -526,6 +534,9 @@ class ClusterState(Object):
 
         if not self.peer_cluster_relation and not self.runs_broker:
             return Status.NO_PEER_CLUSTER_RELATION
+
+        if not self.unit_broker.peer_tls.ready and not self.internal_ca:
+            return Status.NO_INTERNAL_TLS
 
         if not self.peer_cluster.broker_connected:
             return Status.NO_BROKER_DATA
@@ -550,7 +561,10 @@ class ClusterState(Object):
         if not self.cluster.cluster_uuid:
             return Status.NO_CLUSTER_UUID
 
-        if self.cluster.tls_enabled and not self.unit_broker.certificate:
+        if self.runs_broker_only and not self.peer_cluster_ca:
+            return Status.NO_PEER_CLUSTER_CA
+
+        if self.cluster.tls_enabled and not self.unit_broker.client_tls.certificate:
             return Status.NO_CERT
 
         if not self.cluster.internal_user_credentials:
@@ -566,6 +580,12 @@ class ClusterState(Object):
 
         if not self.peer_cluster_relation and not self.runs_broker:
             return Status.NO_PEER_CLUSTER_RELATION
+
+        if not self.peer_cluster.controller_password:
+            return Status.MISSING_CONTROLLER_PASSWORD
+
+        if self.runs_controller_only and not self.peer_cluster_ca:
+            return Status.NO_PEER_CLUSTER_CA
 
         if not self.peer_cluster.broker_connected_kraft_mode:
             return Status.NO_BROKER_DATA
@@ -596,3 +616,59 @@ class ClusterState(Object):
     def runs_controller_only(self) -> bool:
         """Is the charm ONLY running controller in KRaft mode?"""
         return self.runs_controller and not self.runs_broker
+
+    @property
+    def kraft_cluster(self) -> PeerCluster | KafkaCluster:
+        """The appropriate cluster object for read/write actions in KRaft mode."""
+        if self.runs_broker and self.runs_controller:
+            return self.cluster
+
+        return self.peer_cluster
+
+    @property
+    def internal_ca(self) -> Certificate | None:
+        """The internal CA certificate used for the peer relations."""
+        ca = self.cluster.relation_data.get("internal-ca", "")
+        ca_key = self.internal_ca_key
+
+        if ca_key is None or not ca:
+            return None
+
+        return Certificate.from_string(ca)
+
+    @internal_ca.setter
+    def internal_ca(self, value: str) -> None:
+        self.cluster.update({"internal-ca": value})
+
+    @property
+    def internal_ca_key(self) -> PrivateKey | None:
+        """The private key of internal CA certificate used for the peer relations."""
+        if not (ca_key := self.cluster.relation_data.get("internal-ca-key", "")):
+            return None
+
+        return PrivateKey.from_string(ca_key)
+
+    @internal_ca_key.setter
+    def internal_ca_key(self, value: str) -> None:
+        self.cluster.update({"internal-ca-key": value})
+
+    @property
+    def peer_cluster_ca(self) -> str:
+        """CA certificate of the peer-cluster app."""
+        if self.runs_broker_only:
+            return self.kraft_cluster.relation_data.get("controller-ca", "")
+
+        if self.runs_controller_only:
+            return self.kraft_cluster.relation_data.get("broker-ca", "")
+
+        # KRaft single mode
+        return self.unit_broker.peer_tls.ca
+
+    @peer_cluster_ca.setter
+    def peer_cluster_ca(self, value: str) -> None:
+        if self.runs_broker_only:
+            self.kraft_cluster.update({"broker-ca": value})
+        elif self.runs_controller_only:
+            self.kraft_cluster.update({"controller-ca": value})
+
+        self.unit_broker.peer_tls.ca = value

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+from dataclasses import dataclass
 from functools import cached_property
 from typing import MutableMapping, TypeAlias, TypedDict
 
@@ -44,6 +45,24 @@ BrokerCapacity = TypedDict("BrokerCapacity", {"brokerId": str, "capacity": Capac
 BrokerCapacities = TypedDict(
     "BrokerCapacities", {"brokerCapacities": list[BrokerCapacity]}, total=False
 )
+
+
+@dataclass
+class GeneratedCa:
+    """Data class to model generated CA artifacts."""
+
+    ca: str
+    ca_key: str
+
+
+@dataclass
+class SelfSignedCertificate:
+    """Data class to model self signed certificate artifacts."""
+
+    ca: str
+    csr: str
+    certificate: str
+    private_key: str
 
 
 class RelationState:
@@ -579,6 +598,13 @@ class TLSState:
     def ready(self) -> bool:
         """Returns True if all the necessary TLS relation data has been set, False otherwise."""
         return all([self.certificate, self.ca, self.private_key])
+
+    def set_self_signed(self, value: SelfSignedCertificate) -> None:
+        """Sets CA, private_key, CSR, and cert state vars based on the provided `SelfSignedCertificate` bundle."""
+        self.private_key = value.private_key
+        self.certificate = value.certificate
+        self.ca = value.ca
+        self.csr = value.csr
 
 
 class KafkaBroker(RelationState):

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -29,6 +29,7 @@ from literals import (
     SECURITY_PROTOCOL_PORTS,
     AuthMap,
     Substrates,
+    TLSScope,
 )
 from managers.k8s import K8sManager
 
@@ -480,6 +481,99 @@ class KafkaCluster(RelationState):
         return self.relation_data.get("bootstrap-unit-id", "")
 
 
+class TLSState:
+    """State collection metadata for TLS credentials."""
+
+    def __init__(self, relation_state: RelationState, scope: TLSScope):
+        self.scope = scope
+        self.relation_state = relation_state
+        self.relation_data = relation_state.relation_data
+
+    @property
+    def private_key(self) -> str:
+        """The unit private-key set during `certificates_joined`.
+
+        Returns:
+            String of key contents
+            Empty if key not yet generated
+        """
+        return self.relation_data.get(f"{self.scope.value}-private-key", "")
+
+    @private_key.setter
+    def private_key(self, value: str) -> None:
+        self.relation_state.update({f"{self.scope.value}-private-key": value})
+
+    @property
+    def csr(self) -> str:
+        """The unit cert signing request.
+
+        Returns:
+            String of csr contents
+            Empty if csr not yet generated
+        """
+        return self.relation_data.get(f"{self.scope.value}-csr", "")
+
+    @csr.setter
+    def csr(self, value: str) -> None:
+        self.relation_state.update({f"{self.scope.value}-csr": value})
+
+    @property
+    def certificate(self) -> str:
+        """The signed unit certificate from the provider relation.
+
+        Returns:
+            String of cert contents in PEM format
+            Empty if cert not yet generated/signed
+        """
+        return self.relation_data.get(f"{self.scope.value}-certificate", "")
+
+    @certificate.setter
+    def certificate(self, value: str) -> None:
+        self.relation_state.update({f"{self.scope.value}-certificate": value})
+
+    @property
+    def ca(self) -> str:
+        """The ca used to sign unit cert.
+
+        Returns:
+            String of ca contents in PEM format
+            Empty if cert not yet generated/signed
+        """
+        # defaults to ca for backwards compatibility after field change introduced with secrets
+        return self.relation_data.get(f"{self.scope.value}-ca-cert", "")
+
+    @ca.setter
+    def ca(self, value: str) -> None:
+        self.relation_state.update({f"{self.scope.value}-ca-cert": value})
+
+    @property
+    def chain(self) -> list[str]:
+        """The chain used to sign unit cert."""
+        return json.loads(self.relation_data.get(f"{self.scope.value}-chain", "null")) or []
+
+    @chain.setter
+    def chain(self, value: str) -> None:
+        self.relation_state.update({f"{self.scope.value}-chain": value})
+
+    @property
+    def bundle(self) -> list[str]:
+        """The cert bundle used for TLS identity."""
+        if not all([self.certificate, self.ca]):
+            return []
+
+        # manual-tls-certificates is loaded with the signed cert, the intermediate CA that signed it
+        # and then the missing chain for that CA
+        # ZK needs to present the full bundle - aka Keystore
+        # ZK needs to trust each item in the bundle - aka Truststore
+        bundle = [self.certificate, self.ca] + self.chain
+        return sorted(set(bundle), key=bundle.index)  # ordering might matter
+
+    @property
+    def ready(self) -> bool:
+        """Returns True if all the necessary TLS relation data has been set, False otherwise."""
+        return all([self.certificate, self.ca, self.private_key])
+
+
 class KafkaBroker(RelationState):
     """State collection metadata for a unit."""
 
@@ -526,65 +620,15 @@ class KafkaBroker(RelationState):
         return addr
 
     # --- TLS ---
+    @property
+    def peer_tls(self) -> TLSState:
+        """TLS state for internal (peer) communications."""
+        return TLSState(self, TLSScope.PEER)
 
     @property
-    def private_key(self) -> str:
-        """The unit private-key set during `certificates_joined`.
-
-        Returns:
-            String of key contents
-            Empty if key not yet generated
-        """
-        return self.relation_data.get("private-key", "")
-
-    @property
-    def csr(self) -> str:
-        """The unit cert signing request.
-
-        Returns:
-            String of csr contents
-            Empty if csr not yet generated
-        """
-        return self.relation_data.get("csr", "")
-
-    @property
-    def certificate(self) -> str:
-        """The signed unit certificate from the provider relation.
-
-        Returns:
-            String of cert contents in PEM format
-            Empty if cert not yet generated/signed
-        """
-        return self.relation_data.get("certificate", "")
-
-    @property
-    def ca(self) -> str:
-        """The ca used to sign unit cert.
-
-        Returns:
-            String of ca contents in PEM format
-            Empty if cert not yet generated/signed
-        """
-        # defaults to ca for backwards compatibility after field change introduced with secrets
-        return self.relation_data.get("ca-cert", "")
-
-    @property
-    def chain(self) -> list[str]:
-        """The chain used to sign unit cert."""
-        return json.loads(self.relation_data.get("chain", "null")) or []
-
-    @property
-    def bundle(self) -> list[str]:
-        """The cert bundle used for TLS identity."""
-        if not all([self.certificate, self.ca]):
-            return []
-
-        # manual-tls-certificates is loaded with the signed cert, the intermediate CA that signed it
-        # and then the missing chain for that CA
-        # ZK needs to present the full bundle - aka Keystore
-        # ZK needs to trust each item in the bundle - aka Truststore
-        bundle = [self.certificate, self.ca] + self.chain
-        return sorted(set(bundle), key=bundle.index)  # ordering might matter
+    def client_tls(self) -> TLSState:
+        """TLS state for external (client) communications."""
+        return TLSState(self, TLSScope.CLIENT)
 
     @property
     def keystore_password(self) -> str:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -569,6 +569,16 @@ class TLSState:
         return sorted(set(bundle), key=bundle.index)  # ordering might matter
 
     @property
+    def rotation(self) -> bool:
+        """Whether or not CA/chain rotation is in progress."""
+        return bool(self.relation_data.get(f"{self.scope.value}-rotation", ""))
+
+    @rotation.setter
+    def rotation(self, value: bool) -> None:
+        _value = "" if not value else "true"
+        self.relation_state.update({f"{self.scope.value}-rotation": _value})
+
+    @property
     def ready(self) -> bool:
         """Returns True if all the necessary TLS relation data has been set, False otherwise."""
         return all([self.certificate, self.ca, self.private_key])

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -569,12 +569,12 @@ class TLSState:
         return sorted(set(bundle), key=bundle.index)  # ordering might matter
 
     @property
-    def rotation(self) -> bool:
+    def rotate(self) -> bool:
         """Whether or not CA/chain rotation is in progress."""
         return bool(self.relation_data.get(f"{self.scope.value}-rotation", ""))
 
-    @rotation.setter
-    def rotation(self, value: bool) -> None:
+    @rotate.setter
+    def rotate(self, value: bool) -> None:
         _value = "" if not value else "true"
         self.relation_state.update({f"{self.scope.value}-rotation": _value})
 
@@ -631,12 +631,12 @@ class KafkaBroker(RelationState):
 
     # --- TLS ---
     @property
-    def peer_tls(self) -> TLSState:
+    def peer_certs(self) -> TLSState:
         """TLS state for internal (peer) communications."""
         return TLSState(self, TLSScope.PEER)
 
     @property
-    def client_tls(self) -> TLSState:
+    def client_certs(self) -> TLSState:
         """TLS state for external (client) communications."""
         return TLSState(self, TLSScope.CLIENT)
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -539,7 +539,6 @@ class TLSState:
             String of ca contents in PEM format
             Empty if cert not yet generated/signed
         """
-        # defaults to ca for backwards compatibility after field change introduced with secrets
         return self.relation_data.get(f"{self.scope.value}-ca-cert", "")
 
     @ca.setter
@@ -563,8 +562,6 @@ class TLSState:
 
         # manual-tls-certificates is loaded with the signed cert, the intermediate CA that signed it
         # and then the missing chain for that CA
-        # ZK needs to present the full bundle - aka Keystore
-        # ZK needs to trust each item in the bundle - aka Truststore
         bundle = [self.certificate, self.ca] + self.chain
         return sorted(set(bundle), key=bundle.index)  # ordering might matter
 

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from charmlibs import pathops
 from ops.pebble import Layer
 
-from literals import BALANCER, BROKER, Role
+from literals import BALANCER, BROKER, Role, TLSScope
 
 
 class CharmedKafkaPaths:
@@ -56,13 +56,23 @@ class CharmedKafkaPaths:
 
     @property
     def keystore(self):
-        """The Java Keystore containing service private-key and signed certificates."""
-        return f"{self.conf_path}/keystore.p12"
+        """The Java Keystore containing service private-key and signed certificates for clients."""
+        return f"{self.conf_path}/{TLSScope.CLIENT.value}-keystore.p12"
 
     @property
     def truststore(self):
-        """The Java Truststore containing trusted CAs + certificates."""
-        return f"{self.conf_path}/truststore.jks"
+        """The Java Truststore containing trusted CAs + certificates for clients."""
+        return f"{self.conf_path}/{TLSScope.CLIENT.value}-truststore.jks"
+
+    @property
+    def peer_keystore(self):
+        """The Java Keystore containing service private-key and signed certificates for internal peer communications."""
+        return f"{self.conf_path}/{TLSScope.PEER.value}-keystore.p12"
+
+    @property
+    def peer_truststore(self):
+        """The Java Truststore containing trusted CAs + certificates for internal peer communications."""
+        return f"{self.conf_path}/{TLSScope.PEER.value}-truststore.jks"
 
     @property
     def log4j_properties(self):

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -132,6 +132,10 @@ class BalancerOperator(Object):
             return
 
         self.workload.restart()
+
+        if self.charm.state.balancer_tls_rotation:
+            self.charm.state.balancer_tls_rotation = False
+
         logger.info("CruiseControl service started")
 
     def _on_config_changed(self, _: EventBase) -> None:
@@ -182,7 +186,7 @@ class BalancerOperator(Object):
 
             content_changed = True
 
-        if content_changed:
+        if content_changed or self.charm.state.balancer_tls_rotation:
             # safe to update everything even if it hasn't changed, service will restart anyway
             self.config_manager.set_cruise_control_properties()
             self.config_manager.set_broker_capacities()

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -133,8 +133,8 @@ class BalancerOperator(Object):
 
         self.workload.restart()
 
-        if self.charm.state.balancer_tls_rotation:
-            self.charm.state.balancer_tls_rotation = False
+        if self.charm.state.balancer_tls_rotate:
+            self.charm.state.balancer_tls_rotate = False
 
         logger.info("CruiseControl service started")
 
@@ -186,7 +186,7 @@ class BalancerOperator(Object):
 
             content_changed = True
 
-        if content_changed or self.charm.state.balancer_tls_rotation:
+        if content_changed or self.charm.state.balancer_tls_rotate:
             # safe to update everything even if it hasn't changed, service will restart anyway
             self.config_manager.set_cruise_control_properties()
             self.config_manager.set_broker_capacities()

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -119,6 +119,7 @@ class BalancerOperator(Object):
             if self.charm.state.peer_cluster_orchestrator:
                 self.charm.state.peer_cluster_orchestrator.update(payload)
 
+        self.tls_manager.setup_internal_credentials()
         self.config_manager.set_cruise_control_properties()
         self.config_manager.set_broker_capacities()
         self.config_manager.set_cruise_control_auth()

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -169,7 +169,7 @@ class BrokerOperator(Object):
             return
 
         # Internal TLS setup required?
-        if not self.charm.state.unit_broker.peer_tls.ready and not self.charm.state.internal_ca:
+        if not self.charm.state.unit_broker.peer_certs.ready and not self.charm.state.internal_ca:
             if not self.charm.unit.is_leader():
                 event.defer()
                 return
@@ -193,8 +193,8 @@ class BrokerOperator(Object):
         # need to manually add-back key/truststores
         if (
             self.charm.state.cluster.tls_enabled
-            and self.charm.state.unit_broker.client_tls.certificate
-            and self.charm.state.unit_broker.client_tls.ca
+            and self.charm.state.unit_broker.client_certs.certificate
+            and self.charm.state.unit_broker.client_certs.ca
         ):  # TLS is probably completed
             self.tls_manager.configure()
 
@@ -263,7 +263,7 @@ class BrokerOperator(Object):
             )
             self.charm.tls.refresh_tls_certificates.emit()
             # new cert will eventually be dynamically loaded by the broker
-            self.charm.state.unit_broker.client_tls.certificate = ""
+            self.charm.state.unit_broker.client_certs.certificate = ""
 
             return  # early return here to ensure new node cert arrives before updating advertised.listeners
 
@@ -277,7 +277,7 @@ class BrokerOperator(Object):
             )
             self.config_manager.set_server_properties()
 
-        if properties_changed or self.charm.state.tls_rotation:
+        if properties_changed or self.charm.state.tls_rotate:
             if isinstance(event, StorageEvent):  # to get new storages
                 self.controller_manager.format_storages(
                     uuid=self.charm.state.peer_cluster.cluster_uuid,
@@ -305,13 +305,13 @@ class BrokerOperator(Object):
         # Update truststore if needed.
         self.charm.tls.update_truststore()
 
-        if self.charm.state.tls_rotation:
+        if self.charm.state.tls_rotate:
             # If TLS rotation is needed, inform the balancer.
             if self.charm.state.runs_balancer:
-                self.charm.state.balancer_tls_rotation = True
+                self.charm.state.balancer_tls_rotate = True
 
             # Reset TLS rotation state
-            self.charm.state.tls_rotation = False
+            self.charm.state.tls_rotate = False
 
         if self.charm.unit.is_leader():
             self.update_credentials_cache()
@@ -448,7 +448,7 @@ class BrokerOperator(Object):
                     "username": client.username,
                     "password": client.password,
                     "tls": client.tls,
-                    "tls-ca": self.charm.state.unit_broker.client_tls.ca,
+                    "tls-ca": self.charm.state.unit_broker.client_certs.ca,
                 }
             )
 
@@ -458,7 +458,7 @@ class BrokerOperator(Object):
             return
 
         # Update peer-cluster chain of trust
-        self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_tls.bundle
+        self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_certs.bundle
 
         self.charm.state.peer_cluster.update(
             {

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -176,7 +176,12 @@ class BrokerOperator(Object):
                 self.charm.unit.is_leader(),
             ]
         ):
-            self.tls_manager.setup_internal_ca()
+            # Generate internal CA
+            generated_ca = self.tls_manager.generate_internal_ca()
+            self.charm.state.internal_ca = generated_ca.ca
+            self.charm.state.internal_ca_key = generated_ca.ca_key
+            # Now generate unit's self-signed certs
+            self.setup_internal_tls()
 
         current_status = self.charm.state.ready_to_start
         if current_status is not Status.ACTIVE:
@@ -186,7 +191,7 @@ class BrokerOperator(Object):
 
         self.kraft.format_storages()
         self.update_external_services()
-        self.tls_manager.setup_internal_credentials()
+        self.setup_internal_tls()
 
         self.config_manager.set_server_properties()
         self.config_manager.set_client_properties()
@@ -391,6 +396,23 @@ class BrokerOperator(Object):
 
         self.charm.state.unit_broker.update({"storages": self.balancer_manager.storages})
         self.charm.on.config_changed.emit()
+
+    def setup_internal_tls(self) -> None:
+        """Generates a self-signed certificate if required and writes all necessary TLS configuration for internal TLS."""
+        if self.charm.state.unit_broker.peer_certs.ready:
+            self.tls_manager.configure()
+            return
+
+        self_signed_cert = self.tls_manager.generate_self_signed_certificate()
+        if not self_signed_cert:
+            return
+
+        self.charm.state.unit_broker.peer_certs.set_self_signed(self_signed_cert)
+        self.tls_manager.configure()
+
+        if self.charm.unit.is_leader():
+            # If leader, also set the peer cluster chain. Leads to no-op in KRaft single mode.
+            self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_certs.bundle
 
     @property
     def healthy(self) -> bool:

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -169,11 +169,13 @@ class BrokerOperator(Object):
             return
 
         # Internal TLS setup required?
-        if not self.charm.state.unit_broker.peer_certs.ready and not self.charm.state.internal_ca:
-            if not self.charm.unit.is_leader():
-                event.defer()
-                return
-
+        if all(
+            [
+                not self.charm.state.unit_broker.peer_certs.ready,
+                not self.charm.state.internal_ca,
+                self.charm.unit.is_leader(),
+            ]
+        ):
             self.tls_manager.setup_internal_ca()
 
         current_status = self.charm.state.ready_to_start
@@ -297,7 +299,7 @@ class BrokerOperator(Object):
             self.charm.state.unit_broker.unit.set_ports(  # in case of listeners changes
                 *[listener.port for listener in self.config_manager.all_listeners]
             )
-        elif self.charm.state.runs_controller:  # only valid for KRaft-multi on controllers
+        elif self.charm.state.runs_controller_only:
             self.charm.state.unit_broker.unit.set_ports(
                 *[listener.port for listener in self.config_manager.controller_listeners]
             )
@@ -490,7 +492,12 @@ class BrokerOperator(Object):
 
         for client in self.charm.state.clients:
 
-            if not client.password or client.username in users:
+            if not client.password:
+                # client not setup yet.
+                continue
+
+            if client.username in users:
+                # no need to re-add the user.
                 continue
 
             self.auth_manager.add_user(client.username, client.password)

--- a/src/events/controller.py
+++ b/src/events/controller.py
@@ -86,7 +86,7 @@ class KRaftHandler(Object):
             event.defer()
             return
 
-        self._format_storages()
+        self.format_storages()
 
         # update status to add controller
         self.charm.on.update_status.emit()
@@ -125,16 +125,8 @@ class KRaftHandler(Object):
         if self.charm.state.runs_controller and not self.charm.state.cluster.bootstrap_controller:
 
             generated_password = self.charm.workload.generate_password()
-
-            if self.charm.state.peer_cluster_orchestrator:
-
-                if not self.charm.state.peer_cluster_orchestrator.controller_password:
-                    self.charm.state.peer_cluster_orchestrator.update(
-                        {"controller-password": generated_password}
-                    )
-            elif not self.charm.state.peer_cluster.controller_password:
-                # single mode, controller & leader
-                self.charm.state.cluster.update({"controller-password": generated_password})
+            self.charm.state.cluster.update({"controller-password": generated_password})
+            self.charm.state.kraft_cluster.update({"controller-password": generated_password})
 
             bootstrap_data = {
                 "bootstrap-controller": self.charm.state.bootstrap_controller,
@@ -143,9 +135,10 @@ class KRaftHandler(Object):
             }
             self.charm.state.cluster.update(bootstrap_data)
 
-    def _format_storages(self) -> None:
+    def format_storages(self) -> None:
         """Format storages provided relevant keys exist."""
         self.config_manager.set_server_properties()
+
         if self.charm.state.runs_broker:
             credentials = self.charm.state.cluster.internal_user_credentials
         elif self.charm.state.runs_controller:

--- a/src/events/controller.py
+++ b/src/events/controller.py
@@ -138,6 +138,9 @@ class KRaftHandler(Object):
     def format_storages(self) -> None:
         """Format storages provided relevant keys exist."""
         self.config_manager.set_server_properties()
+        if self.controller_manager.get_metadata_directory_id(self.charm.state.log_dirs):
+            # Already formatted!
+            return
 
         if self.charm.state.runs_broker:
             credentials = self.charm.state.cluster.internal_user_credentials

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -107,6 +107,9 @@ class PeerClusterEventsHandler(Object):
 
         self._default_relation_changed(event)
 
+        # Update peer-cluster chain of trust
+        self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_tls.bundle
+
         # will no-op if relation does not exist
         self.charm.state.peer_cluster.update(
             {
@@ -117,7 +120,6 @@ class PeerClusterEventsHandler(Object):
                 "bootstrap-controller": self.charm.state.peer_cluster.bootstrap_controller,
                 "bootstrap-unit-id": self.charm.state.peer_cluster.bootstrap_unit_id,
                 "bootstrap-replica-id": self.charm.state.peer_cluster.bootstrap_replica_id,
-                "controller-ca": self.charm.state.unit_broker.peer_tls.ca,
             }
         )
 
@@ -138,6 +140,9 @@ class PeerClusterEventsHandler(Object):
 
         self._default_relation_changed(event)
 
+        # Update peer-cluster chain of trust
+        self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_tls.bundle
+
         # will no-op if relation does not exist
         self.charm.state.peer_cluster.update(
             {
@@ -149,7 +154,6 @@ class PeerClusterEventsHandler(Object):
                 "racks": str(self.charm.state.peer_cluster.racks),
                 "broker-capacities": json.dumps(self.charm.state.peer_cluster.broker_capacities),
                 "super-users": self.charm.state.super_users,
-                "broker-ca": self.charm.state.unit_broker.peer_tls.ca,
             }
         )
 

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -108,7 +108,7 @@ class PeerClusterEventsHandler(Object):
         self._default_relation_changed(event)
 
         # Update peer-cluster chain of trust
-        self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_tls.bundle
+        self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_certs.bundle
 
         # will no-op if relation does not exist
         self.charm.state.peer_cluster.update(
@@ -141,7 +141,7 @@ class PeerClusterEventsHandler(Object):
         self._default_relation_changed(event)
 
         # Update peer-cluster chain of trust
-        self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_tls.bundle
+        self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_certs.bundle
 
         # will no-op if relation does not exist
         self.charm.state.peer_cluster.update(

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -117,6 +117,7 @@ class PeerClusterEventsHandler(Object):
                 "bootstrap-controller": self.charm.state.peer_cluster.bootstrap_controller,
                 "bootstrap-unit-id": self.charm.state.peer_cluster.bootstrap_unit_id,
                 "bootstrap-replica-id": self.charm.state.peer_cluster.bootstrap_replica_id,
+                "controller-ca": self.charm.state.unit_broker.peer_tls.ca,
             }
         )
 
@@ -148,6 +149,7 @@ class PeerClusterEventsHandler(Object):
                 "racks": str(self.charm.state.peer_cluster.racks),
                 "broker-capacities": json.dumps(self.charm.state.peer_cluster.broker_capacities),
                 "super-users": self.charm.state.super_users,
+                "broker-ca": self.charm.state.unit_broker.peer_tls.ca,
             }
         )
 

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -78,7 +78,10 @@ class KafkaProvider(Object):
 
         # We don't want to set credentials for the client before MTLS setup.
         if requesting_client.mtls_cert and not all(
-            [self.charm.state.cluster.tls_enabled, self.charm.state.unit_broker.certificate]
+            [
+                self.charm.state.cluster.tls_enabled,
+                self.charm.state.unit_broker.client_tls.certificate,
+            ]
         ):
             logger.debug("Missing TLS relation, deferring")
             self.charm._set_status(Status.MTLS_REQUIRES_TLS)
@@ -134,7 +137,10 @@ class KafkaProvider(Object):
             return
 
         if not all(
-            [self.charm.state.cluster.tls_enabled, self.charm.state.unit_broker.certificate]
+            [
+                self.charm.state.cluster.tls_enabled,
+                self.charm.state.unit_broker.client_tls.certificate,
+            ]
         ):
             logger.debug("Missing TLS relation, deferring")
             self.charm._set_status(Status.MTLS_REQUIRES_TLS)

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -80,7 +80,7 @@ class KafkaProvider(Object):
         if requesting_client.mtls_cert and not all(
             [
                 self.charm.state.cluster.tls_enabled,
-                self.charm.state.unit_broker.client_tls.certificate,
+                self.charm.state.unit_broker.client_certs.certificate,
             ]
         ):
             logger.debug("Missing TLS relation, deferring")
@@ -139,7 +139,7 @@ class KafkaProvider(Object):
         if not all(
             [
                 self.charm.state.cluster.tls_enabled,
-                self.charm.state.unit_broker.client_tls.certificate,
+                self.charm.state.unit_broker.client_certs.certificate,
             ]
         ):
             logger.debug("Missing TLS relation, deferring")

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -182,9 +182,7 @@ class TLSHandler(Object):
 
         if state.scope == TLSScope.PEER:
             # switch back to internal TLS
-            is_leader = self.charm.unit.is_leader()
-            self.charm.broker.tls_manager.setup_internal_credentials(is_leader=is_leader)
-            self.charm.balancer.tls_manager.setup_internal_credentials(is_leader=is_leader)
+            self.charm.broker.setup_internal_tls()
 
             state.rotate = True
             self.charm.on.config_changed.emit()

--- a/src/health.py
+++ b/src/health.py
@@ -69,7 +69,7 @@ class KafkaHealth(Object):
         """Gets the number of partitions and their average size from the log dirs."""
         log_dirs_command = [
             "--describe",
-            f"--bootstrap-server {self.charm.state.bootstrap_server}",
+            f"--bootstrap-server {self.charm.state.bootstrap_server_internal}",
             f"--command-config {self.dependent.workload.paths.client_properties}",
         ]
         try:

--- a/src/literals.py
+++ b/src/literals.py
@@ -30,6 +30,7 @@ REL_NAME = "kafka-client"
 OAUTH_REL_NAME = "oauth"
 
 TLS_RELATION = "certificates"
+INTERNAL_TLS_RELATION = "peer-certificates"
 CERTIFICATE_TRANSFER_RELATION = "client-cas"
 PEER_CLUSTER_RELATION = "peer-cluster"
 PEER_CLUSTER_ORCHESTRATOR_RELATION = "peer-cluster-orchestrator"
@@ -42,6 +43,13 @@ MIN_REPLICAS = 3
 KRAFT_VERSION = 1
 
 
+class TLSScope(str, Enum):
+    """Enum for TLS scopes."""
+
+    PEER = "peer"  # for internal communications
+    CLIENT = "client"  # for external/client communications
+
+
 INTER_BROKER_USER = "sync"
 ADMIN_USER = "admin"
 CONTROLLER_USER = "controller"
@@ -50,16 +58,19 @@ BALANCER_WEBSERVER_USER = "balancer"
 BALANCER_WEBSERVER_PORT = 9090
 SECRETS_APP = [
     f"{user}-password" for user in INTERNAL_USERS + [BALANCER_WEBSERVER_USER, CONTROLLER_USER]
-]
+] + ["internal-ca", "internal-ca-key"]
 SECRETS_UNIT = [
-    "ca-cert",
-    "chain",
-    "csr",
-    "certificate",
     "truststore-password",
     "keystore-password",
-    "private-key",
 ]
+for scope in (TLSScope.CLIENT.value, TLSScope.PEER.value):
+    SECRETS_UNIT += [
+        f"{scope}-ca-cert",
+        f"{scope}-chain",
+        f"{scope}-csr",
+        f"{scope}-certificate",
+        f"{scope}-private-key",
+    ]
 
 JMX_EXPORTER_PORT = 9101
 JMX_CC_PORT = 9102
@@ -74,24 +85,22 @@ class Ports:
     client: int
     internal: int
     external: int
+    controller: int
     extra: int = 0
 
 
 AuthProtocol = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]
 AuthMechanism = Literal["SCRAM-SHA-512", "OAUTHBEARER", "SSL"]
-Scope = Literal["INTERNAL", "CLIENT", "EXTERNAL", "EXTRA"]
+Scope = Literal["INTERNAL", "CLIENT", "EXTERNAL", "EXTRA", "CONTROLLER"]
 AuthMap = NamedTuple("AuthMap", protocol=AuthProtocol, mechanism=AuthMechanism)
 
 SECURITY_PROTOCOL_PORTS: dict[AuthMap, Ports] = {
-    AuthMap("SASL_PLAINTEXT", "SCRAM-SHA-512"): Ports(9092, 19092, 29092),
-    AuthMap("SASL_SSL", "SCRAM-SHA-512"): Ports(9093, 19093, 29093),
-    AuthMap("SSL", "SSL"): Ports(9094, 19094, 29094),
-    AuthMap("SASL_PLAINTEXT", "OAUTHBEARER"): Ports(9095, 19095, 29095),
-    AuthMap("SASL_SSL", "OAUTHBEARER"): Ports(9096, 19096, 29096),
+    AuthMap("SASL_PLAINTEXT", "SCRAM-SHA-512"): Ports(9092, 19092, 29092, 9097),
+    AuthMap("SASL_SSL", "SCRAM-SHA-512"): Ports(9093, 19093, 29093, 9098),
+    AuthMap("SSL", "SSL"): Ports(9094, 19094, 29094, 19194),
+    AuthMap("SASL_PLAINTEXT", "OAUTHBEARER"): Ports(9095, 19095, 29095, 19195),
+    AuthMap("SASL_SSL", "OAUTHBEARER"): Ports(9096, 19096, 29096, 19196),
 }
-# FIXME this port should exist on the previous abstraction
-CONTROLLER_PORT = 9097
-CONTROLLER_LISTENER_NAME = "INTERNAL_CONTROLLER"
 
 # FIXME: when running broker node.id will be unit-id + 100. If unit is only running
 # the controller node.id == unit-id. This way we can keep a human readable mapping of ids.
@@ -160,6 +169,7 @@ CONTROLLER = Role(
     requested_secrets=[
         "broker-username",
         "broker-password",
+        "controller-password",
     ],
 )
 BALANCER = Role(
@@ -247,18 +257,18 @@ class Status(Enum):
         BlockedStatus("missing required peer-cluster relation"), "DEBUG"
     )
     SNAP_NOT_INSTALLED = StatusLevel(BlockedStatus(f"unable to install {SNAP_NAME} snap"), "ERROR")
-    SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("Service not running"), "WARNING")
+    SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("service not running"), "WARNING")
     NOT_ALL_RELATED = StatusLevel(MaintenanceStatus("not all units related"), "DEBUG")
     CC_NOT_RUNNING = StatusLevel(BlockedStatus("Cruise Control not running"), "WARNING")
     MISSING_MODE = StatusLevel(
-        BlockedStatus("Application needs to be related with a KRaft controller"), "DEBUG"
+        BlockedStatus("application needs to be related with a KRaft controller"), "DEBUG"
     )
-    NO_CLUSTER_UUID = StatusLevel(WaitingStatus("Waiting for cluster uuid"), "DEBUG")
+    NO_CLUSTER_UUID = StatusLevel(WaitingStatus("waiting for cluster uuid"), "DEBUG")
     NO_BOOTSTRAP_CONTROLLER = StatusLevel(
-        WaitingStatus("Waiting for bootstrap controller"), "DEBUG"
+        WaitingStatus("waiting for bootstrap controller"), "DEBUG"
     )
     MISSING_CONTROLLER_PASSWORD = StatusLevel(
-        WaitingStatus("Waiting for controller user credentials"), "DEBUG"
+        WaitingStatus("waiting for controller user credentials"), "DEBUG"
     )
     BROKER_NOT_CONNECTED = StatusLevel(
         BlockedStatus("unit not connected to the controller"), "ERROR"
@@ -281,11 +291,13 @@ class Status(Enum):
         WaitingStatus("internal broker credentials not yet added"), "DEBUG"
     )
     NO_CERT = StatusLevel(WaitingStatus("unit waiting for signed certificates"), "INFO")
+    NO_INTERNAL_TLS = StatusLevel(WaitingStatus("waiting for internal TLS setup"), "INFO")
+    NO_PEER_CLUSTER_CA = StatusLevel(WaitingStatus("waiting for peer-cluster TLS setup"), "INFO")
     MTLS_REQUIRES_TLS = StatusLevel(
-        BlockedStatus("Can't setup MTLS client without a TLS relation first."), "ERROR"
+        BlockedStatus("can't setup mTLS client without a TLS relation first."), "ERROR"
     )
     INVALID_CLIENT_CERTIFICATE = StatusLevel(
-        BlockedStatus("MTLS Client's certificate is not a valid leaf certificate."), "ERROR"
+        BlockedStatus("mTLS client's certificate is not a valid leaf certificate."), "ERROR"
     )
     SYSCONF_NOT_OPTIMAL = StatusLevel(
         ActiveStatus("machine system settings are not optimal - see logs for info"),

--- a/src/literals.py
+++ b/src/literals.py
@@ -225,7 +225,6 @@ MODE_REMOVE = "remove"
 PROFILE_TESTING = "testing"
 
 
-<<<<<<< HEAD
 class KRaftUnitStatus(str, Enum):
     """KRaft unit status (also known as role) in KRaft Quorums."""
 
@@ -243,8 +242,6 @@ class KRaftQuorumInfo:
     status: KRaftUnitStatus
 
 
-=======
->>>>>>> cc55e44 (refactor: based on first review)
 @dataclass
 class StatusLevel:
     """Status object helper."""

--- a/src/literals.py
+++ b/src/literals.py
@@ -62,15 +62,17 @@ SECRETS_APP = [
 SECRETS_UNIT = [
     "truststore-password",
     "keystore-password",
+    "client-ca-cert",
+    "client-certificate",
+    "client-chain",
+    "client-csr",
+    "client-private-key",
+    "peer-ca-cert",
+    "peer-certificate",
+    "peer-chain",
+    "peer-csr",
+    "peer-private-key",
 ]
-for scope in (TLSScope.CLIENT.value, TLSScope.PEER.value):
-    SECRETS_UNIT += [
-        f"{scope}-ca-cert",
-        f"{scope}-chain",
-        f"{scope}-csr",
-        f"{scope}-certificate",
-        f"{scope}-private-key",
-    ]
 
 JMX_EXPORTER_PORT = 9101
 JMX_CC_PORT = 9102
@@ -223,6 +225,7 @@ MODE_REMOVE = "remove"
 PROFILE_TESTING = "testing"
 
 
+<<<<<<< HEAD
 class KRaftUnitStatus(str, Enum):
     """KRaft unit status (also known as role) in KRaft Quorums."""
 
@@ -240,6 +243,8 @@ class KRaftQuorumInfo:
     status: KRaftUnitStatus
 
 
+=======
+>>>>>>> cc55e44 (refactor: based on first review)
 @dataclass
 class StatusLevel:
     """Status object helper."""

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -48,7 +48,7 @@ class AuthManager:
     def _get_acls_from_cluster(self) -> str:
         """Loads the currently active ACLs from the Kafka cluster."""
         command = [
-            f"--bootstrap-server={self.state.bootstrap_server}",
+            f"--bootstrap-server={self.state.bootstrap_server_internal}",
             f"--command-config={self.workload.paths.client_properties}",
             "--list",
         ]
@@ -169,7 +169,7 @@ class AuthManager:
             `(subprocess.CalledProcessError | ops.pebble.ExecError)`: if the error returned a non-zero exit code
         """
         command = [
-            f"--bootstrap-server={self.state.bootstrap_server}",
+            f"--bootstrap-server={self.state.bootstrap_server_internal}",
             f"--command-config={self.workload.paths.client_properties}",
             "--alter",
             "--entity-type=users",
@@ -206,7 +206,7 @@ class AuthManager:
             `(subprocess.CalledProcessError | ops.pebble.ExecError)`: if the error returned a non-zero exit code
         """
         command = [
-            f"--bootstrap-server={self.state.bootstrap_server}",
+            f"--bootstrap-server={self.state.bootstrap_server_internal}",
             f"--command-config={self.workload.paths.client_properties}",
             "--add",
             f"--allow-principal=User:{username}",
@@ -247,7 +247,7 @@ class AuthManager:
             `(subprocess.CalledProcessError | ops.pebble.ExecError)`: if the error returned a non-zero exit code
         """
         command = [
-            f"--bootstrap-server={self.state.bootstrap_server}",
+            f"--bootstrap-server={self.state.bootstrap_server_internal}",
             f"--command-config={self.workload.paths.client_properties}",
             "--remove",
             f"--allow-principal=User:{username}",

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -479,7 +479,7 @@ class ConfigManager(CommonConfigManager):
             + [
                 f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{CONTROLLER_USER}" password="{password}";',
                 f"sasl.mechanism={self.internal_listener.mechanism}",
-                "security.protocol=SASL_PLAINTEXT",
+                f"security.protocol={self.internal_listener.protocol}",
                 "default.api.timeout.ms=20000",
                 "request.timeout.ms=10000",
             ]

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -466,17 +466,25 @@ class ConfigManager(CommonConfigManager):
         # Strip CC & TLS properties from KRaft quorum client properties file
         stripped_properties = list(
             set(self.server_properties)
-            - set(KAFKA_CRUISE_CONTROL_OPTIONS.splitlines() + self.metrics_reporter_properties + self.tls_properties)
+            - set(
+                KAFKA_CRUISE_CONTROL_OPTIONS.splitlines()
+                + self.metrics_reporter_properties
+                + self.tls_properties
+            )
         )
         stripped_properties.sort()
 
-        return stripped_properties + [
-            f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{CONTROLLER_USER}" password="{password}";',
-            f"sasl.mechanism={self.internal_listener.mechanism}",
-            "security.protocol=SASL_PLAINTEXT",
-            "default.api.timeout.ms=20000",
-            "request.timeout.ms=10000",
-        ] + self.client_tls_properties
+        return (
+            stripped_properties
+            + [
+                f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{CONTROLLER_USER}" password="{password}";',
+                f"sasl.mechanism={self.internal_listener.mechanism}",
+                "security.protocol=SASL_PLAINTEXT",
+                "default.api.timeout.ms=20000",
+                "request.timeout.ms=10000",
+            ]
+            + self.client_tls_properties
+        )
 
     @property
     def oauth_properties(self) -> list[str]:

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -362,7 +362,7 @@ class ConfigManager(CommonConfigManager):
                 f"listener.name.{listener_name}.ssl.keystore.password={self.state.unit_broker.keystore_password}",
             ]
 
-        if not all([self.state.cluster.tls_enabled, self.state.unit_broker.client_tls.ready]):
+        if not all([self.state.cluster.tls_enabled, self.state.unit_broker.client_certs.ready]):
             return properties
 
         return properties + [

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -10,12 +10,14 @@ import os
 import re
 import textwrap
 from abc import abstractmethod
+from functools import cached_property
 from typing import Iterable, cast
 
 from lightkube.core.exceptions import ApiError
 from typing_extensions import override
 
 from core.cluster import ClusterState
+from core.models import PeerCluster
 from core.structured_config import CharmConfig, LogLevel
 from core.workload import CharmedKafkaPaths, WorkloadBase
 from literals import (
@@ -23,8 +25,6 @@ from literals import (
     BALANCER,
     BALANCER_GOALS_TESTING,
     BROKER,
-    CONTROLLER_LISTENER_NAME,
-    CONTROLLER_PORT,
     CONTROLLER_USER,
     DEFAULT_BALANCER_GOALS,
     HARD_BALANCER_GOALS,
@@ -177,6 +177,11 @@ class CommonConfigManager:
     config: CharmConfig
     workload: WorkloadBase
     state: ClusterState
+
+    @cached_property
+    def peer_cluster_state(self) -> PeerCluster:
+        """Cached peer_cluster state."""
+        return self.state.peer_cluster
 
     @property
     def log_level(self) -> str:
@@ -345,21 +350,60 @@ class ConfigManager(CommonConfigManager):
         Returns:
             List of properties to be set
         """
-        mtls = "required" if self.state.cluster.mtls_enabled else "none"
-        return [
+        properties = []
+
+        # Internal listeners always use TLS regardless.
+        for listener in self.controller_listeners + [self.internal_listener]:
+            listener_name = listener.name.lower()
+            properties += [
+                f"listener.name.{listener_name}.ssl.truststore.location={self.workload.paths.peer_truststore}",
+                f"listener.name.{listener_name}.ssl.truststore.password={self.state.unit_broker.truststore_password}",
+                f"listener.name.{listener_name}.ssl.keystore.location={self.workload.paths.peer_keystore}",
+                f"listener.name.{listener_name}.ssl.keystore.password={self.state.unit_broker.keystore_password}",
+            ]
+
+        if not all([self.state.cluster.tls_enabled, self.state.unit_broker.client_tls.ready]):
+            return properties
+
+        return properties + [
             f"ssl.truststore.location={self.workload.paths.truststore}",
             f"ssl.truststore.password={self.state.unit_broker.truststore_password}",
             f"ssl.keystore.location={self.workload.paths.keystore}",
             f"ssl.keystore.password={self.state.unit_broker.keystore_password}",
-            f"ssl.client.auth={mtls}",
         ]
 
     @property
-    def scram_properties(self) -> list[str]:
-        """Builds the properties for each scram listener.
+    def client_tls_properties(self) -> list[str]:
+        """Builds the properties necessary for TLS authentication of clients, either internal or KRaft.
 
         Returns:
-            list of scram properties to be set
+            List of properties to be set
+        """
+        return [
+            f"ssl.truststore.location={self.workload.paths.peer_truststore}",
+            f"ssl.truststore.password={self.state.unit_broker.truststore_password}",
+            f"ssl.keystore.location={self.workload.paths.peer_keystore}",
+            f"ssl.keystore.password={self.state.unit_broker.keystore_password}",
+        ]
+
+    @property
+    def mtls_properties(self) -> list[str]:
+        """Builds the properties necessary for MTLS authentication.
+
+        Returns:
+            List of properties to be set
+        """
+        if not self.state.cluster.mtls_enabled:
+            return []
+
+        return ["ssl.client.auth=required"]
+
+    @property
+    def scram_properties(self) -> list[str]:
+        """Builds the properties for each SCRAM listener.
+
+        Returns:
+            list of SCRAM properties to be set
         """
         username = INTER_BROKER_USER
         password = self.state.cluster.internal_user_credentials.get(INTER_BROKER_USER, "")
@@ -393,18 +437,22 @@ class ConfigManager(CommonConfigManager):
         """Builds the SCRAM properties for controller listener.
 
         Returns:
-            list of scram properties to be set
+            list of SCRAM properties to be set
         """
-        password = self.state.peer_cluster.controller_password
-        listener_mechanism = self.internal_listener.mechanism.lower()
-        listener_name = CONTROLLER_LISTENER_NAME.lower()
+        password = self.peer_cluster_state.controller_password
+        listeners = []
 
-        return [
-            "sasl.enabled.mechanisms=SCRAM-SHA-512",
-            f"sasl.mechanism.controller.protocol={self.internal_listener.mechanism}",
-            f'listener.name.{listener_name}.{listener_mechanism}.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{CONTROLLER_USER}" password="{password}" user_{CONTROLLER_USER}="{password}";',
-            f"listener.name.{listener_name}.sasl.enabled.mechanisms={self.internal_listener.mechanism}",
-        ]
+        for listener in self.controller_listeners:
+            listener_mechanism = listener.mechanism.lower()
+            listener_name = listener.name.lower()
+
+            listeners += [
+                f"sasl.mechanism.controller.protocol={listener.mechanism}",
+                f'listener.name.{listener_name}.{listener_mechanism}.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{CONTROLLER_USER}" password="{password}" user_{CONTROLLER_USER}="{password}";',
+                f"listener.name.{listener_name}.sasl.enabled.mechanisms={listener.mechanism}",
+            ]
+
+        return listeners
 
     @property
     def controller_kraft_client_properties(self) -> list[str]:
@@ -413,12 +461,12 @@ class ConfigManager(CommonConfigManager):
         Returns:
             list of KRaft client properties to be set
         """
-        password = self.state.peer_cluster.controller_password
+        password = self.peer_cluster_state.controller_password
 
-        # Strip CC properties from KRaft quorum client properties file
+        # Strip CC & TLS properties from KRaft quorum client properties file
         stripped_properties = list(
             set(self.server_properties)
-            - set(KAFKA_CRUISE_CONTROL_OPTIONS.splitlines() + self.metrics_reporter_properties)
+            - set(KAFKA_CRUISE_CONTROL_OPTIONS.splitlines() + self.metrics_reporter_properties + self.tls_properties)
         )
         stripped_properties.sort()
 
@@ -428,7 +476,7 @@ class ConfigManager(CommonConfigManager):
             "security.protocol=SASL_PLAINTEXT",
             "default.api.timeout.ms=20000",
             "request.timeout.ms=10000",
-        ]
+        ] + self.client_tls_properties
 
     @property
     def oauth_properties(self) -> list[str]:
@@ -487,14 +535,23 @@ class ConfigManager(CommonConfigManager):
         """Return the internal listener."""
         return Listener(
             host=self.state.unit_broker.internal_address,
-            auth_map=self.state.default_auth,
+            auth_map=self.state.internal_auth,
             scope="INTERNAL",
         )
 
     @property
-    def controller_listener(self) -> None:
-        """Return the controller listener."""
-        pass  # TODO: No good abstraction in place for the controller use case
+    def active_controller_listener(self) -> Listener:
+        """Returns the active (current) controller listener."""
+        return Listener(
+            host=self.state.unit_broker.internal_address,
+            auth_map=self.state.internal_auth,
+            scope="CONTROLLER",
+        )
+
+    @property
+    def controller_listeners(self) -> list[Listener]:
+        """Return all controller listeners including those used in controller listener upgrades."""
+        return [self.active_controller_listener]
 
     @property
     def extra_listeners(self) -> list[Listener]:
@@ -575,6 +632,7 @@ class ConfigManager(CommonConfigManager):
             + self.client_listeners
             + self.external_listeners
             + self.extra_listeners
+            + (self.controller_listeners if self.state.runs_controller else [])
         )
 
     @property
@@ -630,13 +688,10 @@ class ConfigManager(CommonConfigManager):
 
         properties = [
             f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{username}" password="{password}";',
-            f"sasl.mechanism={self.state.default_auth.mechanism}",
-            f"security.protocol={self.state.default_auth.protocol}",
-            f"bootstrap.servers={self.state.bootstrap_server}",
-        ]
-
-        if self.state.cluster.tls_enabled and self.state.unit_broker.certificate:
-            properties += self.tls_properties
+            f"sasl.mechanism={self.state.internal_auth.mechanism}",
+            f"security.protocol={self.state.internal_auth.protocol}",
+            f"bootstrap.servers={self.state.bootstrap_server_internal}",
+        ] + self.client_tls_properties
 
         return [f"{prefix}.{prop}" if prefix else prop for prop in properties]
 
@@ -675,8 +730,8 @@ class ConfigManager(CommonConfigManager):
         properties = [
             f"process.roles={','.join(roles)}",
             f"node.id={node_id}",
-            f"controller.quorum.bootstrap.servers={self.state.peer_cluster.bootstrap_controller}",
-            f"controller.listener.names={CONTROLLER_LISTENER_NAME}",
+            f"controller.quorum.bootstrap.servers={self.peer_cluster_state.bootstrap_controller}",
+            f"controller.listener.names={','.join([listener.name for listener in self.controller_listeners])}",
             *self.controller_scram_properties,
         ]
 
@@ -697,9 +752,10 @@ class ConfigManager(CommonConfigManager):
         protocol_map = [listener.protocol_map for listener in self.all_listeners]
         listeners_repr = [listener.listener for listener in self.all_listeners]
         advertised_listeners = [listener.advertised_listener for listener in self.all_listeners]
-
-        controller_protocol_map = f"{CONTROLLER_LISTENER_NAME}:SASL_PLAINTEXT"
-        controller_listener = f"{CONTROLLER_LISTENER_NAME}://{self.state.unit_broker.internal_address}:{CONTROLLER_PORT}"
+        controller_listeners = [
+            listener.advertised_listener for listener in self.controller_listeners
+        ]
+        controller_protocol_map = [listener.protocol_map for listener in self.controller_listeners]
 
         # NOTE: Case where the controller is running standalone. Early return with a
         # smaller subset of config options
@@ -708,17 +764,19 @@ class ConfigManager(CommonConfigManager):
                 [
                     f"super.users={self.state.super_users}",
                     f"log.dirs={self.state.log_dirs}",
-                    f"listeners={controller_listener}",
-                    f"listener.security.protocol.map={controller_protocol_map}",
+                    f"listeners={','.join(controller_listeners)}",
+                    f"listener.security.protocol.map={','.join(controller_protocol_map)}",
                 ]
                 + self.controller_properties
                 + self.authorizer_class
+                + self.tls_properties
+                # TODO: might want to add self.mtls_properties
             )
             return properties
 
-        protocol_map.append(controller_protocol_map)
-        if self.state.runs_controller:
-            listeners_repr.append(controller_listener)
+        if self.state.runs_broker_only:
+            # KRaft, broker only: we don't need the listener, but still need the protocol mapping
+            protocol_map += controller_protocol_map
 
         properties = (
             [
@@ -738,12 +796,11 @@ class ConfigManager(CommonConfigManager):
             + DEFAULT_CONFIG_OPTIONS.split("\n")
             + self.authorizer_class
             + self.controller_properties
+            + self.tls_properties
+            + self.mtls_properties
         )
 
-        if self.state.cluster.tls_enabled and self.state.unit_broker.certificate:
-            properties += self.tls_properties
-
-        if self.state.runs_balancer or BALANCER.value in self.state.peer_cluster.roles:
+        if self.state.runs_balancer or BALANCER.value in self.peer_cluster_state.roles:
             properties += KAFKA_CRUISE_CONTROL_OPTIONS.splitlines()
             properties += self.metrics_reporter_properties
 
@@ -863,12 +920,12 @@ class BalancerConfigManager(CommonConfigManager):
         if self.config.profile == PROFILE_TESTING:
             goals = BALANCER_GOALS_TESTING
 
-        if self.state.peer_cluster.racks:
+        if self.peer_cluster_state.racks:
             if (
                 min(
-                    [3, len(self.state.peer_cluster.broker_capacities.get("brokerCapacities", []))]
+                    [3, len(self.peer_cluster_state.broker_capacities.get("brokerCapacities", []))]
                 )
-                > self.state.peer_cluster.racks
+                > self.peer_cluster_state.racks
             ):  # replication-factor > racks is not ideal
                 goals = goals + ["RackAwareDistribution"]
             else:
@@ -892,9 +949,9 @@ class BalancerConfigManager(CommonConfigManager):
             List of properties to be set
         """
         return [
-            f"ssl.truststore.location={self.workload.paths.truststore}",
+            f"ssl.truststore.location={self.workload.paths.peer_truststore}",
             f"ssl.truststore.password={self.state.unit_broker.truststore_password}",
-            f"ssl.keystore.location={self.workload.paths.keystore}",
+            f"ssl.keystore.location={self.workload.paths.peer_keystore}",
             f"ssl.keystore.password={self.state.unit_broker.keystore_password}",
             "ssl.client.auth=none",  # TODO mTLS related. Will need changing if mTLS is introduced
         ]
@@ -908,20 +965,18 @@ class BalancerConfigManager(CommonConfigManager):
         """
         properties = (
             [
-                f"bootstrap.servers={self.state.peer_cluster.broker_uris}",
-                f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{self.state.peer_cluster.broker_username}" password="{self.state.peer_cluster.broker_password}";',
-                f"sasl.mechanism={self.state.default_auth.mechanism}",
-                f"security.protocol={self.state.default_auth.protocol}",
+                f"bootstrap.servers={self.peer_cluster_state.broker_uris}",
+                f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{self.peer_cluster_state.broker_username}" password="{self.peer_cluster_state.broker_password}";',
+                f"sasl.mechanism={self.state.internal_auth.mechanism}",
+                f"security.protocol={self.state.internal_auth.protocol}",
                 f"capacity.config.file={self.workload.paths.capacity_jbod_json}",
                 "webserver.security.enable=true",
                 f"webserver.auth.credentials.file={self.workload.paths.cruise_control_auth}",
             ]
             + CRUISE_CONTROL_CONFIG_OPTIONS.split("\n")
             + self.goals
+            + self.cc_tls_properties
         )
-
-        if self.state.cluster.tls_enabled and self.state.unit_broker.certificate:
-            properties += self.cc_tls_properties
 
         if self.config.profile == PROFILE_TESTING:
             properties += CRUISE_CONTROL_TESTING_OPTIONS.split("\n")
@@ -938,7 +993,7 @@ class BalancerConfigManager(CommonConfigManager):
     def set_broker_capacities(self) -> None:
         """Writes all broker storage capacities to `capacityJBOD.json`."""
         self.workload.write(
-            content=json.dumps(self.state.peer_cluster.broker_capacities),
+            content=json.dumps(self.peer_cluster_state.broker_capacities),
             path=self.workload.paths.capacity_jbod_json,
         )
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -8,14 +8,23 @@ import logging
 import re
 import socket
 import subprocess
+from datetime import timedelta
 from typing import TypedDict  # nosec B404
 
+from charms.tls_certificates_interface.v4.tls_certificates import (
+    PrivateKey,
+    generate_ca,
+    generate_certificate,
+    generate_csr,
+    generate_private_key,
+)
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from ops.pebble import ExecError
 
 from core.cluster import ClusterState
+from core.models import TLSScope, TLSState
 from core.structured_config import CharmConfig
 from core.workload import WorkloadBase
 from literals import GROUP, USER_NAME, Substrates
@@ -29,6 +38,7 @@ class TLSManager:
     """Manager for building necessary files for Java TLS auth."""
 
     DEFAULT_HASH_ALGORITHM: hashes.HashAlgorithm = hashes.SHA256()
+    SCOPES = (TLSScope.PEER, TLSScope.CLIENT)
 
     def __init__(
         self,
@@ -44,113 +54,271 @@ class TLSManager:
 
         self.keytool = "charmed-kafka.keytool" if self.substrate == "vm" else "keytool"
 
-    def set_server_key(self) -> None:
-        """Sets the unit private-key."""
-        if not self.state.unit_broker.private_key:
-            logger.error("Can't set private-key to unit, missing private-key in relation data")
+    def get_state(self, scope: TLSScope) -> TLSState:
+        """Returns the TLSState object for the given scope."""
+        if scope == TLSScope.PEER:
+            return self.state.unit_broker.peer_tls
+        elif scope == TLSScope.CLIENT:
+            return self.state.unit_broker.client_tls
+
+        raise NotImplementedError(f"Unknown scope: {scope}")
+
+    def get_truststore_path(self, scope: TLSScope) -> str:
+        """Returns the truststore path for the given scope."""
+        if scope == TLSScope.PEER:
+            return self.workload.paths.peer_truststore
+        elif scope == TLSScope.CLIENT:
+            return self.workload.paths.truststore
+
+        raise NotImplementedError(f"Unknown scope: {scope}")
+
+    def get_keystore_path(self, scope: TLSScope) -> str:
+        """Returns the keystore path for the given scope."""
+        if scope == TLSScope.PEER:
+            return self.workload.paths.peer_keystore
+        elif scope == TLSScope.CLIENT:
+            return self.workload.paths.keystore
+
+        raise NotImplementedError(f"Unknown scope: {scope}")
+
+    def setup_internal_ca(self) -> None:
+        """Set up internal CA to issue self-signed certificates for internal communications.
+
+        Should only run on leader unit.
+        """
+        if not self.state.unit_broker.unit.is_leader():
             return
 
-        self.workload.write(
-            content=self.state.unit_broker.private_key,
-            path=f"{self.workload.paths.conf_path}/server.key",
+        ca_key = generate_private_key()
+        ca = generate_ca(
+            private_key=ca_key,
+            validity=timedelta(days=3650),
+            common_name=f"{self.state.unit_broker.unit.app.name}",
+            organization=TLSScope.PEER.value,
         )
+        self.state.internal_ca = ca.raw
+        self.state.internal_ca_key = ca_key.raw
+
+        # Leads to no-op in KRaft single mode.
+        self.state.peer_cluster_ca = ca.raw
+
+    def setup_internal_credentials(self) -> None:
+        """Generate self-signed certificate for the unit to be used for internal communications."""
+        state = self.get_state(TLSScope.PEER)
+
+        if not self.state.internal_ca:
+            logger.error("Internal CA is not set up yet.")
+            return
+
+        if state.ready:
+            logger.debug("No need to set up internal credentials...")
+            self.configure()
+            return
+
+        ca_key, ca = self.state.internal_ca_key, self.state.internal_ca
+        if ca is None or ca_key is None:
+            raise Exception("Internal CA is not setup yet.")
+
+        private_key = (
+            PrivateKey(state.private_key) if state.private_key else generate_private_key()
+        )
+
+        # Generate CSR & cert
+        sans = self.build_sans()
+        csr = generate_csr(
+            private_key=private_key,
+            common_name=f"{self.state.unit_broker.unit.name}",
+            sans_ip=frozenset(sans["sans_ip"]),
+            sans_dns=frozenset(sans["sans_dns"]),
+        )
+        certificate = generate_certificate(
+            csr=csr, ca=ca, ca_private_key=ca_key, validity=timedelta(days=3650)
+        )
+
+        # Update state
+        state.private_key = private_key.raw
+        state.certificate = certificate.raw
+        state.ca = ca.raw
+        state.csr = csr.raw
+
+        # Write configs
+        self.configure()
+
+    def set_server_key(self) -> None:
+        """Sets the unit private-key."""
+        for scope in self.SCOPES:
+            state = self.get_state(scope)
+
+            if not state.private_key:
+                logger.error("Can't set private-key to unit, missing private-key in relation data")
+                continue
+
+            self.workload.write(
+                content=state.private_key,
+                path=f"{self.workload.paths.conf_path}/{scope.value}-server.key",
+            )
 
     def set_ca(self) -> None:
         """Sets the unit ca."""
-        if not self.state.unit_broker.ca:
-            logger.error("Can't set CA to unit, missing CA in relation data")
-            return
+        for scope in self.SCOPES:
+            state = self.get_state(scope)
 
-        self.workload.write(
-            content=self.state.unit_broker.ca, path=f"{self.workload.paths.conf_path}/ca.pem"
-        )
+            if not state.ca:
+                logger.error("Can't set CA to unit, missing CA in relation data")
+                continue
+
+            self.workload.write(
+                content=state.ca, path=f"{self.workload.paths.conf_path}/{scope.value}-ca.pem"
+            )
 
     def set_certificate(self) -> None:
         """Sets the unit certificate."""
-        if not self.state.unit_broker.certificate:
-            logger.error("Can't set certificate to unit, missing certificate in relation data")
-            return
+        for scope in self.SCOPES:
+            state = self.get_state(scope)
 
-        self.workload.write(
-            content=self.state.unit_broker.certificate,
-            path=f"{self.workload.paths.conf_path}/server.pem",
-        )
+            if not state.certificate:
+                logger.error("Can't set certificate to unit, missing certificate in relation data")
+                continue
+
+            self.workload.write(
+                content=state.certificate,
+                path=f"{self.workload.paths.conf_path}/{scope.value}-server.pem",
+            )
 
     def set_bundle(self) -> None:
         """Sets the unit cert bundle."""
-        if not self.state.unit_broker.certificate or not self.state.unit_broker.ca:
-            logger.error(
-                "Can't set cert bundle to unit, missing certificate or CA in relation data"
-            )
-            return
+        for scope in self.SCOPES:
+            state = self.get_state(scope)
 
-        self.workload.write(
-            content="\n".join(self.state.unit_broker.bundle),
-            path=f"{self.workload.paths.conf_path}/bundle.pem",
-        )
+            if not state.certificate or not state.ca:
+                logger.error(
+                    "Can't set cert bundle to unit, missing certificate or CA in relation data"
+                )
+                continue
+
+            self.workload.write(
+                content="\n".join(state.bundle),
+                path=f"{self.workload.paths.conf_path}/{scope.value}-bundle.pem",
+            )
 
     def set_chain(self) -> None:
         """Sets the unit chain."""
-        if not self.state.unit_broker.bundle:
-            logger.error("Can't set chain to unit, missing chain in relation data")
-            return
+        for scope in self.SCOPES:
+            state = self.get_state(scope)
 
-        # setting each individual cert in the chain for trusting
-        for i, chain_cert in enumerate(self.state.unit_broker.bundle):
-            self.workload.write(
-                content=chain_cert, path=f"{self.workload.paths.conf_path}/bundle{i}.pem"
-            )
+            if not state.bundle:
+                logger.error("Can't set chain to unit, missing chain in relation data")
+                continue
+
+            # setting each individual cert in the chain for trusting
+            for i, chain_cert in enumerate(state.bundle):
+                self.workload.write(
+                    content=chain_cert,
+                    path=f"{self.workload.paths.conf_path}/{scope.value}-bundle{i}.pem",
+                )
 
     def set_truststore(self) -> None:
         """Adds CA to JKS truststore."""
-        trust_aliases = [f"bundle{i}" for i in range(len(self.state.unit_broker.bundle))]
-        for alias in trust_aliases:
-            command = f"{self.keytool} -import -v -alias {alias} -file {alias}.pem -keystore truststore.jks -storepass {self.state.unit_broker.truststore_password} -noprompt"
-            try:
+        for scope in self.SCOPES:
+            state = self.get_state(scope)
 
-                self.workload.exec(
-                    command=command.split(), working_dir=self.workload.paths.conf_path
-                )
-                self.workload.exec(
-                    f"chown {USER_NAME}:{GROUP} {self.workload.paths.truststore}".split()
-                )
-                self.workload.exec(f"chmod 770 {self.workload.paths.truststore}".split())
-            except (subprocess.CalledProcessError, ExecError) as e:
-                # in case this reruns and fails
-                if e.stdout and "already exists" in e.stdout:
-                    continue
-                logger.error(e.stdout)
-                raise e
+            trust_aliases = [f"bundle{i}" for i in range(len(state.bundle))]
+            for alias in trust_aliases:
+                command = [
+                    self.keytool,
+                    "-import",
+                    "-v",
+                    "-alias",
+                    alias,
+                    "-file",
+                    f"{scope.value}-{alias}.pem",
+                    "-keystore",
+                    f"{scope.value}-truststore.jks",
+                    "-storepass",
+                    f"{self.state.unit_broker.truststore_password}",
+                    "-noprompt",
+                ]
+                try:
+                    self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
+                    self.workload.exec(
+                        f"chown {USER_NAME}:{GROUP} {self.get_truststore_path(scope)}".split()
+                    )
+                    self.workload.exec(f"chmod 770 {self.get_truststore_path(scope)}".split())
+                except (subprocess.CalledProcessError, ExecError) as e:
+                    # in case this reruns and fails
+                    if e.stdout and "already exists" in e.stdout:
+                        continue
+                    logger.error(e.stdout)
+                    raise e
 
     def set_keystore(self) -> None:
         """Creates and adds unit cert and private-key to the keystore."""
-        if not (
-            all(
-                [
-                    self.state.unit_broker.private_key,
-                    self.state.unit_broker.certificate,
-                    self.state.unit_broker.ca,
-                ]
-            )
-        ):
-            logger.error("Can't set keystore, missing TLS artifacts.")
-            return
+        for scope in self.SCOPES:
+            state = self.get_state(scope)
 
-        command = f"openssl pkcs12 -export -in bundle.pem -inkey server.key -passin pass:{self.state.unit_broker.keystore_password} -certfile server.pem -out keystore.p12 -password pass:{self.state.unit_broker.keystore_password}"
+            if not all([state.private_key, state.certificate, state.ca]):
+                logger.error("Can't set keystore, missing TLS artifacts.")
+                continue
 
-        try:
-            self.workload.exec(command=command.split(), working_dir=self.workload.paths.conf_path)
-            self.workload.exec(f"chown {USER_NAME}:{GROUP} {self.workload.paths.keystore}".split())
-            self.workload.exec(f"chmod 770 {self.workload.paths.keystore}".split())
-        except (subprocess.CalledProcessError, ExecError) as e:
-            logger.error(e.stdout)
-            raise e
+            command = [
+                "openssl",
+                "pkcs12",
+                "-export",
+                "-in",
+                f"{scope.value}-bundle.pem",
+                "-inkey",
+                f"{scope.value}-server.key",
+                "-passin",
+                f"pass:{self.state.unit_broker.keystore_password}",
+                "-certfile",
+                f"{scope.value}-server.pem",
+                "-out",
+                f"{scope.value}-keystore.p12",
+                "-password",
+                f"pass:{self.state.unit_broker.keystore_password}",
+            ]
 
-    def import_cert(self, alias: str, filename: str) -> None:
+            try:
+                self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
+                self.workload.exec(
+                    f"chown {USER_NAME}:{GROUP} {self.get_keystore_path(scope)}".split()
+                )
+                self.workload.exec(f"chmod 770 {self.get_keystore_path(scope)}".split())
+            except (subprocess.CalledProcessError, ExecError) as e:
+                logger.error(e.stdout)
+                raise e
+
+    def configure(self) -> None:
+        """Write all TLS artifacts including certs, keys, and keystores/truststores to the disk."""
+        self.set_server_key()
+        self.set_ca()
+        self.set_chain()
+        self.set_certificate()
+        self.set_bundle()
+        self.set_truststore()
+        self.set_keystore()
+
+        if ca_cert := self.state.peer_cluster_ca:
+            self.update_cert(alias="peer-cluster-ca", cert=ca_cert, scope=TLSScope.PEER)
+
+    def import_cert(self, alias: str, filename: str, scope: TLSScope = TLSScope.CLIENT) -> None:
         """Add a certificate to the truststore."""
-        command = f"{self.keytool} -import -v -alias {alias} -file {filename} -keystore truststore.jks -storepass {self.state.unit_broker.truststore_password} -noprompt"
+        command = [
+            self.keytool,
+            "-import",
+            "-v",
+            "-alias",
+            alias,
+            "-file",
+            filename,
+            "-keystore",
+            f"{scope.value}-truststore.jks",
+            "-storepass",
+            f"{self.state.unit_broker.truststore_password}",
+            "-noprompt",
+        ]
         try:
-            self.workload.exec(command=command.split(), working_dir=self.workload.paths.conf_path)
+            self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
         except (subprocess.CalledProcessError, ExecError) as e:
             # in case this reruns and fails
             if e.stdout and "already exists" in e.stdout:
@@ -159,13 +327,25 @@ class TLSManager:
             logger.error(e.stdout)
             raise e
 
-    def remove_cert(self, alias: str) -> None:
+    def remove_cert(self, alias: str, scope: TLSScope = TLSScope.CLIENT) -> None:
         """Remove a cert from the truststore."""
         try:
-            command = f"{self.keytool} -delete -v -alias {alias} -keystore truststore.jks -storepass {self.state.unit_broker.truststore_password} -noprompt"
-            self.workload.exec(command=command.split(), working_dir=self.workload.paths.conf_path)
+            command = [
+                self.keytool,
+                "-delete",
+                "-v",
+                "-alias",
+                alias,
+                "-keystore",
+                f"{scope.value}-truststore.jks",
+                "-storepass",
+                f"{self.state.unit_broker.truststore_password}",
+                "-noprompt",
+            ]
+            self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
             self.workload.exec(
-                f"rm -f {alias}.pem".split(), working_dir=self.workload.paths.conf_path
+                f"rm -f {scope.value}-{alias}.pem".split(),
+                working_dir=self.workload.paths.conf_path,
             )
         except (subprocess.CalledProcessError, ExecError) as e:
             if e.stdout and "does not exist" in e.stdout:
@@ -174,13 +354,13 @@ class TLSManager:
             logger.error(e.stdout)
             raise e
 
-    def update_cert(self, alias: str, cert: str) -> None:
+    def update_cert(self, alias: str, cert: str, scope: TLSScope = TLSScope.CLIENT) -> None:
         """Update a certificate in the truststore."""
         # we should remove the previous cert first. If it doesn't exist, it will not raise an error.
-        self.remove_cert(alias=alias)
-        filename = f"{alias}.pem"
+        self.remove_cert(alias=alias, scope=scope)
+        filename = f"{scope.value}-{alias}.pem"
         self.workload.write(content=cert, path=f"{self.workload.paths.conf_path}/{filename}")
-        self.import_cert(alias=f"{alias}", filename=filename)
+        self.import_cert(alias=alias, filename=filename, scope=scope)
 
     def alias_needs_update(self, alias: str, cert: str) -> bool:
         """Checks whether an alias in the truststore requires update based on the provided certificate."""
@@ -227,12 +407,26 @@ class TLSManager:
                 ),
             }
 
-    def get_current_sans(self) -> Sans | None:
+    def get_current_sans(self, scope: TLSScope = TLSScope.CLIENT) -> Sans | None:
         """Gets the current SANs for the unit cert."""
-        if not self.state.unit_broker.certificate:
+        state = self.get_state(scope)
+        if (
+            not state.certificate
+            or not (
+                self.workload.root / self.workload.paths.conf_path / f"{scope.value}-server.pem"
+            ).exists()
+        ):
             return
 
-        command = ["openssl", "x509", "-noout", "-ext", "subjectAltName", "-in", "server.pem"]
+        command = [
+            "openssl",
+            "x509",
+            "-noout",
+            "-ext",
+            "subjectAltName",
+            "-in",
+            f"{scope.value}-server.pem",
+        ]
 
         try:
             sans_lines = self.workload.exec(
@@ -261,10 +455,13 @@ class TLSManager:
 
         return {"sans_ip": sorted(sans_ip), "sans_dns": sorted(sans_dns)}
 
-    def remove_stores(self) -> None:
+    def remove_stores(self, scope: TLSScope = TLSScope.CLIENT) -> None:
         """Cleans up all keys/certs/stores on a unit."""
         for pattern in ["*.pem", "*.key", "*.p12", "*.jks"]:
-            for path in (self.workload.root / self.workload.paths.conf_path).glob(pattern):
+            for path in (self.workload.root / self.workload.paths.conf_path).glob(
+                f"{scope.value}-{pattern}"
+            ):
+                logger.debug(f"Removing {path}")
                 path.unlink()
 
     def reload_truststore(self) -> None:
@@ -299,11 +496,42 @@ class TLSManager:
         if alias not in self.trusted_certificates:
             raise Exception(f"{alias=} can't be found in the truststore.")
 
-        cert = "\n".join(self.workload.read(f"{self.workload.paths.conf_path}/{alias}.pem"))
+        cert = "\n".join(
+            self.workload.read(
+                f"{self.workload.paths.conf_path}/{TLSScope.CLIENT.value}-{alias}.pem"
+            )
+        )
         if not cert:
             raise FileNotFoundError(f"Can't find the certificate for {alias=}")
 
         return self.certificate_distinguished_name(cert)
+
+    def get_trusted_certificates(self, truststore_path: str) -> dict[str, bytes]:
+        """Returns a mapping of alias to certificate fingerprint (hash) for all the certificates loaded in the given truststore."""
+        if not (self.workload.root / truststore_path).exists():
+            return {}
+
+        command = [
+            self.keytool,
+            "-list",
+            "-keystore",
+            truststore_path,
+            "-storepass",
+            self.state.unit_broker.truststore_password,
+            "-noprompt",
+        ]
+        raw = self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
+
+        # each record in the truststore has the following format:
+        #
+        # May DD, YYYY, trustedCertEntry,
+        # Certificate fingerprint (SHA-256): E5:2E:...:EB:F3
+        #
+        # SHA-256 is 32 bytes, so the hash would be 64 hex chars + 31 colons = 95 chars
+        return {
+            match[0]: self.keytool_hash_to_bytes(match[1])
+            for match in re.findall("(.+?),.+?trustedCertEntry.*?\n.+?([0-9a-fA-F:]{95})\n", raw)
+        }
 
     @staticmethod
     def is_valid_leaf_certificate(cert: str) -> bool:
@@ -348,22 +576,10 @@ class TLSManager:
 
     @property
     def trusted_certificates(self) -> dict[str, bytes]:
-        """Returns a mapping of alias to certificate fingerprint (hash) for all the certificates loaded in the truststore."""
-        if not (self.workload.root / self.workload.paths.truststore).exists():
-            return {}
+        """Returns a mapping of alias to certificate fingerprint (hash) for all the certificates loaded in the CLIENT truststore."""
+        return self.get_trusted_certificates(self.workload.paths.truststore)
 
-        command = f"{self.keytool} -list -keystore truststore.jks -storepass {self.state.unit_broker.truststore_password} -noprompt"
-        raw = self.workload.exec(
-            command=command.split(), working_dir=self.workload.paths.conf_path
-        )
-
-        # each record in the truststore has the following format:
-        #
-        # May DD, YYYY, trustedCertEntry,
-        # Certificate fingerprint (SHA-256): E5:2E:...:EB:F3
-        #
-        # SHA-256 is 32 bytes, so the hash would be 64 hex chars + 31 colons = 95 chars
-        return {
-            match[0]: self.keytool_hash_to_bytes(match[1])
-            for match in re.findall("(.+?),.+?trustedCertEntry.*?\n.+?([0-9a-fA-F:]{95})\n", raw)
-        }
+    @property
+    def peer_trusted_certificates(self) -> dict[str, bytes]:
+        """Returns a mapping of alias to certificate fingerprint (hash) for all the certificates loaded in the PEER truststore."""
+        return self.get_trusted_certificates(self.workload.paths.peer_truststore)

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -59,9 +59,9 @@ class TLSManager:
     def get_state(self, scope: TLSScope) -> TLSState:
         """Returns the TLSState object for the given scope."""
         if scope == TLSScope.PEER:
-            return self.state.unit_broker.peer_tls
+            return self.state.unit_broker.peer_certs
         elif scope == TLSScope.CLIENT:
-            return self.state.unit_broker.client_tls
+            return self.state.unit_broker.client_certs
 
         raise NotImplementedError(f"Unknown scope: {scope}")
 
@@ -311,7 +311,7 @@ class TLSManager:
                 continue
 
             alias = f"{self.PEER_CLUSTER_ALIAS}{i}"
-            state.rotation = True
+            state.rotate = True
 
             self.update_cert(alias=alias, cert=cert, scope=TLSScope.PEER)
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -35,7 +35,7 @@ Sans = TypedDict("Sans", {"sans_ip": list[str], "sans_dns": list[str]})
 
 
 class UnknownScopeError(Exception):
-    """Exception raised when TLS scope is undefined or not impelemented."""
+    """Exception raised when TLS scope is undefined or not implemented."""
 
 
 class TLSManager:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -295,7 +295,10 @@ class TLSManager:
                 raise e
 
     def update_peer_cluster_trust(self) -> None:
-        """..."""
+        """Updates peer truststore with current state of peer-cluster certificate chain.
+
+        This method will toggle the TLS rotation state variable if certificate change is detected in the peer-cluster relationship.
+        """
         bundle = self.state.peer_cluster_ca
         state = self.get_state(TLSScope.PEER)
 

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -46,11 +46,6 @@ from integration.helpers.jubilant import (
 )
 from literals import SECURITY_PROTOCOL_PORTS
 
-RESTART_DELAY = 60
-CLIENT_TIMEOUT = 30
-REELECTION_TIME = 25
-PRODUCING_MESSAGES = 10
-
 logger = logging.getLogger(__name__)
 
 BROKER_PORT = SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -44,7 +44,12 @@ from integration.helpers.jubilant import (
     kraft_quorum_status,
     produce_and_check_logs,
 )
-from literals import CONTROLLER_PORT, SECURITY_PROTOCOL_PORTS
+from literals import SECURITY_PROTOCOL_PORTS
+
+RESTART_DELAY = 60
+CLIENT_TIMEOUT = 30
+REELECTION_TIME = 25
+PRODUCING_MESSAGES = 10
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +243,8 @@ def test_freeze_broker_with_topic_leader(
         else 0
     )
     address = get_unit_ipv4_address(juju.model, f"{controller_app}/{controller_unit_num}")
-    bootstrap_controller = f"{address}:{CONTROLLER_PORT}"
+    controller_port = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].controller
+    bootstrap_controller = f"{address}:{controller_port}"
     controller_unit = f"{controller_app}/{controller_unit_num}"
 
     logger.info(

--- a/tests/integration/helpers/ha.py
+++ b/tests/integration/helpers/ha.py
@@ -57,7 +57,7 @@ def get_topic_description(juju: jubilant.Juju, topic: str) -> TopicDescription:
             continue
 
         bootstrap_servers.append(
-            f"{unit_ip}:{SECURITY_PROTOCOL_PORTS['SASL_PLAINTEXT', 'SCRAM-SHA-512'].client}"
+            f"{unit_ip}:{SECURITY_PROTOCOL_PORTS['SASL_SSL', 'SCRAM-SHA-512'].internal}"
         )
 
     output = ""
@@ -96,7 +96,7 @@ def get_topic_offsets(juju: jubilant.Juju, topic: str) -> list[str]:
             continue
 
         bootstrap_servers.append(
-            f"{unit_ip}:{SECURITY_PROTOCOL_PORTS['SASL_PLAINTEXT', 'SCRAM-SHA-512'].client}"
+            f"{unit_ip}:{SECURITY_PROTOCOL_PORTS['SASL_SSL', 'SCRAM-SHA-512'].internal}"
         )
 
     result = ""

--- a/tests/integration/helpers/ha.py
+++ b/tests/integration/helpers/ha.py
@@ -17,7 +17,7 @@ from integration.helpers.jubilant import KRaftUnitStatus, all_active_idle, kraft
 from integration.helpers.pytest_operator import check_socket, get_unit_ipv4_address
 from literals import KRAFT_NODE_ID_OFFSET, PATHS, SECURITY_PROTOCOL_PORTS
 
-CONTROLLER_PORT = 9097
+CONTROLLER_PORT = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].controller
 PROCESS = "kafka.Kafka"
 SERVICE_DEFAULT_PATH = "/etc/systemd/system/snap.charmed-kafka.daemon.service"
 RESTART_DELAY = 60

--- a/tests/integration/test_balancer.py
+++ b/tests/integration/test_balancer.py
@@ -22,10 +22,11 @@ from integration.helpers.pytest_operator import (
     get_replica_count_by_broker_id,
 )
 from literals import (
+    INTERNAL_TLS_RELATION,
     PEER_CLUSTER_ORCHESTRATOR_RELATION,
     PEER_CLUSTER_RELATION,
-    TLS_RELATION,
 )
+
 
 logger = logging.getLogger(__name__)
 
@@ -315,10 +316,12 @@ class TestBalancer:
         await ops_test.model.wait_for_idle(apps=[TLS_NAME], idle_period=15)
         assert ops_test.model.applications[TLS_NAME].status == "active"
 
-        await ops_test.model.add_relation(TLS_NAME, f"{APP_NAME}:{TLS_RELATION}")
+        await ops_test.model.add_relation(TLS_NAME, f"{APP_NAME}:{INTERNAL_TLS_RELATION}")
 
         if self.balancer_app != APP_NAME:
-            await ops_test.model.add_relation(TLS_NAME, f"{self.balancer_app}:{TLS_RELATION}")
+            await ops_test.model.add_relation(
+                TLS_NAME, f"{self.balancer_app}:{INTERNAL_TLS_RELATION}"
+            )
 
         await ops_test.model.wait_for_idle(
             apps=list({APP_NAME, CONTROLLER_NAME, self.balancer_app}),

--- a/tests/integration/test_balancer.py
+++ b/tests/integration/test_balancer.py
@@ -27,7 +27,6 @@ from literals import (
     PEER_CLUSTER_RELATION,
 )
 
-
 logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.balancer

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -99,7 +99,7 @@ async def test_remove_controller_relation_relate(ops_test: OpsTest, kraft_mode, 
 async def test_listeners(ops_test: OpsTest, app_charm, kafka_apps):
     address = await get_address(ops_test=ops_test)
     assert check_socket(
-        address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].internal
+        address, SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].internal
     )  # Internal listener
 
     # Client listener should not be enabled if there is no relations

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -18,11 +18,20 @@ from integration.helpers.pytest_operator import (
     kraft_quorum_status,
 )
 from literals import (
-    CONTROLLER_PORT,
     KRAFT_NODE_ID_OFFSET,
     PEER_CLUSTER_ORCHESTRATOR_RELATION,
     PEER_CLUSTER_RELATION,
     SECURITY_PROTOCOL_PORTS,
+<<<<<<< HEAD
+=======
+    AuthMap,
+)
+
+from .helpers import (
+    APP_NAME,
+    SERIES,
+    KRaftMode,
+>>>>>>> 0eea264 ([DPE-7526] feat: use multiple TLS interfaces for internal/external)
     KRaftUnitStatus,
 )
 
@@ -47,16 +56,15 @@ class TestKRaft:
     async def _assert_listeners_accessible(
         self, ops_test: OpsTest, broker_unit_num=0, controller_unit_num=0
     ):
+        auth_map = AuthMap("SASL_SSL", "SCRAM-SHA-512")
         logger.info(f"Asserting broker listeners are up: {APP_NAME}/{broker_unit_num}")
         address = await get_address(ops_test=ops_test, app_name=APP_NAME, unit_num=broker_unit_num)
         assert check_socket(
-            address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].internal
+            address, SECURITY_PROTOCOL_PORTS[auth_map].internal
         )  # Internal listener
 
         # Client listener should not be enabled if there is no relations
-        assert not check_socket(
-            address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
-        )
+        assert not check_socket(address, SECURITY_PROTOCOL_PORTS[auth_map].client)
 
         logger.info(
             f"Asserting controller listeners are up: {self.controller_app}/{controller_unit_num}"
@@ -67,7 +75,7 @@ class TestKRaft:
                 ops_test=ops_test, app_name=self.controller_app, unit_num=controller_unit_num
             )
 
-        assert check_socket(address, CONTROLLER_PORT)
+        assert check_socket(address, SECURITY_PROTOCOL_PORTS[auth_map].controller)
 
     @pytest.mark.abort_on_fail
     @pytest.mark.skip_if_deployed
@@ -150,7 +158,7 @@ class TestKRaft:
     async def test_authorizer(self, ops_test: OpsTest):
 
         address = await get_address(ops_test=ops_test)
-        port = SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].internal
+        port = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].internal
 
         await create_test_topic(ops_test, f"{address}:{port}")
 
@@ -171,7 +179,8 @@ class TestKRaft:
         )
 
         address = await get_address(ops_test=ops_test, app_name=self.controller_app)
-        bootstrap_controller = f"{address}:{CONTROLLER_PORT}"
+        controller_port = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].controller
+        bootstrap_controller = f"{address}:{controller_port}"
 
         unit_status = kraft_quorum_status(
             ops_test, f"{self.controller_app}/0", bootstrap_controller
@@ -210,7 +219,8 @@ class TestKRaft:
             )
 
         address = await get_address(ops_test=ops_test, app_name=self.controller_app, unit_num=1)
-        bootstrap_controller = f"{address}:{CONTROLLER_PORT}"
+        controller_port = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].controller
+        bootstrap_controller = f"{address}:{controller_port}"
         offset = KRAFT_NODE_ID_OFFSET if self.controller_app == APP_NAME else 0
 
         unit_status = kraft_quorum_status(
@@ -259,7 +269,8 @@ class TestKRaft:
             )
 
         address = await get_address(ops_test=ops_test, app_name=self.controller_app, unit_num=3)
-        bootstrap_controller = f"{address}:{CONTROLLER_PORT}"
+        controller_port = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].controller
+        bootstrap_controller = f"{address}:{controller_port}"
         offset = KRAFT_NODE_ID_OFFSET if self.deployment_strat == "single" else 0
 
         unit_status = kraft_quorum_status(

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -12,13 +12,12 @@ from integration.helpers.pytest_operator import (
     SERIES,
     check_user,
     deploy_cluster,
-    get_address,
     get_client_usernames,
     get_provider_data,
     load_acls,
     load_super_users,
 )
-from literals import CONTROLLER_USER, INTERNAL_USERS, SECURITY_PROTOCOL_PORTS
+from literals import CONTROLLER_USER, INTERNAL_USERS
 
 logger = logging.getLogger(__name__)
 
@@ -74,13 +73,7 @@ async def test_deploy_charms_relate_active(
             model_full_name=ops_test.model_full_name,
         )
 
-    address = await get_address(ops_test)
-    port = SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
-    bootstrap_server = f"{address}:{port}"
-
-    for acl in load_acls(
-        model_full_name=ops_test.model_full_name, bootstrap_server=bootstrap_server
-    ):
+    for acl in load_acls(model_full_name=ops_test.model_full_name):
         assert acl.username in usernames
         assert acl.operation in ["READ", "DESCRIBE"]
         assert acl.resource_type in ["GROUP", "TOPIC"]
@@ -110,13 +103,7 @@ async def test_deploy_multiple_charms_same_topic_relate_active(
             model_full_name=ops_test.model_full_name,
         )
 
-    address = await get_address(ops_test)
-    port = SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
-    bootstrap_server = f"{address}:{port}"
-
-    for acl in load_acls(
-        model_full_name=ops_test.model_full_name, bootstrap_server=bootstrap_server
-    ):
+    for acl in load_acls(model_full_name=ops_test.model_full_name):
         assert acl.username in usernames
         assert acl.operation in ["READ", "DESCRIBE"]
         assert acl.resource_type in ["GROUP", "TOPIC"]
@@ -135,11 +122,7 @@ async def test_remove_application_removes_user_and_acls(
         await ops_test.model.wait_for_idle(apps=kafka_apps, idle_period=60, status="active")
 
     # checks that old users are removed from active cluster ACLs
-    address = await get_address(ops_test)
-    port = SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
-    bootstrap_server = f"{address}:{port}"
-
-    acls = load_acls(model_full_name=ops_test.model_full_name, bootstrap_server=bootstrap_server)
+    acls = load_acls(model_full_name=ops_test.model_full_name)
     acl_usernames = set()
     for acl in acls:
         acl_usernames.add(acl.username)
@@ -170,11 +153,7 @@ async def test_deploy_producer_same_topic(
             apps=[*kafka_apps, DUMMY_NAME_1], idle_period=60, status="active"
         )
 
-    address = await get_address(ops_test)
-    port = SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
-    bootstrap_server = f"{address}:{port}"
-
-    acls = load_acls(model_full_name=ops_test.model_full_name, bootstrap_server=bootstrap_server)
+    acls = load_acls(model_full_name=ops_test.model_full_name)
     acl_usernames = set()
     for acl in acls:
         acl_usernames.add(acl.username)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -10,7 +10,7 @@ import tempfile
 
 import kafka
 import pytest
-from charms.tls_certificates_interface.v3.tls_certificates import generate_private_key
+from charms.tls_certificates_interface.v4.tls_certificates import generate_private_key
 from pytest_operator.plugin import OpsTest
 
 from integration.helpers.pytest_operator import (
@@ -117,7 +117,7 @@ async def test_kafka_tls(ops_test: OpsTest, app_charm, kafka_apps):
     )
 
     # Rotate credentials
-    new_private_key = generate_private_key().decode("utf-8")
+    new_private_key = generate_private_key().raw
 
     await set_tls_private_key(ops_test, key=new_private_key)
 
@@ -132,7 +132,7 @@ async def test_kafka_tls(ops_test: OpsTest, app_charm, kafka_apps):
     )
 
     assert private_key != private_key_2
-    assert private_key_2 == new_private_key
+    assert private_key_2 == new_private_key.strip()
 
 
 @pytest.mark.abort_on_fail
@@ -206,7 +206,7 @@ async def test_certificate_transfer(ops_test: OpsTest, kafka_apps):
         "cert": search_secrets(ops_test=ops_test, owner=requirer, search_key="certificate"),
         "ca_cert": search_secrets(ops_test=ops_test, owner=requirer, search_key="ca-certificate"),
         "broker_ca": search_secrets(
-            ops_test=ops_test, owner=f"{APP_NAME}/0", search_key="ca-cert"
+            ops_test=ops_test, owner=f"{APP_NAME}/0", search_key="client-ca-cert"
         ),
     }
 
@@ -223,7 +223,7 @@ async def test_certificate_transfer(ops_test: OpsTest, kafka_apps):
     address = await get_address(ops_test, app_name=APP_NAME, unit_num=0)
     ssl_port = SECURITY_PROTOCOL_PORTS["SSL", "SSL"].client
     ssl_bootstrap_server = f"{address}:{ssl_port}"
-    sasl_port = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].client
+    sasl_port = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].internal
     sasl_bootstrap_server = f"{address}:{sasl_port}"
 
     # create `test` topic and set ACLs
@@ -318,9 +318,16 @@ async def test_tls_removed(ops_test: OpsTest, kafka_apps):
             "ssh", unit.name, "sudo ls /var/snap/charmed-kafka/current/etc/kafka"
         )
         assert not ret
-        file_extensions = {f.split(".")[-1] for f in stdout.split() if f}
-        logging.info(f"{', '.join(file_extensions)} files found on {unit.name}")
+        file_extensions = {
+            f.split(".")[-1] for f in stdout.split() if f and f.startswith("client-")
+        }
+        logging.info(f"CLIENT TLS: {', '.join(file_extensions)} files found on {unit.name}")
         assert not {"pem", "key", "p12", "jks"} & file_extensions
+
+        # peer TLS artifacts should remain intact.
+        file_extensions = {f.split(".")[-1] for f in stdout.split() if f and f.startswith("peer-")}
+        logging.info(f"PEER TLS: {', '.join(file_extensions)} files found on {unit.name}")
+        assert {"pem", "key", "p12", "jks"} & file_extensions
 
 
 @pytest.mark.abort_on_fail

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -34,9 +34,12 @@ def zk_data() -> dict[str, str]:
 
 @pytest.fixture(scope="module")
 def kraft_data() -> dict[str, str]:
+    tls_data = generate_tls_artifacts(sans_ip=["10.10.10.11"])
     return {
         "bootstrap-controller": "10.10.10.10:9097",
         "cluster-uuid": "random-uuid",
+        "internal-ca": tls_data.ca,
+        "internal-ca-key": tls_data.signing_key,
     }
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -81,6 +81,13 @@ def patched_trust(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture(autouse=True)
+def patched_get_users():
+    # patch AuthManager.get_users here, we have unit tests in test_auth
+    with patch("managers.auth.AuthManager.get_users", return_value=["admin"]):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def random_uuid():
     with patch("managers.controller.ControllerManager.generate_uuid") as gen_uuid:
         gen_uuid.return_value = "some-random-uuid"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -74,6 +74,13 @@ def patched_workload(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture(autouse=True)
+def patched_trust(monkeypatch: pytest.MonkeyPatch):
+    # patch peer_trusted_certificates here,
+    # we have comprehensive unit tests in test_tls_manager
+    monkeypatch.setattr("managers.tls.TLSManager.peer_trusted_certificates", {})
+
+
+@pytest.fixture(autouse=True)
 def random_uuid():
     with patch("managers.controller.ControllerManager.generate_uuid") as gen_uuid:
         gen_uuid.return_value = "some-random-uuid"

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -70,3 +70,11 @@ def test_generate_consumer_acls():
 
     assert sorted(operations) == sorted({"READ", "DESCRIBE"})
     assert sorted(resource_types) == sorted({"TOPIC", "GROUP"})
+
+
+def test_get_users():
+    stub = """
+        SCRAM credential configs for user-principal 'admin' are SCRAM-SHA-512=iterations=4096
+        SCRAM credential configs for user-principal 'relation-8' are SCRAM-SHA-512=iterations=4096
+    """
+    assert AuthManager._parse_describe_users(stub) == ["admin", "relation-8"]

--- a/tests/unit/test_balancer.py
+++ b/tests/unit/test_balancer.py
@@ -263,6 +263,11 @@ def test_ready_to_start_ok(
             new_callable=PropertyMock,
             return_value=[],
         ),
+        patch(
+            "managers.tls.TLSManager.build_sans",
+            return_value={"sans_ip": ["10.10.10.10"], "sans_dns": ["dns"]},
+        ),
+        patch("managers.tls.TLSManager.configure"),
         patch("health.KafkaHealth.machine_configured", return_value=True),
         patch("charms.operator_libs_linux.v2.snap.SnapCache"),  # specific VM, works fine on k8s
     ):

--- a/tests/unit/test_balancer.py
+++ b/tests/unit/test_balancer.py
@@ -14,6 +14,7 @@ import pytest
 import yaml
 from ops import ActiveStatus
 from ops.testing import ActionFailed, Container, Context, PeerRelation, State
+from tests.unit.helpers import generate_tls_artifacts
 
 from charm import KafkaCharm
 from literals import (
@@ -202,6 +203,7 @@ def test_ready_to_start_ok(
 ) -> None:
     # Given
     ctx = ctx_broker_and_balancer
+    tls_data = generate_tls_artifacts()
     cluster_peer = PeerRelation(
         PEER,
         local_app_data=passwords_data | kraft_data | {"controller-password": "password"},
@@ -219,6 +221,8 @@ def test_ready_to_start_ok(
             "storages": json.dumps(
                 {f"/var/snap/charmed-kafka/common/var/lib/kafka/data/{0}": "10240"}
             ),
+            "peer-certificate": tls_data.certificate,
+            "peer-ca-cert": tls_data.ca,
         },
     )
     restart_peer = PeerRelation("restart", "restart")
@@ -242,6 +246,9 @@ def test_ready_to_start_ok(
             new_callable=PropertyMock,
             return_value={"brokerCapacities": [{}, {}, {}]},
         ),
+        # The json.loads patch above leads to corrupt data for TLSState.chain
+        # which also relies on json.loads
+        patch("core.models.TLSState.chain", new_callable=PropertyMock, return_value=[]),
         patch("workload.KafkaWorkload.read"),
         patch("workload.BalancerWorkload.exec"),
         patch("workload.BalancerWorkload.restart"),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,6 +20,7 @@ from literals import (
     PEER,
     REL_NAME,
     SUBSTRATE,
+    TLS_RELATION,
     Status,
 )
 
@@ -155,7 +156,7 @@ def test_ready_to_start_waits_no_broker_data(
     state_out = ctx.run(ctx.on.start(), state_in)
 
     # Then
-    assert state_out.unit_status == Status.NO_BROKER_DATA.value.status
+    assert state_out.unit_status == Status.NO_PEER_CLUSTER_CA.value.status
 
 
 def test_ready_to_start_succeeds(
@@ -333,7 +334,7 @@ def test_start_does_not_start_if_leader_has_not_set_creds(ctx: Context, base_sta
 
     # Then
     patched_start_snap_service.assert_not_called()
-    assert state_out.unit_status == Status.NO_BOOTSTRAP_CONTROLLER.value.status
+    assert state_out.unit_status == Status.NO_INTERNAL_TLS.value.status
 
 
 def test_update_status_blocks_if_broker_not_active(
@@ -532,15 +533,16 @@ def test_config_changed_updates_server_properties(ctx: Context, base_state: Stat
 
 
 def test_config_changed_requests_new_certificate(
-    ctx: Context, base_state: State, zk_data: dict[str, str]
+    ctx: Context, base_state: State, kraft_data: dict[str, str], passwords_data: dict[str, str]
 ) -> None:
     """Checks that if there is a diff in SANs, that a new certificate is requested."""
     # Given
-    cluster_peer = PeerRelation(PEER, PEER)
+    cluster_peer = PeerRelation(PEER, PEER, local_app_data=kraft_data | passwords_data)
     restart_peer = PeerRelation("restart", "rolling_op")
+    client_tls_rel = Relation(TLS_RELATION, "tls-certificates")
     state_in = dataclasses.replace(
         base_state,
-        relations=[cluster_peer, restart_peer],
+        relations=[cluster_peer, restart_peer, client_tls_rel],
     )
 
     # When
@@ -554,35 +556,39 @@ def test_config_changed_requests_new_certificate(
         patch("events.upgrade.KafkaUpgrade.idle", return_value=True),
         patch("workload.KafkaWorkload.read", return_value=["gandalf=grey"]),
         patch("managers.config.ConfigManager.set_client_properties"),
-        patch("events.tls.TLSHandler._request_certificate_renewal") as request_certificate_renewal,
         patch(
             "managers.tls.TLSManager.get_current_sans",
-            return_value={"sans_ip": ["earendil"], "sans_dns": ["denethor"]},
+            return_value={"sans_ip": ["10.10.10.11"], "sans_dns": ["denethor"]},
         ),
         patch(
             "managers.tls.TLSManager.build_sans",
-            return_value={"sans_ip": ["earendil"], "sans_dns": ["aragorn"]},
+            return_value={"sans_ip": ["10.10.10.11"], "sans_dns": ["aragorn"]},
         ),
         patch(
             "charms.rolling_ops.v0.rollingops.RollingOpsManager._on_run_with_lock", autospec=True
         ),
     ):
-        ctx.run(ctx.on.config_changed(), state_in)
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
 
     # Then
-    assert request_certificate_renewal.call_count
+    # A new CSR should have been created and saved in unit databag, since TLS requirer mode is UNIT
+    assert (
+        "certificate_signing_requests" in state_out.get_relation(client_tls_rel.id).local_unit_data
+    )
 
 
+# @pytest.mark.skip
 def test_config_changed_does_not_request_new_certificate_for_slashes(
-    ctx: Context, base_state: State, zk_data: dict[str, str]
+    ctx: Context, base_state: State, kraft_data: dict[str, str], passwords_data: dict[str, str]
 ) -> None:
     """Checks that if there is a diff in SANs, that a new certificate is not requested if the SAN was the unit|app name."""
     # Given
-    cluster_peer = PeerRelation(PEER, PEER)
+    cluster_peer = PeerRelation(PEER, PEER, local_app_data=kraft_data | passwords_data)
     restart_peer = PeerRelation("restart", "rolling_op")
+    client_tls_rel = Relation(TLS_RELATION, "tls-certificates")
     state_in = dataclasses.replace(
         base_state,
-        relations=[cluster_peer, restart_peer],
+        relations=[cluster_peer, restart_peer, client_tls_rel],
     )
 
     # When
@@ -596,23 +602,26 @@ def test_config_changed_does_not_request_new_certificate_for_slashes(
         patch("events.upgrade.KafkaUpgrade.idle", return_value=True),
         patch("workload.KafkaWorkload.read", return_value=["gandalf=grey"]),
         patch("managers.config.ConfigManager.set_client_properties"),
-        patch("events.tls.TLSHandler._request_certificate_renewal") as request_certificate_renewal,
         patch(
             "managers.tls.TLSManager.get_current_sans",
-            return_value={"sans_ip": ["earendil"], "sans_dns": [CHARM_KEY]},
+            return_value={"sans_ip": ["10.10.10.11"], "sans_dns": [CHARM_KEY]},
         ),
         patch(
             "managers.tls.TLSManager.build_sans",
-            return_value={"sans_ip": ["earendil"], "sans_dns": [f"{CHARM_KEY}/0"]},
+            return_value={"sans_ip": ["10.10.10.11"], "sans_dns": [f"{CHARM_KEY}/0"]},
         ),
         patch(
             "charms.rolling_ops.v0.rollingops.RollingOpsManager._on_run_with_lock", autospec=True
         ),
     ):
-        ctx.run(ctx.on.config_changed(), state_in)
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
 
     # Then
-    assert not request_certificate_renewal.call_count
+    # No CSR is expected here
+    assert (
+        "certificate_signing_requests"
+        not in state_out.get_relation(client_tls_rel.id).local_unit_data
+    )
 
 
 def test_config_changed_updates_client_properties(ctx: Context, base_state: State) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -655,7 +655,7 @@ def test_config_changed_updates_client_properties(ctx: Context, base_state: Stat
         ctx.run(ctx.on.config_changed(), state_in)
 
     # Then
-    set_client_properties.assert_called_once()
+    set_client_properties.assert_called()
 
 
 def test_config_changed_updates_client_data(ctx: Context, base_state: State) -> None:
@@ -687,8 +687,8 @@ def test_config_changed_updates_client_data(ctx: Context, base_state: State) -> 
         ctx.run(ctx.on.config_changed(), state_in)
 
     # Then
-    patched_set_client_properties.assert_called_once()
-    patched_update_client_data.assert_called_once()
+    patched_set_client_properties.assert_called()
+    patched_update_client_data.assert_called()
 
 
 def test_config_changed_restarts(ctx: Context, base_state: State) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -139,13 +139,14 @@ def test_listeners_in_server_properties(charm_configuration: dict, base_state: S
 
     host = "treebeard" if SUBSTRATE == "vm" else "kafka-k8s-0.kafka-k8s-endpoints"
     sasl_pm = "SASL_PLAINTEXT_SCRAM_SHA_512"
+    ssl_pm = "SASL_SSL_SCRAM_SHA_512"
 
     expected_listeners = [
-        f"INTERNAL_{sasl_pm}://0.0.0.0:19092",
+        f"INTERNAL_{ssl_pm}://0.0.0.0:19093",
         f"CLIENT_{sasl_pm}://0.0.0.0:9092",
     ]
     expected_advertised_listeners = [
-        f"INTERNAL_{sasl_pm}://{host}:19092",
+        f"INTERNAL_{ssl_pm}://{host}:19093",
         f"CLIENT_{sasl_pm}://{host}:9092",
     ]
     if SUBSTRATE == "k8s":
@@ -205,7 +206,7 @@ def test_extra_listeners_in_server_properties(charm_configuration: dict, base_st
         KafkaCharm, meta=METADATA, config=charm_configuration, actions=ACTIONS, unit_id=0
     )
     expected_listener_names = {
-        "INTERNAL_SASL_PLAINTEXT_SCRAM_SHA_512",
+        "INTERNAL_SASL_SSL_SCRAM_SHA_512",
         "CLIENT_SASL_PLAINTEXT_SCRAM_SHA_512",
         "CLIENT_SSL_SSL",
         "EXTRA_SASL_PLAINTEXT_SCRAM_SHA_512_0",
@@ -309,7 +310,7 @@ def test_oauth_client_listeners_in_server_properties(ctx: Context, base_state: S
     )
 
     host = "treebeard" if SUBSTRATE == "vm" else "kafka-k8s-0.kafka-k8s-endpoints"
-    internal_protocol, internal_port = "INTERNAL_SASL_PLAINTEXT_SCRAM_SHA_512", "19092"
+    internal_protocol, internal_port = "INTERNAL_SASL_SSL_SCRAM_SHA_512", "19093"
     scram_client_protocol, scram_client_port = "CLIENT_SASL_PLAINTEXT_SCRAM_SHA_512", "9092"
     oauth_client_protocol, oauth_client_port = "CLIENT_SASL_PLAINTEXT_OAUTHBEARER", "9095"
 
@@ -340,7 +341,7 @@ def test_ssl_listeners_in_server_properties(ctx: Context, base_state: State, pat
     cluster_peer = PeerRelation(
         PEER,
         PEER,
-        local_unit_data={"private-address": "treebeard", "certificate": "keepitsecret"},
+        local_unit_data={"private-address": "treebeard", "client-certificate": "keepitsecret"},
         local_app_data={"tls": "enabled", "mtls": "enabled"},
     )
     # Simulate data-integrator relation

--- a/tests/unit/test_kraft.py
+++ b/tests/unit/test_kraft.py
@@ -89,7 +89,9 @@ def test_ready_to_start_no_peer_cluster(charm_configuration, base_state: State):
     assert state_out.unit_status == Status.NO_PEER_CLUSTER_RELATION.value.status
 
 
-def test_ready_to_start_missing_data_as_controller(charm_configuration, base_state: State):
+def test_ready_to_start_missing_peer_tls_data_as_controller(
+    charm_configuration, base_state: State
+):
     # Given
     charm_configuration["options"]["roles"]["default"] = "controller"
     ctx = Context(
@@ -100,6 +102,29 @@ def test_ready_to_start_missing_data_as_controller(charm_configuration, base_sta
     )
     cluster_peer = PeerRelation(PEER, PEER)
     peer_cluster = Relation(PEER_CLUSTER_RELATION, "peer_cluster")
+    state_in = dataclasses.replace(base_state, relations=[cluster_peer, peer_cluster])
+
+    # When
+    with patch("workload.KafkaWorkload.run_bin_command", return_value="cluster-uuid-number"):
+        state_out = ctx.run(ctx.on.start(), state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_PEER_CLUSTER_CA.value.status
+
+
+def test_ready_to_start_missing_broker_data_as_controller(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    peer_cluster = Relation(
+        PEER_CLUSTER_RELATION, "peer_cluster", remote_app_data={"broker-ca": "broker-ca"}
+    )
     state_in = dataclasses.replace(base_state, relations=[cluster_peer, peer_cluster])
 
     # When
@@ -155,14 +180,19 @@ def test_ready_to_start(charm_configuration, base_state: State):
     ):
         state_out = ctx.run(ctx.on.start(), state_in)
 
+    secret_contents = [k for secret in state_out.secrets for k in secret.latest_content]
+
     # Then
     assert "cluster-uuid" in state_out.get_relations(PEER)[0].local_app_data
     assert "bootstrap-controller" in state_out.get_relations(PEER)[0].local_app_data
     assert "bootstrap-unit-id" in state_out.get_relations(PEER)[0].local_app_data
     assert "bootstrap-replica-id" in state_out.get_relations(PEER)[0].local_app_data
     # Only the internal users should be created.
-    assert "admin-password" in next(iter(state_out.secrets)).latest_content
-    assert "sync-password" in next(iter(state_out.secrets)).latest_content
+    assert "admin-password" in secret_contents
+    assert "sync-password" in secret_contents
+    assert "controller-password" in secret_contents
+    assert "internal-ca" in secret_contents
+    assert "internal-ca-key" in secret_contents
     assert state_out.unit_status == ActiveStatus()
 
 

--- a/tests/unit/test_kraft.py
+++ b/tests/unit/test_kraft.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 from ops import ActiveStatus
 from ops.testing import Container, Context, PeerRelation, Relation, State
+from tests.unit.helpers import generate_tls_artifacts
 
 from charm import KafkaCharm
 from literals import (
@@ -122,8 +123,11 @@ def test_ready_to_start_missing_broker_data_as_controller(charm_configuration, b
         actions=ACTIONS,
     )
     cluster_peer = PeerRelation(PEER, PEER)
+    tls_data = generate_tls_artifacts()
     peer_cluster = Relation(
-        PEER_CLUSTER_RELATION, "peer_cluster", remote_app_data={"broker-ca": "broker-ca"}
+        PEER_CLUSTER_RELATION,
+        "peer_cluster",
+        remote_app_data={"broker-ca": json.dumps([tls_data.ca])},
     )
     state_in = dataclasses.replace(base_state, relations=[cluster_peer, peer_cluster])
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -101,8 +101,10 @@ def test_client_relation_created_adds_user(ctx: Context, base_state: State) -> N
         state_out = ctx.run(ctx.on.relation_changed(client_relation), state_in)
 
     # Then
+    secret_contents = [k for secret in state_out.secrets for k in secret.latest_content]
+
     patched_add_user.assert_called_once()
-    assert f"relation-{client_relation.id}" in next(iter(state_out.secrets)).tracked_content
+    assert f"relation-{client_relation.id}" in secret_contents
 
 
 def test_client_relation_broken_removes_user(ctx: Context, base_state: State) -> None:
@@ -144,7 +146,8 @@ def test_client_relation_broken_removes_user(ctx: Context, base_state: State) ->
     patched_remove_acls.assert_called_once()
     patched_delete_user.assert_called_once()
     # validating username got removed, by removing the full secret
-    assert not state_out.secrets
+    secret_contents = [k for secret in state_out.secrets for k in secret.latest_content]
+    assert f"relation-{client_relation.id}" not in secret_contents
 
 
 def test_client_relation_joined_sets_necessary_relation_data(
@@ -232,7 +235,13 @@ def test_mtls_without_tls_relation(
 
 
 @pytest.mark.parametrize("tls_artifacts", [False, True], indirect=True)
-def test_mtls_setup(ctx: Context, base_state: State, tls_artifacts: TLSArtifacts) -> None:
+def test_mtls_setup(
+    ctx: Context,
+    base_state: State,
+    tls_artifacts: TLSArtifacts,
+    kraft_data: dict[str, str],
+    passwords_data: dict[str, str],
+) -> None:
     # Given
     restart_relation = PeerRelation("restart", "rolling_op")
     client_rel_id = 21
@@ -254,8 +263,10 @@ def test_mtls_setup(ctx: Context, base_state: State, tls_artifacts: TLSArtifacts
     cluster_peer = PeerRelation(
         PEER,
         PEER,
-        local_app_data={f"relation-{client_relation.id}": "password", "tls": "enabled"},
-        local_unit_data={"certificate": "cert", "ca-cert": "ca"},
+        local_app_data={f"relation-{client_relation.id}": "password", "tls": "enabled"}
+        | kraft_data
+        | passwords_data,
+        local_unit_data={"client-certificate": "cert", "client-ca-cert": "ca"},
     )
     state_in = dataclasses.replace(
         base_state,

--- a/tests/unit/test_tls_manager.py
+++ b/tests/unit/test_tls_manager.py
@@ -99,8 +99,9 @@ def java_jks_test(truststore_path: str, truststore_password: str, ssl_server_por
 
 
 @pytest.fixture()
-def tls_manager(tmp_path_factory):
+def tls_manager(tmp_path_factory, monkeypatch):
     """A TLSManager instance with minimal functioning mock `Workload` and `State`."""
+    monkeypatch.undo()
     mock_workload = MagicMock(spec=WorkloadBase)
     mock_workload.write = lambda content, path: open(path, "w").write(content)
     mock_workload.exec = _exec
@@ -293,7 +294,7 @@ def test_tls_manager_truststore_functionality(
     tls_manager.remove_cert("other-app")
     log_record = caplog.records[-1]
     assert "alias <other-app> does not exist" in log_record.msg.lower()
-    assert log_record.levelname == "WARNING"
+    assert log_record.levelname == "DEBUG"
 
 
 @pytest.mark.skipif(
@@ -347,3 +348,32 @@ def test_simulate_os_errors(tls_manager: TLSManager):
 
     with pytest.raises(subprocess.CalledProcessError):
         tls_manager.remove_cert("some-alias")
+
+
+def test_peer_cluster_trust(tls_manager: TLSManager):
+    _set_manager_state(tls_manager)
+    tls_manager.state.roles = "broker"
+    tls_data = generate_tls_artifacts(subject="controller/0")
+
+    tls_manager.state.peer_cluster_ca = [tls_data.ca]
+    tls_manager.update_peer_cluster_trust()
+
+    trusted_certs = tls_manager.peer_trusted_certificates
+    assert f"{tls_manager.PEER_CLUSTER_ALIAS}0" in trusted_certs
+    assert len(trusted_certs) == 1
+    fingerprint = next(iter(trusted_certs.values()))
+
+    # expect no-op here
+    tls_manager.update_peer_cluster_trust()
+    assert len(tls_manager.peer_trusted_certificates) == 1
+
+    # Now let's rotate
+    new_tls_data = generate_tls_artifacts(subject="controller/0")
+    tls_manager.state.peer_cluster_ca = [new_tls_data.ca]
+
+    tls_manager.update_peer_cluster_trust()
+    trusted_certs = tls_manager.peer_trusted_certificates
+    assert f"{tls_manager.PEER_CLUSTER_ALIAS}0" in trusted_certs
+    assert len(trusted_certs) == 1
+    new_fingerprint = next(iter(trusted_certs.values()))
+    assert new_fingerprint != fingerprint

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ set_env =
     kraft: TEST_FILE=test_kraft.py
     balancer-single: DEPLOYMENT=single
     balancer-multi: DEPLOYMENT=multi
+    kraft-tls: TEST_FILE=test_kraft.py
+    kraft-tls: TLS=enabled
 
 pass_env =
     PYTHONPATH
@@ -89,11 +91,12 @@ commands =
     poetry install --with integration
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/
 
-[testenv:integration-{charm,provider,scaling,password-rotation,tls,upgrade,ha,ha-controller,kraft}]
+[testenv:integration-{charm,provider,scaling,password-rotation,tls,upgrade,ha,ha-controller,kraft,kraft-tls}]
 description = Run integration tests
 pass_env =
     {[testenv]pass_env}
     CI
+    TLS
 commands =
     poetry install --with integration
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/{env:TEST_FILE}


### PR DESCRIPTION
This PR adds a `peer-certificates` interface for internal TLS communications (INTERNAL listener, CONTROLLER listener, and balancer). Also, kafka operator now uses TLS by default for internal listeners. It follows the DA185 spec regarding internal CA setup and TLS split.

## Changes:
- Upgrade to `tls-certificates` v4
- Use TLS for internal listeners by default
- Use an internal CA for initial setup
- Adds `peer-certificates` interface
- Adds `TLSScope` to TLS state, handler and manager. Now assuming two scopes (client, peer) with their own TLS certs, keys, keystores, truststores, and lifecycle management.

## Enhancements
- Status messages are now all lower-cased to be consistent.

