### PR TITLE
Add optional flags to provides endpoints

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,11 +34,14 @@ peers:
 provides:
   kafka-client:
     interface: kafka_client
+    optional: true
   cos-agent:
     interface: cos_agent
+    optional: true
   peer-cluster-orchestrator:
     interface: peer_cluster
     limit: 1
+    optional: true
 
 requires:
   certificates:


### PR DESCRIPTION
## Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

## Solution

Set `optional` flag on provides endpoints to indicate correct optionality.
