### PR TITLE
Fix the product link in RTD docs header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ html_context = {
     # TODO: If there's no such website,
     #       remove the {{ product_page }} link from the page header template
     #       (usually .sphinx/_templates/header.html; also, see README.rst).
-    "product_page": "https://canonical.com/data/kafka",
+    "product_page": "canonical.com/data/kafka",
     # Product tag image; the orange part of your logo, shown in the page header
     #
     # TODO: To add a tag image, uncomment and update as needed.


### PR DESCRIPTION
Fix the product link in RTD docs header -- the link was broken due to "https://" prefix which apparently doesn't work correctly in the current Starter pack.