### PR TITLE
[DPE-7583] Split metadata.log.dir from log.dirs

### DIFF
--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -464,6 +464,15 @@ class ClusterState(Object):
         return ",".join([os.fspath(storage.location) for storage in self.model.storages["data"]])
 
     @property
+    def metadata_log_dir(self) -> str:
+        """Builds the necessary metadata.log.dir based on log_dirs.
+
+        Returns:
+            String of metadata.log.dir property value to be set
+        """
+        return f"{self.log_dirs.split(',')[0]}/metadata"
+
+    @property
     def planned_units(self) -> int:
         """Return the planned units for the charm."""
         return self.model.app.planned_units()

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -700,6 +700,7 @@ class ConfigManager(CommonConfigManager):
                 [
                     f"super.users={self.state.super_users}",
                     f"log.dirs={self.state.log_dirs}",
+                    f"metadata.log.dir={self.state.metadata_log_dir}",
                     f"listeners={controller_listener}",
                     f"listener.security.protocol.map={controller_protocol_map}",
                 ]
@@ -716,6 +717,7 @@ class ConfigManager(CommonConfigManager):
             [
                 f"super.users={self.state.super_users}",
                 f"log.dirs={self.state.log_dirs}",
+                f"metadata.log.dir={self.state.metadata_log_dir}",
                 f"listener.security.protocol.map={','.join(protocol_map)}",
                 f"listeners={','.join(listeners_repr)}",
                 f"advertised.listeners={','.join(advertised_listeners)}",

--- a/src/managers/controller.py
+++ b/src/managers/controller.py
@@ -75,11 +75,7 @@ class ControllerManager:
         return uuid
 
     def get_metadata_directory_id(self, log_dirs: str) -> str:
-        """Read directory.id from meta.properties file in the logs dir.
-
-        If metadata.log.dir is not set, it will be found in the first log directory declared in
-        log.dirs
-        """
+        """Read directory.id from meta.properties file in the metadata logs dir."""
         raw = self.workload.read(os.path.join(log_dirs, "meta.properties"))
         for line in raw:
             if line.startswith("directory.id"):
@@ -115,7 +111,7 @@ class ControllerManager:
             if "DuplicateVoterException" not in error_details:
                 raise e
 
-        metadata_directory_id = self.get_metadata_directory_id(self.state.log_dirs)
+        metadata_directory_id = self.get_metadata_directory_id(self.state.metadata_log_dir)
         return metadata_directory_id
 
     @retry(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -126,6 +126,23 @@ def test_log_dirs_in_server_properties(ctx: Context, base_state: State) -> None:
     assert found_log_dirs
 
 
+def test_metadata_log_dir_in_server_properties(ctx: Context, base_state: State) -> None:
+    """Checks that metadata.log.dir is added to server_properties."""
+    # Given
+    found_metadata_log_dir = False
+    state_in = base_state
+
+    # When
+    with (ctx(ctx.on.config_changed(), state_in) as manager,):
+        charm = cast(KafkaCharm, manager.charm)
+        for prop in charm.broker.config_manager.server_properties:
+            if "metadata.log.dir" in prop:
+                found_metadata_log_dir = True
+
+    # Then
+    assert found_metadata_log_dir
+
+
 def test_listeners_in_server_properties(charm_configuration: dict, base_state: State) -> None:
     """Checks that listeners are split into INTERNAL, CLIENT and EXTERNAL."""
     # Given


### PR DESCRIPTION
Splits metatada into a separate subfolder.