### PR TITLE
Hotfix: Tutorial titles and headings

### DIFF
--- a/docs/tutorial/cleanup.md
+++ b/docs/tutorial/cleanup.md
@@ -1,5 +1,5 @@
 (tutorial-cleanup)=
-# 9. Cleanup your environment
+# 8. Cleanup your environment
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 
@@ -42,4 +42,3 @@ If you're looking for what to do next you can:
 - [Report](https://github.com/canonical/kafka-operator/issues) any problems you encountered.
 - [Give us your feedback](https://matrix.to/#/#charmhub-data-platform:ubuntu.com).
 - [Contribute to the code base](https://github.com/canonical/kafka-operator)
-

--- a/docs/tutorial/deploy.md
+++ b/docs/tutorial/deploy.md
@@ -1,5 +1,5 @@
 (tutorial-deploy)=
-# 3. Deploy Apache Kafka
+# 2. Deploy Apache Kafka
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 

--- a/docs/tutorial/deploy.md
+++ b/docs/tutorial/deploy.md
@@ -3,19 +3,17 @@
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 
-## Deploy Charmed Apache Kafka (and Charmed ZooKeeper)
-
 To deploy Charmed Apache Kafka, all you need to do is run the following commands, which will automatically fetch [Apache Kafka](https://charmhub.io/kafka?channel=3/stable) and [Apache ZooKeeper](https://charmhub.io/zookeeper?channel=3/stable) charms from [Charmhub](https://charmhub.io/) and deploy them to your model. For example, to deploy a cluster of five Apache ZooKeeper units and three Apache Kafka units, you can simply run:
 
 ```shell
-$ juju deploy zookeeper -n 5
-$ juju deploy kafka -n 3
+juju deploy zookeeper -n 5
+juju deploy kafka -n 3
 ```
 
 After this, it is necessary to connect them:
 
 ```shell
-$ juju relate kafka zookeeper
+juju relate kafka zookeeper
 ```
 
 Juju will now fetch Charmed Apache Kafka and Charmed Apache Zookeeper and begin deploying them to the LXD cloud. This process can take several minutes depending on how provisioned (RAM, CPU, etc) your machine is. You can track the progress by running:
@@ -146,4 +144,3 @@ snap info charmed-kafka
 However, although the commands above can run within the cluster, it is generally recommended during operations
 to enable external listeners and use these for running the admin commands from outside the cluster. 
 To do so, as we will see in the next section, we will deploy a [data-integrator](https://charmhub.io/data-integrator) charm and relate it to Charmed Apache Kafka.
-

--- a/docs/tutorial/enable-encryption.md
+++ b/docs/tutorial/enable-encryption.md
@@ -3,8 +3,6 @@
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 
-## Transport Layer Security (TLS)
-
 [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) is used to encrypt data exchanged between two applications; it secures data transmitted over the network. Typically, enabling TLS within a highly available database, and between a highly available database and client/server applications, requires domain-specific knowledge and a high level of expertise. Fortunately, the domain-specific knowledge has been encoded into Charmed Apache Kafka. This means (re-)configuring TLS on Charmed Apache Kafka is readily available and requires minimal effort on your end.
 
 Again, relations come in handy here as TLS is enabled via relations; i.e. by relating Charmed Apache Kafka to the [Self-signed Certificates Charm](https://charmhub.io/self-signed-certificates) via the [`tls-certificates`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/tls_certificates/v1/README.md) charm relations. The `tls-certificates` relation centralises TLS certificate management in a consistent manner and handles providing, requesting, and renewing TLS certificates, making it possible to use different providers, like the self-signed certificates but also other services, e.g. Let's Encrypt.
@@ -14,7 +12,7 @@ In this tutorial, we will distribute [self-signed certificates](https://en.wikip
 that is also trusted by all applications. This setup is only for show-casing purposes and self-signed certificates should **never** be used in a production cluster. For more information about which charm may better suit your use-case, please refer to [this post](https://charmhub.io/topics/security-with-x-509-certificates).
 ```
 
-### Configure TLS
+## Configure TLS
 
 Before enabling TLS on Charmed Apache Kafka we must first deploy the `self-signed-certificates` charm:
 
@@ -55,7 +53,7 @@ telnet <IP> 9092
 telnet <IP> 9093
 ```
 
-### Enable TLS encrypted connection
+## Enable TLS encrypted connection
 
 Once TLS is configured on the cluster side, client applications should be configured as well to connect to
 the correct port and trust the self-signed CA provided by the `self-signed-certificates` charm. 
@@ -95,7 +93,7 @@ Note that if the `kafka-test-app` was running before, there may be multiple logs
 runs. Refer to the latest logs produced and also check that in the logs the connection is indeed established
 with the encrypted port `9093`.
 
-### Remove external TLS certificate
+## Remove external TLS certificate
 
 To remove the external TLS and return to the locally generated one, remove relation with certificates provider:
 

--- a/docs/tutorial/enable-encryption.md
+++ b/docs/tutorial/enable-encryption.md
@@ -1,5 +1,5 @@
 (tutorial-enable-encryption)=
-# 6. Enable Encryption
+# 5. Enable Encryption
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 

--- a/docs/tutorial/environment.md
+++ b/docs/tutorial/environment.md
@@ -1,5 +1,5 @@
 (tutorial-environment)=
-# 2. Set up the environment
+# 1. Set up the environment
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 

--- a/docs/tutorial/environment.md
+++ b/docs/tutorial/environment.md
@@ -3,14 +3,12 @@
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 
-## Setup the environment
-
 For this tutorial, we will need to set up the environment with two main components:
 
 * LXD that is a simple and lightweight virtual machine provisioner
 * Juju that will help us to deploy and manage Apache Kafka and related applications
 
-### Prepare LXD
+## Prepare LXD
 
 The fastest, simplest way to get started with Charmed Apache Kafka is to set up a local LXD cloud. LXD is a system container and virtual machine manager; Apache Kafka will be run in one of these containers and managed by Juju. While this tutorial covers the basics of LXD, you can [explore more LXD here](https://linuxcontainers.org/lxd/getting-started-cli/). LXD comes pre-installed on Ubuntu 20.04 LTS. Verify that LXD is installed by entering the command `which lxd` into the command line, this will output:
 
@@ -33,7 +31,7 @@ You can list all LXD containers by entering the command `lxc list` into the comm
 +------+-------+------+------+------+-----------+
 ```
 
-### Install and prepare Juju
+## Install and prepare Juju
 
 [Juju](https://juju.is/) is an Operator Lifecycle Manager (OLM) for clouds, bare metal, LXD or Kubernetes. We will be using it to deploy and manage Apache Kafka. As with LXD, Juju is installed from a snap package:
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,26 +1,18 @@
+(tutorial-index)=
+# Tutorial
+
 (tutorial-introduction)=
-```{include} introduction.md
+```{include} introduction.inc
 
 ```
 
-(tutorial-index)=
 ## Step-by-step guide
 
 Here’s an overview of the steps required with links to our separate tutorials that deal with each individual step:
 
-- [Set up the environment](tutorial-environment)
-- [Deploy Charmed Apache Kafka](tutorial-deploy)
-- [Integrate with client applications](tutorial-integrate-with-client-applications)
-- [Manage passwords](tutorial-manage-passwords)
-- [Enable encryption](tutorial-enable-encryption)
-- [Use Kafka Connect for ETL](tutorial-kafka-connect)
-- [Rebalance and Reassign Partitions](tutorial-rebalance-partitions)
-- [Cleanup your environment](tutorial-cleanup)
-
 ```{toctree}
 :titlesonly:
 :maxdepth: 2
-:hidden:
 
 1. Set up the environment<environment.md>
 2. Deploy Apache Kafka<deploy.md>

--- a/docs/tutorial/integrate-with-client-applications.md
+++ b/docs/tutorial/integrate-with-client-applications.md
@@ -1,5 +1,5 @@
 (tutorial-integrate-with-client-applications)=
-# 4. Integrate with client applications
+# 3. Integrate with client applications
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 

--- a/docs/tutorial/integrate-with-client-applications.md
+++ b/docs/tutorial/integrate-with-client-applications.md
@@ -3,15 +3,13 @@
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 
-## Integrate with client applications
-
 As mentioned in the previous section of the Tutorial, the recommended way to create and manage users is by means of another charm: the [Data Integrator Charm](https://charmhub.io/data-integrator). This lets us to encode users directly in the Juju model, and - as shown in the following - rotate user credentials with and without application downtime using Relations.
 
 ```{note}
 Relations, or what Juju documentation describes also as [Integrations](https://documentation.ubuntu.com/juju/3.6/reference/relation/), let two charms to exchange information and interact with one another. Creating a relation between Apache Kafka and the Data Integrator will automatically generate a username, password, and assign read/write permissions on a given topic. This is the simplest method to create and manage users in Charmed Apache Kafka.
 ```
 
-### Data Integrator charm
+## Data Integrator charm
 
 The [Data Integrator charm](https://charmhub.io/data-integrator) is a bare-bones charm for central management of database users, providing support for different kinds of data platforms (e.g. MongoDB, MySQL, PostgreSQL, Apache Kafka, OpenSearch, etc.) with a consistent, opinionated and robust user experience. To deploy the Data Integrator charm we can use the command `juju deploy` we have learned above:
 
@@ -26,7 +24,7 @@ Located charm "data-integrator" in charm-hub, revision 11
 Deploying "data-integrator" from charm-hub charm "data-integrator", revision 11 in channel stable on jammy
 ```
 
-### Relate to Charmed Apache Kafka
+## Relate to Charmed Apache Kafka
 
 Now that the Database Integrator charm has been set up, we can relate it to Charmed Apache Kafka. This will automatically create a username, password, and database for the Database Integrator charm. Relate the two applications with:
 
@@ -90,7 +88,7 @@ ok: "True"
 
 Save the value listed under `bootstrap-server`, `username` and `password`. *(Note: your hostname, usernames, and passwords will likely be different.)*
 
-### Produce/consume messages
+## Produce/consume messages
 
 We will now use the username and password to produce some messages to Apache Kafka. To do so, we will first deploy the [Apache Kafka Test App](https://charmhub.io/kafka-test-app): a test charm that also bundles some python scripts to push data to Apache Kafka, e.g.:
 
@@ -172,13 +170,13 @@ python3 -m charms.kafka.v0.client \
   -c "cg"
 ```
 
-### Charm client applications
+## Charm client applications
 
 Actually, the Data Integrator is only a very special client charm, that implements the `kafka_client` relation for exchanging data with Charmed Apache Kafka and user management via relations. 
 
 For example, the steps above for producing and consuming messages to Apache Kafka have also been implemented in the `kafka-test-app` charm (that also implements the `kafka_client` relation) providing a fully integrated charmed user experience, where producing/consuming messages can simply be achieved using relations.  
 
-#### Producing messages
+### Producing messages
 
 To produce messages to Apache Kafka, we need to configure the `kafka-test-app` to act as a producer, publishing messages to a specific topic:
 
@@ -225,7 +223,7 @@ To stop the process (although it is very likely that the process has already sto
 juju remove-relation kafka-test-app kafka
 ```
 
-#### Consuming messages
+### Consuming messages
 
 Note that the `kafka-test-app` charm can also similarly be used to consume messages by changing its configuration to
 

--- a/docs/tutorial/introduction.inc
+++ b/docs/tutorial/introduction.inc
@@ -1,4 +1,3 @@
-# Tutorial
 <!-- # Charmed Apache Kafka tutorial -->
 
 The Charmed Apache Kafka Operator delivers automated operations management from [Day 0 to Day 2](https://codilime.com/blog/day-0-day-1-day-2-the-software-lifecycle-in-the-cloud-age/) on the [Apache Kafka](https://kafka.apache.org/) event streaming platform.

--- a/docs/tutorial/manage-passwords.md
+++ b/docs/tutorial/manage-passwords.md
@@ -1,16 +1,15 @@
 (tutorial-manage-passwords)=
-# 5. Manage passwords
+# 4. Manage passwords
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
-## Manage passwords
 
 Passwords help to secure our cluster and are essential for security. Over time it is a good practice to change the password frequently. Here we will go through setting and changing the password both for the admin user and external Apache Kafka users managed by the data-integrator.
 
-### Admin user
+## Admin user
 
 The admin user password management is handled directly by the charm, by using Juju actions. 
 
-#### Retrieve the admin password
+### Retrieve the admin password
 
 As previously mentioned, the admin password can be retrieved by running the `get-admin-credentials` action on the Charmed Apache Kafka application:
 
@@ -41,7 +40,7 @@ unit-kafka-1:
 
 The admin password is under the result: `password`.
 
-#### Rotate the admin password
+### Rotate the admin password
 
 You can change the admin password to a new random password by entering:
 
@@ -70,7 +69,7 @@ The admin password is under the result: `admin-password`. It should be different
 When changing the admin password you will also need to update the admin password the in Kafka connection parameters; as the old password will no longer be valid.
 ```
 
-#### Set the admin password
+### Set the admin password
 
 You can change the admin password to a specific password by entering:
 
@@ -99,11 +98,11 @@ The admin password under the result: `admin-password` should match whatever you 
 When changing the admin password you will also need to update the admin password in the Kafka connection parameters, as the old password will no longer be valid.
 ```
 
-### External Apache Kafka users
+## External Apache Kafka users
 
 Unlike Admin management, the password management for external Apache Kafka users is instead managed using relations. Let's see this into play with the Data Integrator charm, that we have deployed in the previous part of the tutorial.
 
-#### Retrieve the password
+### Retrieve the password
 
 Similarly to the Charmed Apache Kafka, the `data-integrator` also exposes an action to retrieve the credentials, e.g. 
 
@@ -126,7 +125,7 @@ ok: "True"
 
 As before, the admin password is under the result: `password`.
 
-#### Rotate the password
+### Rotate the password
 
 The easiest way to rotate user credentials using the `data-integrator` is by removing and then re-relating the `data-integrator` with the `kafka` charm
 
@@ -157,7 +156,7 @@ ok: "True"
 
 To rotate external passwords with no or limited downtime, please refer to the how-to guide on [app management](how-to-manage-applications).
 
-#### Remove the user
+### Remove the user
 
 To remove the user, remove the relation. Removing the relation automatically removes the user that was created when the relation was created. Enter the following to remove the relation:
 

--- a/docs/tutorial/rebalance-partitions.md
+++ b/docs/tutorial/rebalance-partitions.md
@@ -1,9 +1,7 @@
 (tutorial-rebalance-partitions)=
-# 7. Rebalance and Reassign Partitions
+# 7. Rebalance and reassign partitions
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
-
-## Partition rebalancing and reassignment
 
 By default, when adding more brokers to an Apache Kafka cluster, the current allocated partitions on the original brokers are not automatically redistributed across the new brokers. This can lead to inefficient resource usage and over-provisioning. On the other hand, when removing brokers to reduce capacity, partitions assigned to the removed brokers are also not redistributed, which can result in under-replicated data at best and permanent data loss at worst.
 
@@ -17,7 +15,7 @@ At a high level, Cruise Control is made up of the following five components:
 - **Web server** - a REST API for user operations
 - **Executor** - issues re-allocation commands to Apache Kafka
 
-### Deploying partition balancer
+## Deploying partition balancer
 
 The Charmed Apache Kafka charm has a configuration option `roles`, which takes a list of possible values.
 Different roles can be configured to run on the same machine, or as separate Juju applications.
@@ -48,7 +46,7 @@ Now, to make the new `cruise-control` application aware of the existing Apache K
 juju integrate kafka:peer-cluster-orchestrator cruise-control:peer-cluster
 ```
 
-### Adding new brokers
+## Adding new brokers
 
 After completing the steps in the [Integrate with client applications](integrate-with-client-applications) tutorial page, you should have three `kafka` units and a client application actively writing messages to an existing topic. Let's scale-out the `kafka` application to four units:
 
@@ -162,7 +160,7 @@ This should produce an output similar to the result seen below, with broker `3` 
 }
 ```
 
-### Removing old brokers
+## Removing old brokers
 
 To safely scale-in an Apache Kafka cluster, we must make sure to carefully move any existing data from units about to be removed, to another unit that will persist.
 
@@ -213,7 +211,7 @@ Now, it is safe to scale-in the cluster, removing the broker number `3` complete
 juju remove-unit kafka/3
 ```
 
-### Full cluster rebalancing
+## Full cluster rebalancing
 
 Over time, an Apache Kafka cluster in production may develop an imbalance in partition allocation, with some brokers having greater/fewer allocated than others. This can occur as topic load fluctuates, partitions are added or removed due to reconfiguration, or new topics are created or deleted. Therefore, as part of regular cluster maintenance, administrators should periodically redistribute partitions across existing broker units to ensure optimal performance.
 
@@ -240,4 +238,3 @@ To implement the proposed changes, run the same command but with `dryrun=false`:
 ```bash
 juju run cruise-control/0 rebalance mode=full dryrun=false --wait=10m
 ```
-

--- a/docs/tutorial/rebalance-partitions.md
+++ b/docs/tutorial/rebalance-partitions.md
@@ -1,5 +1,5 @@
 (tutorial-rebalance-partitions)=
-# 8. Rebalance and Reassign Partitions
+# 7. Rebalance and Reassign Partitions
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 

--- a/docs/tutorial/use-kafka-connect.md
+++ b/docs/tutorial/use-kafka-connect.md
@@ -1,5 +1,5 @@
 (tutorial-kafka-connect)=
-# 7. Use Kafka Connect for ETL
+# 6. Use Kafka Connect for ETL
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 

--- a/docs/tutorial/use-kafka-connect.md
+++ b/docs/tutorial/use-kafka-connect.md
@@ -3,22 +3,20 @@
 
 This is a part of the [Charmed Apache Kafka Tutorial](index.md).
 
-## Using Kafka Connect for ETL
-
 In this part of the tutorial, we are going to use [Kafka Connect](https://kafka.apache.org/documentation/#connect) - an ETL framework on top of Apache Kafka - to seamlessly move data between different charmed database technologies.
 
 We will follow a step-by-step process for moving data between [Canonical Data Platform charms](https://canonical.com/data) using Kafka Connect. Specifically, we will showcase a particular use-case of loading data from a relational database, i.e. PostgreSQL, to a document store and search engine, i.e. OpenSearch, entirely using charmed solutions.
 
 By the end, you should be able to use Kafka Connect integrator and Kafka Connect charms to streamline data ETL tasks on Canonical Data Platform charmed solutions.
 
-### Prerequisites
+## Prerequisites
 
 We will be deploying different charmed data solutions including PostgreSQL and OpenSearch. If you require more information or face issues deploying any of the mentioned products, you should consult the respective documentations:
 
 - For PostgreSQL, refer to [Charmed PostgreSQL tutorial](https://canonical-charmed-postgresql.readthedocs-hosted.com/14/tutorial/).
 - For OpenSearch, refer to [Charmed OpenSearch tutorial](https://charmhub.io/opensearch/docs/tutorial).
 
-### Check current deployment
+## Check current deployment
 
 Up to this point, we should have a 3-unit Apache Kafka application, related to a 5-unit ZooKeeper application. That means the `juju status` command should show an output similar to the following:
 
@@ -44,7 +42,7 @@ zookeeper/3                  active    idle   3        10.38.169.119
 zookeeper/4                  active    idle   4        10.38.169.215             
 ```
 
-### Set the necessary kernel properties for OpenSearch
+## Set the necessary kernel properties for OpenSearch
 
 Since we will be deploying the OpenSearch charm, we need to make necessary kernel configurations required for OpenSearch charm to function properly, [described in detail here](https://charmhub.io/opensearch/docs/t-set-up#p-24545-set-kernel-parameters). This basically means running the following commands:
 
@@ -75,7 +73,7 @@ EOF
 juju model-config --file=./cloudinit-userdata.yaml
 ```
 
-### Deploy the databases and Kafka Connect charms
+## Deploy the databases and Kafka Connect charms
 
 Deploy the PostgreSQL, OpenSearch, and Kafka Connect charms:
 
@@ -87,7 +85,7 @@ juju deploy opensearch --channel 2/stable --config profile=testing
 
 OpenSearch charm requires a TLS relation to become active. We will use the [`self-signed-certificates` charm](https://charmhub.io/self-signed-certificates) that was deployed earlier in the [Enable Encryption](https://charmhub.io/kafka/docs/t-enable-encryption) part of this Tutorial.
 
-### Enable TLS
+## Enable TLS
 
 Using the `juju status` command, you should see that the Kafka Connect and OpenSearch applications are in `blocked` state. In order to activate them, we need to make necessary integrations using the `juju integrate` command.
 
@@ -140,7 +138,7 @@ zookeeper/3                  active    idle   3        10.38.169.119
 zookeeper/4                  active    idle   4        10.38.169.215             
 ```
 
-### Load test data
+## Load test data
 
 In a real-world scenario, an application would typically write data to a PostgreSQL database. However, for the purposes of this tutorial, we’ll generate test data using a simple SQL script and load it into a PostgreSQL database using the `psql` command-line tool included with the PostgreSQL charm.
 
@@ -243,7 +241,7 @@ The output should indicate that the `posts` table has five rows now:
 
 Log out from the PostgreSQL unit using `exit` command or the `Ctrl+D` keyboard shortcut.
 
-### Deploy and integrate the `postgresql-connect-integrator` charm
+## Deploy and integrate the `postgresql-connect-integrator` charm
 
 Now that you have sample data loaded into PostgreSQL, it is time to deploy the `postgresql-connect-integrator` charm to enable integration of PostgreSQL and Kafka Connect applications. 
 First, deploy the charm in `source` mode using the `juju deploy` command and provide the minimum necessary configurations:
@@ -279,7 +277,7 @@ postgresql-connect-integrator/0*  active    idle   13       10.38.169.83    8080
 This means that the integrator application is actively copying data from the source database (named `tutorial`) into Apache Kafka topics prefixed with `etl_`. 
 For example, rows in the `posts` table will be published into the Apache Kafka topic named `etl_posts`.
 
-### Deploy and integrate the `opensearch-connect-integrator` charm
+## Deploy and integrate the `opensearch-connect-integrator` charm
 
 You are almost done with the ETL task, the only remaining part is to move data from Apache Kafka to OpenSearch. 
 To do that, deploy another Kafka Connect integrator named `opensearch-connect-integrator` in the `sink` mode:
@@ -310,7 +308,7 @@ postgresql-connect-integrator/0*  active    idle   13       10.38.169.83    8080
 ...
 ```
 
-### Verify data transfer
+## Verify data transfer
 
 Now it's time to verify that the data is being copied from the PostgreSQL database to the OpenSearch index. 
 We can use the OpenSearch REST API for that purpose.
@@ -404,4 +402,3 @@ Which now should have six hits (output is truncated):
 ```
 
 Congratulations! You have successfully completed an ETL job that continuously moves data from PostgreSQL to OpenSearch, using entirely charmed solutions.
-


### PR DESCRIPTION
Fix Tutorial Titles numeration.
Fix Tutorial heading levels (Title of a page could have been duplicated as h2 when migrated from Discourse).
Adjust Tutorial index page syntax for more robustness with include directive, title, and anchors.