### PR TITLE
[DPE-7413] Extend SSL mapping validation

### DIFF
--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -4,15 +4,14 @@
 
 """Structured configuration for the Kafka charm."""
 import logging
-import re
 from enum import Enum
 from typing import Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import Field, validator
 
-from managers.ssl_principal_mapper import SslPrincipalMapper
 from literals import BALANCER, BROKER, CONTROLLER, SUBSTRATE
+from managers.ssl_principal_mapper import SslPrincipalMapper
 
 logger = logging.getLogger(__name__)
 
@@ -89,10 +88,10 @@ class CharmConfig(BaseConfigModel):
     @classmethod
     def ssl_principal_mapping_rules_validator(cls, value: str) -> str | None:
         """Check that the list is formed by valid regex values."""
+        rules = SslPrincipalMapper.split_rules(value)
         # parse_rules will raise ValueError if the rules are not valid
-        SslPrincipalMapper.parse_rules(
-            SslPrincipalMapper.split_rules(value)
-        )
+        SslPrincipalMapper.parse_rules(rules)
+        return value
 
     @validator("transaction_state_log_num_partitions", "offsets_topic_num_partitions")
     @classmethod

--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -11,6 +11,7 @@ from typing import Literal
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import Field, validator
 
+from managers.ssl_principal_mapper import SslPrincipalMapper
 from literals import BALANCER, BROKER, CONTROLLER, SUBSTRATE
 
 logger = logging.getLogger(__name__)
@@ -88,16 +89,10 @@ class CharmConfig(BaseConfigModel):
     @classmethod
     def ssl_principal_mapping_rules_validator(cls, value: str) -> str | None:
         """Check that the list is formed by valid regex values."""
-        # get all regex up until replacement position "/"
-        # TODO: check that there is a replacement as well, not: RULE:regex/
-        pat = re.compile(r"RULE:([^/]+)(?:,RULE:[^/]+)*(?:DEFAULT){0,1}")
-        matches = re.findall(pat, value)
-        for match in matches:
-            try:
-                re.compile(match)
-            except re.error:
-                raise ValueError("Non valid regex pattern")
-        return value
+        # parse_rules will raise ValueError if the rules are not valid
+        SslPrincipalMapper.parse_rules(
+            SslPrincipalMapper.split_rules(value)
+        )
 
     @validator("transaction_state_log_num_partitions", "offsets_topic_num_partitions")
     @classmethod

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -142,26 +142,21 @@ class AuthManager:
         Args:
             username: the user name to add
             password: the user password
-            internal: flag to use internal ports or client ones
 
         Raises:
             `(subprocess.CalledProcessError | ops.pebble.ExecError)`: if the error returned a non-zero exit code
         """
-        base_command = [
+        command = [
             "--alter",
             "--entity-type=users",
             f"--entity-name={username}",
             f"--add-config=SCRAM-SHA-512=[password={password}]",
-        ]
-
-        command = base_command + [
             f"--bootstrap-server={self.state.bootstrap_server_internal}",
             f"--command-config={self.workload.paths.client_properties}",
         ]
-        opts = []
 
         self.workload.run_bin_command(
-            bin_keyword="configs", bin_args=command, opts=opts + [self.log4j_opts]
+            bin_keyword="configs", bin_args=command, opts=[self.log4j_opts]
         )
 
     def delete_user(self, username: str) -> None:

--- a/src/managers/ssl_principal_mapper.py
+++ b/src/managers/ssl_principal_mapper.py
@@ -61,9 +61,9 @@ class Rule:
 
         From Kafka's SslPrincipalMapper.java:
 
-        > If we find a back reference that is not valid, then we will treat it as a literal string. 
-        For example, if we have 3 capturing groups and the Replacement Value has the value is 
-        "I owe $8 to him", then we want to treat the $8 as a literal "$8", rather than attempting 
+        > If we find a back reference that is not valid, then we will treat it as a literal string.
+        For example, if we have 3 capturing groups and the Replacement Value has the value is
+        "I owe $8 to him", then we want to treat the $8 as a literal "$8", rather than attempting
         to use it as a back reference.
         """
 
@@ -83,7 +83,7 @@ class Rule:
         if self.is_default:
             return "DEFAULT"
         buf = f"RULE:{self.pattern.pattern if self.pattern else ''}"
-        if self.replacement:
+        if self.replacement is not None:
             buf += f"/{self.replacement}"
         if self.to_lower_case:
             buf += "/L"
@@ -126,7 +126,7 @@ class SslPrincipalMapper:
                 raise ValueError(
                     f"Invalid rule: `{rule}`, unmatched substring: `{rule[matcher.end():]}`"
                 )
-            # empty rules are ignored
+            # add a DEFAULT rule if empty
             if matcher.group(1) is not None:
                 result.append(Rule())
             elif matcher.group(2) is not None:

--- a/src/managers/ssl_principal_mapper.py
+++ b/src/managers/ssl_principal_mapper.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Manager for handling Kafka SSL principal mappings."""
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SSL_PRINCIPAL_MAPPING_RULES = "DEFAULT"
+
+
+class NoMatchingRuleError(Exception):
+    """Raised when there not a rule that matches a distinguished name."""
+
+
+class Rule:
+    """Python implementation of org.apache.kafka.common.security.ssl.SslPrincipalMapper.Rule.java."""
+
+    BACK_REFERENCE_PATTERN = re.compile(r"\$(\d+)")
+
+    def __init__(
+        self,
+        pattern: str | None = None,
+        replacement: str | None = None,
+        to_lower_case: bool = False,
+        to_upper_case: bool = False,
+    ):
+        self.is_default = pattern is None
+        self.pattern = re.compile(pattern) if pattern else None
+        self.replacement = replacement
+        self.to_lower_case = to_lower_case
+        self.to_upper_case = to_upper_case
+
+    def apply(self, distinguished_name: str) -> str | None:
+        """Apply the rule to a distinguished name.
+
+        Returns:
+            the principal name if a rule matches or None
+        """
+        if self.is_default or self.pattern is None or self.replacement is None:
+            return distinguished_name
+
+        result = None
+        m = self.pattern.match(distinguished_name)
+        if m:
+            result = self.pattern.sub(
+                self.escape_literal_back_references(self.replacement, len(m.groups())),
+                distinguished_name,
+            )
+        if self.to_lower_case and result is not None:
+            result = result.lower()
+        elif self.to_upper_case and result is not None:
+            result = result.upper()
+        return result
+
+    def escape_literal_back_references(self, unescaped: str, num_capturing_groups: int) -> str:
+        """Escape back references in the replacement value.
+
+        From Kafka's SslPrincipalMapper.java:
+
+        > If we find a back reference that is not valid, then we will treat it as a literal string. 
+        For example, if we have 3 capturing groups and the Replacement Value has the value is 
+        "I owe $8 to him", then we want to treat the $8 as a literal "$8", rather than attempting 
+        to use it as a back reference.
+        """
+
+        def repl(match):
+            """For every $n match, if we have a capturing group n, then return backslash-n."""
+            group_num = int(match.group(1))
+            if 1 <= group_num <= num_capturing_groups:
+                return f"\\{group_num}"
+            else:
+                # Treat as literal if group doesn't exist
+                return f"${group_num}"
+
+        return re.sub(self.BACK_REFERENCE_PATTERN, repl, unescaped)
+
+    def __repr__(self):
+        """Class representation."""
+        if self.is_default:
+            return "DEFAULT"
+        buf = f"RULE:{self.pattern.pattern if self.pattern else ''}"
+        if self.replacement:
+            buf += f"/{self.replacement}"
+        if self.to_lower_case:
+            buf += "/L"
+        elif self.to_upper_case:
+            buf += "/U"
+        return buf
+
+
+class SslPrincipalMapper:
+    """Python implementation of org.apache.kafka.common.security.ssl.SslPrincipalMapper.java."""
+
+    RULE_PATTERN = r"(DEFAULT)|RULE:((\\.|[^\\/])*)/((\\.|[^\\/])*)/([LU]?).*?|(.*?)"
+    RULE_SPLITTER = re.compile(r"\s*(" + RULE_PATTERN + r")\s*(,\s*|$)")
+    RULE_PARSER = re.compile(RULE_PATTERN)
+
+    def __init__(self, ssl_principal_mapping_rules: str | None = None):
+        self.rules: list[Rule] = self.parse_rules(self.split_rules(ssl_principal_mapping_rules))
+
+    @staticmethod
+    def split_rules(ssl_principal_mapping_rules: str | None = None) -> list[str]:
+        """Split the rules from a string into a list of rules in string format."""
+        if ssl_principal_mapping_rules is None:
+            ssl_principal_mapping_rules = DEFAULT_SSL_PRINCIPAL_MAPPING_RULES
+        result = []
+        for match in SslPrincipalMapper.RULE_SPLITTER.finditer(
+            ssl_principal_mapping_rules.strip()
+        ):
+            result.append(match.group(1))
+        return result
+
+    @staticmethod
+    def parse_rules(rules: list[str]) -> list[Rule]:
+        """Parse the rules from a list of string into Rule objects."""
+        result: list[Rule] = []
+        for rule in rules:
+            matcher = SslPrincipalMapper.RULE_PARSER.match(rule)
+            if not matcher:
+                raise ValueError(f"Invalid rule: {rule}")
+            if len(rule) != matcher.end():
+                raise ValueError(
+                    f"Invalid rule: `{rule}`, unmatched substring: `{rule[matcher.end():]}`"
+                )
+            # empty rules are ignored
+            if matcher.group(1) is not None:
+                result.append(Rule())
+            elif matcher.group(2) is not None:
+                result.append(
+                    Rule(
+                        pattern=matcher.group(2),
+                        replacement=matcher.group(4),
+                        to_lower_case=matcher.group(6) == "L",
+                        to_upper_case=matcher.group(6) == "U",
+                    )
+                )
+        return result
+
+    def get_name(self, distinguished_name: str) -> str:
+        """Get the principal name from a distinguished name using the mapping rules."""
+        for rule in self.rules:
+            principal_name = rule.apply(distinguished_name)
+            if principal_name is not None:
+                return principal_name
+        raise NoMatchingRuleError(f"No rules apply to {distinguished_name}, rules {self.rules}")
+
+    def __repr__(self):
+        """Class representation."""
+        return f"SslPrincipalMapper(rules = {self.rules})"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -612,7 +612,7 @@ def balancer_is_ready(ops_test: OpsTest, app_name: str) -> bool:
         logger.error(e)
         return False
 
-    print(f"{monitor_state_json=}")
+    logger.debug(f"{monitor_state_json=}")
 
     return all(
         [
@@ -646,8 +646,7 @@ def get_kafka_broker_state(ops_test: OpsTest, app_name: str) -> JSON:
         logger.error(e)
         return False
 
-    print(f"{broker_state_json=}")
-
+    logger.debug(f"{broker_state_json=}")
     return broker_state_json
 
 
@@ -682,7 +681,7 @@ def kraft_quorum_status(
             continue
 
     if verbose:
-        print(unit_status)
+        logger.debug(f"{unit_status=}")
 
     return unit_status
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -143,7 +143,7 @@ async def test_client_properties_makes_admin_connection(ops_test: OpsTest, kafka
     )
     result = await run_client_properties(ops_test=ops_test)
     assert result
-    print(result)
+    logger.debug(f"{result=}")
 
     acls = 0
     for line in result.strip().split("\n"):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -541,7 +541,7 @@ def test_ssl_principal_mapping_rules(charm_configuration: dict, base_state: Stat
     # Given
     charm_configuration["options"]["ssl_principal_mapping_rules"][
         "default"
-    ] = "RULE:^(erebor)$/$1,DEFAULT"
+    ] = "RULE:^(erebor)$/$1/,DEFAULT"
     cluster_peer = PeerRelation(PEER, PEER)
     state_in = dataclasses.replace(base_state, relations=[cluster_peer])
     ctx = Context(
@@ -561,7 +561,7 @@ def test_ssl_principal_mapping_rules(charm_configuration: dict, base_state: Stat
 
         # Then
         assert (
-            "ssl.principal.mapping.rules=RULE:^(erebor)$/$1,DEFAULT"
+            "ssl.principal.mapping.rules=RULE:^(erebor)$/$1/,DEFAULT"
             in charm.broker.config_manager.server_properties
         )
 

--- a/tests/unit/test_ssl_principal_mapping.py
+++ b/tests/unit/test_ssl_principal_mapping.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+
+from managers.ssl_principal_mapper import SslPrincipalMapper
+
+logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.broker
+
+
+def test_valid_rules():
+    _test_valid_rule("DEFAULT")
+    _test_valid_rule("RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/")
+    _test_valid_rule("RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L, DEFAULT")
+    _test_valid_rule("RULE:^CN=(.*?),OU=ServiceUsers.*$/$1@$2/")
+    _test_valid_rule("RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L")
+    _test_valid_rule("RULE:^cn=(.?),ou=(.?),dc=(.?),dc=(.?)$/$1@$2/U")
+    _test_valid_rule("RULE:^CN=([^,ADEFLTU,]+)(,.*|$)/$1/")
+    _test_valid_rule("RULE:^CN=([^,DEFAULT,]+)(,.*|$)/$1/")
+
+
+def _test_valid_rule(rules):
+    SslPrincipalMapper.parse_rules(SslPrincipalMapper.split_rules(rules))
+
+
+def test_invalid_rules():
+    invalid_rules = [
+        "default",
+        "DEFAUL",
+        "DEFAULT/L",
+        "DEFAULT/U",
+        "RULE:CN=(.*?),OU=ServiceUsers.*/$1",
+        "rule:^CN=(.*?),OU=ServiceUsers.*$/$1/",
+        "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L/U",
+        "RULE:^CN=(.*?),OU=ServiceUsers.*$/L",
+        "RULE:^CN=(.*?),OU=ServiceUsers.*$/U",
+        "RULE:^CN=(.*?),OU=ServiceUsers.*$/LU",
+    ]
+    for rules in invalid_rules:
+        with pytest.raises(ValueError):
+            SslPrincipalMapper.parse_rules(SslPrincipalMapper.split_rules(rules))
+
+
+def test_ssl_principal_mapper():
+    rules = ", ".join(
+        [
+            "RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/L",
+            "RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/L",
+            "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1@$2/U",
+            "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/U",
+            "DEFAULT",
+        ]
+    )
+    mapper = SslPrincipalMapper(rules)
+    assert "duke" == mapper.get_name("CN=Duke,OU=ServiceUsers,O=Org,C=US")
+    assert "duke@sme" == mapper.get_name("CN=Duke,OU=SME,O=mycp,L=Fulton,ST=MD,C=US")
+    assert "DUKE@SME" == mapper.get_name("cn=duke,ou=sme,dc=mycp,dc=com")
+    assert "DUKE" == mapper.get_name("cN=duke,OU=JavaSoft,O=Sun Microsystems")
+    assert "OU=JavaSoft,O=Sun Microsystems,C=US" == mapper.get_name(
+        "OU=JavaSoft,O=Sun Microsystems,C=US"
+    )
+
+
+def _test_rules_splitting(expected, rules):
+    mapper = SslPrincipalMapper(rules)
+    assert f"SslPrincipalMapper(rules = {expected})" == str(mapper)
+
+
+def test_rules_splitting():
+    _test_rules_splitting("[]", "")
+    _test_rules_splitting("[DEFAULT]", "DEFAULT")
+    _test_rules_splitting("[RULE:/]", "RULE://")
+    _test_rules_splitting("[RULE:/.*]", "RULE:/.*/")
+    _test_rules_splitting("[RULE:/.*/L]", "RULE:/.*/L")
+    _test_rules_splitting("[RULE:/, DEFAULT]", "RULE://,DEFAULT")
+    _test_rules_splitting("[RULE:/, DEFAULT]", "  RULE:// ,  DEFAULT  ")
+    _test_rules_splitting("[RULE:   /     , DEFAULT]", "  RULE:   /     / ,  DEFAULT  ")
+    _test_rules_splitting("[RULE:  /     /U, DEFAULT]", "  RULE:  /     /U   ,DEFAULT  ")
+    _test_rules_splitting(
+        "[RULE:([A-Z]*)/$1/U, RULE:([a-z]+)/$1, DEFAULT]",
+        "  RULE:([A-Z]*)/$1/U   ,RULE:([a-z]+)/$1/,   DEFAULT  ",
+    )
+    _test_rules_splitting("[]", ",   , , ,      , , ,   ")
+    _test_rules_splitting("[RULE:/, DEFAULT]", ",,RULE://,,,DEFAULT,,")
+    _test_rules_splitting("[RULE: /   , DEFAULT]", ",  , RULE: /   /    ,,,   DEFAULT, ,   ")
+    _test_rules_splitting("[RULE:   /  /U, DEFAULT]", "     ,  , RULE:   /  /U    ,,  ,DEFAULT, ,")
+    _test_rules_splitting("[RULE:\\/\\\\\\(\\)\\n\\t/\\/\\/]", "RULE:\\/\\\\\\(\\)\\n\\t/\\/\\//")
+    _test_rules_splitting(
+        "[RULE:\\**\\/+/*/L, RULE:\\/*\\**/**]", "RULE:\\**\\/+/*/L,RULE:\\/*\\**/**/"
+    )
+    _test_rules_splitting(
+        "[RULE:,RULE:,/,RULE:,\\//U, RULE:,/RULE:,, RULE:,RULE:,/L,RULE:,/L, RULE:, DEFAULT, /DEFAULT, DEFAULT]",
+        "RULE:,RULE:,/,RULE:,\\//U,RULE:,/RULE:,/,RULE:,RULE:,/L,RULE:,/L,RULE:, DEFAULT, /DEFAULT/,DEFAULT",
+    )
+
+
+def test_comma_with_whitespace():
+    rules = r"RULE:^CN=((\\, *|\w)+)(,.*|$)/$1/,DEFAULT"
+    mapper = SslPrincipalMapper(rules)
+    assert "Tkac\\, Adam" == mapper.get_name("CN=Tkac\\, Adam,OU=ITZ,DC=geodis,DC=cz")

--- a/tests/unit/test_tls_manager.py
+++ b/tests/unit/test_tls_manager.py
@@ -41,7 +41,6 @@ def _exec(
     _: bool = False,
 ) -> str:
     _command = " ".join(command) if isinstance(command, list) else command
-    print(_command)
 
     for bin in ("chown", "chmod"):
         if _command.startswith(bin):
@@ -341,7 +340,6 @@ def test_simulate_os_errors(tls_manager: TLSManager):
             continue
 
         with pytest.raises(subprocess.CalledProcessError):
-            print(f"Calling {method}")
             getattr(tls_manager, method)()
 
     with pytest.raises(subprocess.CalledProcessError):

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,8 @@ commands =
         --skip {tox_root}/venv \
         --skip {tox_root}/.mypy_cache \
         --skip {tox_root}/icon.svg \
-        --skip {tox_root}/poetry.lock
+        --skip {tox_root}/poetry.lock \
+        --skip {tox_root}/tests/unit/test_ssl_principal_mapping.py
     poetry run codespell {[vars]lib_path}
 
     poetry run ruff check {[vars]all_path}


### PR DESCRIPTION
Extends mapping validation using upstream module.

> **NOTE**: The extended functionality of checking backwards literals has not been implemented. eg: If we have 5 capturing groups and the replacement pattern looks like $13, upstream logic sees that we don't have 13 capturing groups, so it truncates the next digit. Then, the `3` becomes a literal and `$1` resolves to the first capturing group.