### PR TITLE
[DPE-7522] feat: add HA during CA rotation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,7 @@ jobs:
           - integration-password-rotation
           - integration-tls
           - integration-refresh
+          - integration-tls-complex
           - integration-kraft
           - integration-kraft-tls
           - integration-ha
@@ -137,6 +138,7 @@ jobs:
           - integration-password-rotation
           - integration-tls
           - integration-refresh
+          - integration-tls-complex
           - integration-balancer-single
           - integration-balancer-multi
           - integration-kraft

--- a/src/charm.py
+++ b/src/charm.py
@@ -175,6 +175,9 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         time.sleep(10.0)
         self.broker.update_credentials_cache()
 
+        # Force update our trusted certs relation data.
+        self.broker.update_peer_truststore_state(force=True)
+
     def _disable_enable_restart_broker(self, event: RunWithLock) -> None:
         """Handler for `rolling_ops` disable_enable restart events.
 

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -506,7 +506,7 @@ class ClusterState(Object):
         """Check for active controller relation and adding of inter-broker auth username.
 
         Returns:
-            True if ZK is related and `sync` user has been added. False otherwise.
+            True if controller is related and `sync` user has been added. False otherwise.
         """
         if not self.peer_relation:
             return Status.NO_PEER_RELATION
@@ -756,7 +756,6 @@ class ClusterState(Object):
         if not (relation := self.kraft_cluster.relation):
             return False
 
-        return (
-            relation.data[relation.app].get("peer-cluster-rotate") == "true"
-            and self.cluster.relation_data.get("peer-cluster-rotate") == "true"
+        return relation.data[relation.app].get("peer-cluster-rotate") == "true" and any(
+            unit.peer_certs.rotate for unit in self.brokers
         )

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -735,7 +735,7 @@ class ClusterState(Object):
         if not relation:
             return False
 
-        return relation.data[relation.app].get("peer-cluser-rotate") == "true"
+        return relation.data[relation.app].get("peer-cluster-rotate") == "true"
 
     @peer_cluster_tls_rotate.setter
     def peer_cluster_tls_rotate(self, value: bool) -> None:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -595,6 +595,23 @@ class TLSState:
         self.relation_state.update({f"{self.scope.value}-rotation": _value})
 
     @property
+    def trusted_certificates(self) -> set[str]:
+        """Returns a list of certificate fingeprints loaded into this unit's truststore."""
+        trust_list = json.loads(self.relation_data.get(f"{self.scope.value}-trust", "null")) or []
+        return set(trust_list)
+
+    @trusted_certificates.setter
+    def trusted_certificates(self, value: str | list[str]) -> None:
+        _value = [value] if isinstance(value, str) else value
+        _value.sort()
+        _value = json.dumps(_value)
+
+        if set(_value) == self.trusted_certificates:
+            return
+
+        self.relation_state.update({f"{self.scope.value}-trust": _value})
+
+    @property
     def ready(self) -> bool:
         """Returns True if all the necessary TLS relation data has been set, False otherwise."""
         return all([self.certificate, self.ca, self.private_key])

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -603,11 +603,12 @@ class TLSState:
     @trusted_certificates.setter
     def trusted_certificates(self, value: str | list[str]) -> None:
         _value = [value] if isinstance(value, str) else value
-        _value.sort()
-        _value = json.dumps(_value)
 
         if set(_value) == self.trusted_certificates:
             return
+
+        _value.sort()
+        _value = json.dumps(_value)
 
         self.relation_state.update({f"{self.scope.value}-trust": _value})
 

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -183,6 +183,11 @@ class WorkloadBase(ABC):
         ...
 
     @abstractmethod
+    def modify_time(self, file: str) -> float:
+        """Returns the last modify time of a file on the workload in UNIX timestamp format."""
+        ...
+
+    @abstractmethod
     def run_bin_command(self, bin_keyword: str, bin_args: list[str], opts: list[str] = []) -> str:
         """Runs kafka bin command with desired args.
 
@@ -213,6 +218,12 @@ class WorkloadBase(ABC):
     @abstractmethod
     def container_can_connect(self) -> bool:
         """Flag to check if workload container can connect."""
+        ...
+
+    @property
+    @abstractmethod
+    def last_restart(self) -> float:
+        """Returns a UNIX timestamp of last time the service was restarted."""
         ...
 
     @staticmethod

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -5,8 +5,10 @@
 """Supporting objects for Kafka charm state."""
 
 import secrets
+import socket
 import string
 from abc import ABC, abstractmethod
+from contextlib import closing
 
 from charmlibs import pathops
 from ops.pebble import Layer
@@ -235,3 +237,24 @@ class WorkloadBase(ABC):
             String of 32 randomized letter+digit characters
         """
         return "".join([secrets.choice(string.ascii_letters + string.digits) for _ in range(32)])
+
+    @staticmethod
+    def ping(bootstrap_nodes: str) -> bool:
+        """Check if any socket in `bootstrap_nodes` is available or not.
+
+        Args:
+            bootstrap_nodes (str): A string representation of bootstrap nodes, in the format: host1:port1,host2:port2,...
+
+        Returns:
+            bool: True if any socket is open.
+        """
+        for host_port in bootstrap_nodes.split(","):
+            if ":" not in host_port:
+                continue
+
+            host, port = host_port.split(":")
+            with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+                if sock.connect_ex((host, int(port))) == 0:
+                    return True
+
+        return False

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -173,6 +173,7 @@ class WorkloadBase(ABC):
         command: list[str] | str,
         env: dict[str, str] | None = None,
         working_dir: str | None = None,
+        log_on_error: bool = True,
     ) -> str:
         """Runs a command on the workload substrate."""
         ...

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -535,7 +535,7 @@ class BrokerOperator(Object):
             self.auth_manager.add_user(client.username, client.password)
 
     def update_peer_truststore_state(self, force: bool = False) -> None:
-        """Updates the relation data pertinent to the unit/app truststore state on respective data bags.
+        """Updates the relation data reflecting the unit/app truststore state on respective data bags.
 
         Args:
             force (bool, optional): Bypass the check of whether a restart is performed after truststore modification time. Defaults to False.

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -244,8 +244,19 @@ class BrokerOperator(Object):
         # update environment
         self.config_manager.set_environment()
 
-        # Update peer-cluster trusted certs and check for TLS rotation
+        # Update peer-cluster trusted certs and check for TLS rotation on the other side.
+        old_peer_certs = self.tls_manager.peer_trusted_certificates.values()
         self.tls_manager.update_peer_cluster_trust()
+        new_peer_certs = self.tls_manager.peer_trusted_certificates.values()
+        peer_cluster_tls_rotate = set(new_peer_certs) - set(old_peer_certs)
+
+        if (
+            self.charm.state.tls_rotate
+            and not self.tls_manager.peer_cluster_app_trusts_new_bundle()
+        ):
+            # we should wait for the other side to finish rolling restart.
+            event.defer()
+            return
 
         if sans_ip_changed or sans_dns_changed:
             logger.info(
@@ -273,7 +284,7 @@ class BrokerOperator(Object):
             )
             self.config_manager.set_server_properties()
 
-        if properties_changed or self.charm.state.tls_rotate:
+        if any([properties_changed, self.charm.state.tls_rotate, peer_cluster_tls_rotate]):
             if isinstance(event, StorageEvent):  # to get new storages
                 self.controller_manager.format_storages(
                     uuid=self.charm.state.peer_cluster.cluster_uuid,
@@ -299,6 +310,7 @@ class BrokerOperator(Object):
             )
 
         # Update truststore if needed.
+        self.update_peer_truststore_state()
         self.charm.tls.update_truststore()
 
         if self.charm.state.tls_rotate:
@@ -327,6 +339,15 @@ class BrokerOperator(Object):
         # NOTE for situations like IP change and late integration with rack-awareness charm.
         # If properties have changed, the broker will restart.
         self.charm.on.config_changed.emit()
+
+        # remove temporary trust aliases if they're no longer needed.
+        if (
+            self.tls_manager.has_temporary_trust_aliases
+            and self.tls_manager.both_apps_trust_new_bundle()
+        ):
+            logger.info("Removing decommissioned CA from truststore.")
+            self.tls_manager.rebuild_truststore()
+            self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
 
         try:
             if self.health and not self.health.machine_configured():
@@ -512,3 +533,30 @@ class BrokerOperator(Object):
                 continue
 
             self.auth_manager.add_user(client.username, client.password)
+
+    def update_peer_truststore_state(self, force: bool = False) -> None:
+        """Updates the relation data pertinent to the unit/app truststore state on respective data bags.
+
+        Args:
+            force (bool, optional): Bypass the check of whether a restart is performed after truststore modification time. Defaults to False.
+        """
+        truststore_path = self.workload.root / self.workload.paths.peer_truststore
+
+        if not truststore_path.exists():
+            return
+
+        if not force and self.workload.last_restart <= self.workload.modify_time(
+            self.workload.paths.peer_truststore
+        ):
+            # We shouldn't update the relation data, because we need a restart first.
+            return
+
+        trusted_certs = [
+            self.tls_manager.bytes_to_keytool_hash(_hash, sep="")
+            for _hash in self.tls_manager.peer_trusted_certificates.values()
+        ]
+
+        self.charm.state.unit_broker.peer_certs.trusted_certificates = trusted_certs
+
+        if self.charm.unit.is_leader():
+            self.charm.state.refresh_peer_cluster_trust_state()

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -263,7 +263,6 @@ class BrokerOperator(Object):
                 logger.debug(
                     "Both sides are rotating TLS certificates, initiating rolling restart..."
                 )
-                logger.info("$$$$$$$$$$$$$$$$ TIE BREAK!")
                 should_defer = False
 
             if should_defer:

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -342,7 +342,7 @@ class BrokerOperator(Object):
 
         # remove temporary trust aliases if they're no longer needed.
         if (
-            self.tls_manager.has_temporary_trust_aliases
+            self.tls_manager.peer_truststore_has_temporary_aliases
             and self.tls_manager.both_apps_trust_new_bundle()
         ):
             logger.info("Removing decommissioned CA from truststore.")

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -331,6 +331,9 @@ class BrokerOperator(Object):
 
             # Reset TLS rotation state
             self.charm.state.tls_rotate = False
+
+        # Turn off peer-cluster TLS rotate if all units are done, only run on leader unit
+        if not any(unit.peer_certs.rotate for unit in self.charm.state.brokers):
             self.charm.state.peer_cluster_tls_rotate = False
 
         if self.charm.unit.is_leader():

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -114,16 +114,19 @@ class PeerClusterEventsHandler(Object):
         # Update peer-cluster chain of trust
         self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_certs.bundle
 
+        # Optimization: cache peer_cluster to avoid multiple loadings
+        peer_cluster_state = self.charm.state.peer_cluster
+
         # will no-op if relation does not exist
         self.charm.state.peer_cluster.update(
             {
-                "balancer-username": self.charm.state.peer_cluster.balancer_username,
-                "balancer-password": self.charm.state.peer_cluster.balancer_password,
-                "balancer-uris": self.charm.state.peer_cluster.balancer_uris,
-                "controller-password": self.charm.state.peer_cluster.controller_password,
-                "bootstrap-controller": self.charm.state.peer_cluster.bootstrap_controller,
-                "bootstrap-unit-id": self.charm.state.peer_cluster.bootstrap_unit_id,
-                "bootstrap-replica-id": self.charm.state.peer_cluster.bootstrap_replica_id,
+                "balancer-username": peer_cluster_state.balancer_username,
+                "balancer-password": peer_cluster_state.balancer_password,
+                "balancer-uris": peer_cluster_state.balancer_uris,
+                "controller-password": peer_cluster_state.controller_password,
+                "bootstrap-controller": peer_cluster_state.bootstrap_controller,
+                "bootstrap-unit-id": peer_cluster_state.bootstrap_unit_id,
+                "bootstrap-replica-id": peer_cluster_state.bootstrap_replica_id,
             }
         )
 
@@ -147,16 +150,19 @@ class PeerClusterEventsHandler(Object):
         # Update peer-cluster chain of trust
         self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_certs.bundle
 
+        # Optimization: cache peer_cluster to avoid multiple loadings
+        peer_cluster_state = self.charm.state.peer_cluster
+
         # will no-op if relation does not exist
         self.charm.state.peer_cluster.update(
             {
                 "roles": self.charm.state.roles,
-                "broker-username": self.charm.state.peer_cluster.broker_username,
-                "broker-password": self.charm.state.peer_cluster.broker_password,
-                "broker-uris": self.charm.state.peer_cluster.broker_uris,
-                "cluster-uuid": self.charm.state.peer_cluster.cluster_uuid,
-                "racks": str(self.charm.state.peer_cluster.racks),
-                "broker-capacities": json.dumps(self.charm.state.peer_cluster.broker_capacities),
+                "broker-username": peer_cluster_state.broker_username,
+                "broker-password": peer_cluster_state.broker_password,
+                "broker-uris": peer_cluster_state.broker_uris,
+                "cluster-uuid": peer_cluster_state.cluster_uuid,
+                "racks": str(peer_cluster_state.racks),
+                "broker-capacities": json.dumps(peer_cluster_state.broker_capacities),
                 "super-users": self.charm.state.super_users,
             }
         )

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -22,6 +22,7 @@ from ops.charm import (
     RelationCreatedEvent,
     RelationEvent,
     SecretChangedEvent,
+    UpdateStatusEvent,
 )
 from ops.framework import Object
 
@@ -167,7 +168,8 @@ class PeerClusterEventsHandler(Object):
             }
         )
 
-        self.charm.on.config_changed.emit()  # ensure both broker+balancer get a changed event
+        if not isinstance(event, UpdateStatusEvent):
+            self.charm.on.config_changed.emit()  # ensure both broker+balancer get a changed event
 
     def _on_peer_cluster_broken(self, _: RelationBrokenEvent):
         """Handle the required logic to remove."""

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -2,9 +2,10 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Manager for handling Kafka TLS configuration."""
+"""Handler for TLS/mTLS events."""
 
 import base64
+import copy
 import json
 import logging
 import re
@@ -37,6 +38,7 @@ from literals import (
     Status,
     TLSScope,
 )
+from managers.tls import TLSManager
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
@@ -171,6 +173,7 @@ class TLSHandler(Object):
         )
 
         # clear TLS state
+        old_bundle = copy.deepcopy(state.bundle)
         state.csr = ""
         state.certificate = ""
         state.chain = ""
@@ -183,6 +186,12 @@ class TLSHandler(Object):
         if state.scope == TLSScope.PEER:
             # switch back to internal TLS
             self.charm.broker.setup_internal_tls()
+
+            # Keep the old bundle
+            for dependent in ["broker", "balancer"]:
+                getattr(self.charm, dependent).tls_manager.import_bundle(
+                    bundle=old_bundle, scope=state.scope, alias_prefix=TLSManager.OLD_PREFIX
+                )
 
             state.rotate = True
             self.charm.on.config_changed.emit()
@@ -208,6 +217,8 @@ class TLSHandler(Object):
         if state.ca and event.ca.raw != state.ca:
             ca_changed = True
 
+        old_bundle = copy.deepcopy(state.bundle)
+
         state.certificate = event.certificate.raw
         state.ca = event.ca.raw
         state.chain = json.dumps([certificate.raw for certificate in event.chain])
@@ -215,6 +226,12 @@ class TLSHandler(Object):
         for dependent in ["broker", "balancer"]:
             getattr(self.charm, dependent).tls_manager.remove_stores(scope=state.scope)
             getattr(self.charm, dependent).tls_manager.configure()
+
+            if ca_changed:
+                # Keep the old bundle
+                getattr(self.charm, dependent).tls_manager.import_bundle(
+                    bundle=old_bundle, scope=state.scope, alias_prefix=TLSManager.OLD_PREFIX
+                )
 
         if certificate_changed or ca_changed:
             # this will trigger a restart.

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -248,6 +248,10 @@ class TLSHandler(Object):
             # Update peer-cluster CA/chain.
             self.charm.state.peer_cluster_ca = self.charm.state.unit_broker.peer_certs.bundle
 
+            # Inform the peer-cluster app of the rotate
+            if self.requirer_state(self.peer_certificates).rotate:
+                self.charm.state.peer_cluster_tls_rotate = True
+
         self.charm.on.config_changed.emit()
 
     def _on_client_certificate_available(self, event: CertificateAvailableEvent) -> None:

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -186,7 +186,7 @@ class AuthManager:
                 bin_keyword="configs", bin_args=command, opts=[self.log4j_opts]
             )
         except (subprocess.CalledProcessError, ExecError) as e:
-            if e.stderr and "delete a user credential that does not exist" in e.stderr:
+            if "delete a user credential that does not exist" in f"{e.stdout} {e.stderr}":
                 logger.warning(f"User: {username} can't be deleted, it does not exist")
                 return
             raise

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -37,6 +37,7 @@ from literals import (
     PATHS,
     PROFILE_TESTING,
     SECURITY_PROTOCOL_PORTS,
+    SUBSTRATE,
     AuthMap,
     Scope,
 )
@@ -284,6 +285,9 @@ class CommonConfigManager:
     @property
     def auxiliary_paths(self) -> list[str]:
         """Auxiliary environment variables for logs, config and other useful base paths."""
+        if SUBSTRATE == "k8s":
+            return []
+
         if self.state.runs_broker or self.state.runs_controller:
             return [f"{key}={path}" for key, path in PATHS["kafka"].items()]
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -216,6 +216,7 @@ class TLSManager:
             state = self.get_state(scope)
             self.import_bundle(bundle=state.bundle, scope=scope)
 
+            # Exit early if the bundle was empty and no truststore file is created.
             if not (self.workload.root / self.get_truststore_path(scope)).exists():
                 continue
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -588,7 +588,10 @@ class TLSManager:
 
     def rebuild_truststore(self) -> None:
         """Destroys and rebuilds peer (internal) truststore."""
-        (self.workload.root / self.workload.paths.peer_truststore).unlink()
+        try:
+            (self.workload.root / self.workload.paths.peer_truststore).unlink()
+        except FileNotFoundError:
+            pass
         self.set_truststore()
         self.update_peer_cluster_trust()
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -309,7 +309,9 @@ class TLSManager:
             "-noprompt",
         ]
         try:
-            self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
+            self.workload.exec(
+                command=command, working_dir=self.workload.paths.conf_path, log_on_error=False
+            )
         except (subprocess.CalledProcessError, ExecError) as e:
             # in case this reruns and fails
             if e.stdout and "already exists" in e.stdout:
@@ -355,7 +357,9 @@ class TLSManager:
                 f"{self.state.unit_broker.truststore_password}",
                 "-noprompt",
             ]
-            self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
+            self.workload.exec(
+                command=command, working_dir=self.workload.paths.conf_path, log_on_error=False
+            )
             self.workload.exec(
                 f"rm -f {scope.value}-{alias}.pem".split(),
                 working_dir=self.workload.paths.conf_path,

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -43,7 +43,8 @@ class TLSManager:
 
     DEFAULT_HASH_ALGORITHM: hashes.HashAlgorithm = hashes.SHA256()
     SCOPES = (TLSScope.PEER, TLSScope.CLIENT)
-    TEMP_ALIAS_PREFIX = "new-"
+    OLD_PREFIX = "old-"
+    NEW_PREFIX = "new-"
     PEER_CLUSTER_ALIAS = "cluster-tls"
 
     def __init__(
@@ -210,38 +211,18 @@ class TLSManager:
                 )
 
     def set_truststore(self) -> None:
-        """Adds CA to JKS truststore."""
+        """Adds bundle to JKS truststore."""
         for scope in self.SCOPES:
             state = self.get_state(scope)
+            self.import_bundle(bundle=state.bundle, scope=scope)
 
-            trust_aliases = [f"bundle{i}" for i in range(len(state.bundle))]
-            for alias in trust_aliases:
-                command = [
-                    self.keytool,
-                    "-import",
-                    "-v",
-                    "-alias",
-                    alias,
-                    "-file",
-                    f"{scope.value}-{alias}.pem",
-                    "-keystore",
-                    f"{scope.value}-truststore.jks",
-                    "-storepass",
-                    f"{self.state.unit_broker.truststore_password}",
-                    "-noprompt",
-                ]
-                try:
-                    self.workload.exec(command=command, working_dir=self.workload.paths.conf_path)
-                    self.workload.exec(
-                        f"chown {USER_NAME}:{GROUP} {self.get_truststore_path(scope)}".split()
-                    )
-                    self.workload.exec(f"chmod 770 {self.get_truststore_path(scope)}".split())
-                except (subprocess.CalledProcessError, ExecError) as e:
-                    # in case this reruns and fails
-                    if e.stdout and "already exists" in e.stdout:
-                        continue
-                    logger.error(e.stdout)
-                    raise e
+            if not (self.workload.root / self.get_truststore_path(scope)).exists():
+                continue
+
+            self.workload.exec(
+                f"chown {USER_NAME}:{GROUP} {self.get_truststore_path(scope)}".split()
+            )
+            self.workload.exec(f"chmod 770 {self.get_truststore_path(scope)}".split())
 
     def set_keystore(self) -> None:
         """Creates and adds unit cert and private-key to the keystore."""
@@ -281,12 +262,8 @@ class TLSManager:
                 raise e
 
     def update_peer_cluster_trust(self) -> None:
-        """Updates peer truststore with current state of peer-cluster certificate chain.
-
-        This method will toggle the TLS rotation state variable if certificate change is detected in the peer-cluster relationship.
-        """
+        """Updates peer truststore with current state of peer-cluster certificate chain."""
         bundle = self.state.peer_cluster_ca
-        state = self.get_state(TLSScope.PEER)
 
         if not bundle:
             return
@@ -297,7 +274,10 @@ class TLSManager:
                 continue
 
             alias = f"{self.PEER_CLUSTER_ALIAS}{i}"
-            state.rotate = True
+
+            if alias in trusted_certs:
+                # we should use the `new-` prefix to keep old and new bundles
+                alias = f"{self.NEW_PREFIX}{alias}"
 
             self.update_cert(alias=alias, cert=cert, scope=TLSScope.PEER)
 
@@ -337,6 +317,28 @@ class TLSManager:
                 return
             logger.error(e.stdout)
             raise e
+
+    def import_bundle(self, bundle: list[str], scope: TLSScope, alias_prefix: str = "") -> None:
+        """Add a list (bundle) of certificates to the truststore.
+
+        Args:
+            bundle (list[str]): certificate bundle to import
+            scope (TLSScope): TLS scope to use
+            alias_prefix (str, optional): an optional prefix to be prepended to the imported aliases. Defaults to "".
+        """
+        if not bundle:
+            return
+
+        for i, certificate in enumerate(bundle):
+
+            alias = f"{alias_prefix}bundle{i}"
+            filename = f"{scope.value}-{alias}.pem"
+            file_path = self.workload.root / self.workload.paths.conf_path / filename
+
+            if not file_path.exists():
+                self.workload.write(content=certificate, path=f"{file_path}")
+
+            self.import_cert(alias=alias, filename=filename, scope=scope)
 
     def remove_cert(self, alias: str, scope: TLSScope = TLSScope.CLIENT) -> None:
         """Remove a cert from the truststore."""
@@ -544,6 +546,50 @@ class TLSManager:
             for match in re.findall("(.+?),.+?trustedCertEntry.*?\n.+?([0-9a-fA-F:]{95})\n", raw)
         }
 
+    def peer_cluster_app_trusts_new_bundle(self) -> bool:
+        """Checks whether the peer-cluster (remote) app has loaded this (local) app's cert bundle or not."""
+        if self.state.runs_broker and self.state.runs_controller:
+            # Not applicable for KRaft single mode
+            return True
+
+        for certificate in self.state.unit_broker.peer_certs.bundle:
+            if self.is_valid_leaf_certificate(certificate):
+                # peer-cluster app does not need to trust leaf certificates,
+                # only chain & CA certs should be trusted.
+                continue
+
+            hash_bytes = self.certificate_fingerprint(certificate)
+            if (
+                self.bytes_to_keytool_hash(hash_bytes)
+                not in self.state.trusted_by_peer_cluster_app
+            ):
+                return False
+
+        return True
+
+    def both_apps_trust_new_bundle(self) -> bool:
+        """During a TLS rotation, checks whether new bundle is added to the truststore and a restart is done."""
+        common_truststore = self.state.trusted_by_our_app & self.state.trusted_by_peer_cluster_app
+        bundles = self.state.unit_broker.peer_certs.bundle + self.state.peer_cluster_ca
+
+        for certificate in bundles:
+            if self.is_valid_leaf_certificate(certificate):
+                # peer-cluster app does not need to trust leaf certificates,
+                # only chain & CA certs should be trusted.
+                continue
+
+            hash_bytes = self.certificate_fingerprint(certificate)
+            if self.bytes_to_keytool_hash(hash_bytes) not in common_truststore:
+                return False
+
+        return True
+
+    def rebuild_truststore(self) -> None:
+        """Destroys and rebuilds peer (internal) truststore."""
+        (self.workload.root / self.workload.paths.peer_truststore).unlink()
+        self.set_truststore()
+        self.update_peer_cluster_trust()
+
     @staticmethod
     def is_valid_leaf_certificate(cert: str) -> bool:
         """Validates if `cert` is a valid leaf certificate (not a CA)."""
@@ -585,6 +631,11 @@ class TLSManager:
         """Converts a hash in the keytool format (AB:CD:0F:...) to a bytes object."""
         return bytes([int(s, 16) for s in hash.split(":")])
 
+    @staticmethod
+    def bytes_to_keytool_hash(hash_bytes: bytes, sep: str = "") -> str:
+        """Converts a bytes object to keytool hash format (AB:CD:0F:...), with customizable separator."""
+        return sep.join(hex(b)[2:] for b in hash_bytes).upper()
+
     @property
     def trusted_certificates(self) -> dict[str, bytes]:
         """Returns a mapping of alias to certificate fingerprint (hash) for all the certificates loaded in the CLIENT truststore."""
@@ -594,3 +645,12 @@ class TLSManager:
     def peer_trusted_certificates(self) -> dict[str, bytes]:
         """Returns a mapping of alias to certificate fingerprint (hash) for all the certificates loaded in the PEER truststore."""
         return self.get_trusted_certificates(self.workload.paths.peer_truststore)
+
+    @property
+    def has_temporary_trust_aliases(self) -> bool:
+        """Returns True if any temporary/TLS rotation-related cert is loaded into the peer (internal) truststore."""
+        for alias in self.peer_trusted_certificates:
+            if alias.startswith(self.OLD_PREFIX) or alias.startswith(self.NEW_PREFIX):
+                return True
+
+        return False

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -648,7 +648,7 @@ class TLSManager:
         return self.get_trusted_certificates(self.workload.paths.peer_truststore)
 
     @property
-    def has_temporary_trust_aliases(self) -> bool:
+    def peer_truststore_has_temporary_aliases(self) -> bool:
         """Returns True if any temporary/TLS rotation-related cert is loaded into the peer (internal) truststore."""
         for alias in self.peer_trusted_certificates:
             if alias.startswith(self.OLD_PREFIX) or alias.startswith(self.NEW_PREFIX):

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -328,9 +328,6 @@ class TLSManager:
             scope (TLSScope): TLS scope to use
             alias_prefix (str, optional): an optional prefix to be prepended to the imported aliases. Defaults to "".
         """
-        if not bundle:
-            return
-
         for i, certificate in enumerate(bundle):
 
             alias = f"{alias_prefix}bundle{i}"

--- a/src/workload.py
+++ b/src/workload.py
@@ -90,6 +90,7 @@ class Workload(WorkloadBase):
         command: list[str] | str,
         env: Mapping[str, str] | None = None,
         working_dir: str | None = None,
+        log_on_error: bool = True,
     ) -> str:
         try:
             output = subprocess.check_output(
@@ -103,7 +104,8 @@ class Workload(WorkloadBase):
             logger.debug(f"{output=}")
             return output
         except subprocess.CalledProcessError as e:
-            logger.error(f"cmd failed - cmd={e.cmd}, stdout={e.stdout}, stderr={e.stderr}")
+            if log_on_error:
+                logger.error(f"cmd failed - cmd={e.cmd}, stdout={e.stdout}, stderr={e.stderr}")
             raise e
 
     @override

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import logging
 import os
 import pathlib
 import subprocess

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -113,9 +113,6 @@ async def _build_charm(self, charm_path: typing.Union[str, os.PathLike]) -> path
 # -- Jubilant --
 
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
-
 @pytest.fixture(scope="module")
 def juju(request: pytest.FixtureRequest):
     model = request.config.getoption("--model")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -124,7 +124,7 @@ def juju(request: pytest.FixtureRequest):
     if model is None:
         with jubilant.temp_model(keep=keep_models) as juju:
             juju.wait_timeout = 10 * 60
-            juju.model_config({"update-status-hook-interval": "90s"})
+            juju.model_config({"update-status-hook-interval": "180s"})
             yield juju
 
             log = juju.debug_log(limit=1000)

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -4,6 +4,8 @@
 import asyncio
 import logging
 import os
+import pathlib
+import tempfile
 import time
 from dataclasses import dataclass
 from multiprocessing import Event, Process, Queue
@@ -177,8 +179,26 @@ class ContinuousWrites:
             servers=relation_data["endpoints"].split(","),
             username=relation_data["username"],
             password=relation_data["password"],
-            security_protocol="SASL_PLAINTEXT",
+            **self.generate_client_security_config(relation_data),
+            replication_factor=3,
         )
+
+    @staticmethod
+    def generate_client_security_config(provider_data: dict) -> dict[str, str]:
+        """Generate security_protocol, cafile_path and certfile_path config for KafkaClient."""
+        _kwargs = {"security_protocol": "SASL_PLAINTEXT"}
+
+        if provider_data.get("tls") == "enabled":
+            broker_ca = provider_data.get("tls-ca", "")
+            _, filename = tempfile.mkstemp()
+            tmp_file = pathlib.Path(filename)
+            tmp_file.write_text(broker_ca)
+            _kwargs = {
+                "security_protocol": "SASL_SSL",
+                "cafile_path": f"{tmp_file}",
+                "certfile_path": f"{tmp_file}",
+            }
+        return _kwargs
 
     @staticmethod
     async def _run(
@@ -197,7 +217,8 @@ class ContinuousWrites:
                 servers=relation_data["endpoints"].split(","),
                 username=relation_data["username"],
                 password=relation_data["password"],
-                security_protocol="SASL_PLAINTEXT",
+                **ContinuousWrites.generate_client_security_config(relation_data),
+                replication_factor=3,
             )
 
         write_value = starting_number

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -242,6 +242,8 @@ class ContinuousWrites:
                 time.sleep(0.1)
 
     @staticmethod
-    def _run_async(event: Event, data_queue: Queue, starting_number: int, model: str, produce_rate: float):
+    def _run_async(
+        event: Event, data_queue: Queue, starting_number: int, model: str, produce_rate: float
+    ):
         """Run async code."""
         asyncio.run(ContinuousWrites._run(event, data_queue, starting_number, model, produce_rate))

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -113,7 +113,11 @@ class ContinuousWrites:
             num_partitions=1,
             replication_factor=3,
         )
-        client.create_topic(topic=topic_config)
+        try:
+            client.create_topic(topic=topic_config)
+        except TopicAlreadyExistsError:
+            self.clear()
+            client.create_topic(topic=topic_config)
 
     @retry(
         wait=wait_fixed(wait=5) + wait_random(0, 5),

--- a/tests/integration/helpers/__init__.py
+++ b/tests/integration/helpers/__init__.py
@@ -1,8 +1,11 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
+import tempfile
 from enum import Enum
 from pathlib import Path
+from subprocess import PIPE, CalledProcessError, check_output
 from typing import Literal
 
 import yaml
@@ -30,6 +33,9 @@ class KRaftUnitStatus(Enum):
     OBSERVER = "Observer"
 
 
+logger = logging.getLogger(__name__)
+
+
 def unit_id_to_broker_id(unit_id: int) -> int:
     """Converts unit id to broker id in KRaft mode."""
     return KRAFT_NODE_ID_OFFSET + unit_id
@@ -38,3 +44,34 @@ def unit_id_to_broker_id(unit_id: int) -> int:
 def broker_id_to_unit_id(broker_id: int) -> int:
     """Converts broker id to unit id in KRaft mode."""
     return broker_id - KRAFT_NODE_ID_OFFSET
+
+
+def sign_manual_certs(model: str | None, manual_app: str = "manual-tls-certificates") -> None:
+    delim = "-----BEGIN CERTIFICATE REQUEST-----"
+
+    csrs_cmd = f"JUJU_MODEL={model} juju run {manual_app}/0 get-outstanding-certificate-requests --format=json | jq -r '.[\"{manual_app}/0\"].results.result' | jq '.[].csr' | sed 's/\\\\n/\\n/g' | sed 's/\\\"//g'"
+    csrs = check_output(csrs_cmd, stderr=PIPE, universal_newlines=True, shell=True).split(delim)
+
+    for i, csr in enumerate(csrs):
+        if not csr:
+            continue
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            csr_file = tmp_dir / f"csr{i}"
+            csr_file.write_text(delim + csr)
+
+            cert_file = tmp_dir / f"{i}.pem"
+
+            try:
+                sign_cmd = f"openssl x509 -req -in {csr_file} -CAkey tests/integration/data/int.key -CA tests/integration/data/int.pem -days 100 -CAcreateserial -out {cert_file} -copy_extensions copyall --passin pass:password"
+                provide_cmd = f'JUJU_MODEL={model} juju run {manual_app}/0 provide-certificate ca-certificate="$(base64 -w0 tests/integration/data/int.pem)" ca-chain="$(base64 -w0 tests/integration/data/root.pem)" certificate="$(base64 -w0 {cert_file})" certificate-signing-request="$(base64 -w0 {csr_file})"'
+
+                check_output(sign_cmd, stderr=PIPE, universal_newlines=True, shell=True)
+                response = check_output(
+                    provide_cmd, stderr=PIPE, universal_newlines=True, shell=True
+                )
+                logger.info(f"{response=}")
+            except CalledProcessError as e:
+                logger.error(f"{e.stdout=}, {e.stderr=}, {e.output=}")
+                raise e

--- a/tests/integration/helpers/ha.py
+++ b/tests/integration/helpers/ha.py
@@ -18,6 +18,7 @@ from integration.helpers.pytest_operator import check_socket, get_unit_ipv4_addr
 from literals import KRAFT_NODE_ID_OFFSET, PATHS, SECURITY_PROTOCOL_PORTS
 
 CONTROLLER_PORT = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].controller
+BROKER_PORT = SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
 PROCESS = "kafka.Kafka"
 SERVICE_DEFAULT_PATH = "/etc/systemd/system/snap.charmed-kafka.daemon.service"
 RESTART_DELAY = 60
@@ -275,12 +276,14 @@ def all_listeners_up(
     raise TimeoutError()
 
 
-def assert_all_brokers_up(juju: jubilant.Juju, timeout_seconds: int = 600) -> None:
+def assert_all_brokers_up(
+    juju: jubilant.Juju, timeout_seconds: int = 600, port: int = BROKER_PORT
+) -> None:
     """Waits until client listeners are up on all broker units."""
     return all_listeners_up(
         juju=juju,
         app_name=APP_NAME,
-        listener_port=SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client,
+        listener_port=port,
         timeout_seconds=timeout_seconds,
     )
 

--- a/tests/integration/helpers/pytest_operator.py
+++ b/tests/integration/helpers/pytest_operator.py
@@ -7,7 +7,6 @@ import logging
 import re
 import socket
 import subprocess
-import tempfile
 from contextlib import closing
 from json.decoder import JSONDecodeError
 from pathlib import Path
@@ -698,37 +697,6 @@ def kraft_quorum_status(
         logger.debug(f"{unit_status=}")
 
     return unit_status
-
-
-def sign_manual_certs(ops_test: OpsTest, manual_app: str = "manual-tls-certificates") -> None:
-    delim = "-----BEGIN CERTIFICATE REQUEST-----"
-
-    csrs_cmd = f"JUJU_MODEL={ops_test.model_full_name} juju run {manual_app}/0 get-outstanding-certificate-requests --format=json | jq -r '.[\"{manual_app}/0\"].results.result' | jq '.[].csr' | sed 's/\\\\n/\\n/g' | sed 's/\\\"//g'"
-    csrs = check_output(csrs_cmd, stderr=PIPE, universal_newlines=True, shell=True).split(delim)
-
-    for i, csr in enumerate(csrs):
-        if not csr:
-            continue
-
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_dir = Path(tmp)
-            csr_file = tmp_dir / f"csr{i}"
-            csr_file.write_text(delim + csr)
-
-            cert_file = tmp_dir / f"{i}.pem"
-
-            try:
-                sign_cmd = f"openssl x509 -req -in {csr_file} -CAkey tests/integration/data/int.key -CA tests/integration/data/int.pem -days 100 -CAcreateserial -out {cert_file} -copy_extensions copyall --passin pass:password"
-                provide_cmd = f'JUJU_MODEL={ops_test.model_full_name} juju run {manual_app}/0 provide-certificate ca-certificate="$(base64 -w0 tests/integration/data/int.pem)" ca-chain="$(base64 -w0 tests/integration/data/root.pem)" certificate="$(base64 -w0 {cert_file})" certificate-signing-request="$(base64 -w0 {csr_file})"'
-
-                check_output(sign_cmd, stderr=PIPE, universal_newlines=True, shell=True)
-                response = check_output(
-                    provide_cmd, stderr=PIPE, universal_newlines=True, shell=True
-                )
-                logger.info(f"{response=}")
-            except CalledProcessError as e:
-                logger.error(f"{e.stdout=}, {e.stderr=}, {e.output=}")
-                raise e
 
 
 async def list_truststore_aliases(

--- a/tests/integration/helpers/pytest_operator.py
+++ b/tests/integration/helpers/pytest_operator.py
@@ -731,12 +731,14 @@ def sign_manual_certs(ops_test: OpsTest, manual_app: str = "manual-tls-certifica
                 raise e
 
 
-async def list_truststore_aliases(ops_test: OpsTest, unit: str = f"{APP_NAME}/0") -> list[str]:
+async def list_truststore_aliases(
+    ops_test: OpsTest, unit: str = f"{APP_NAME}/0", scope: Literal["client", "peer"] = "client"
+) -> list[str]:
     truststore_password = extract_truststore_password(ops_test=ops_test, unit_name=unit)
 
     try:
         result = check_output(
-            f"JUJU_MODEL={ops_test.model_full_name} juju ssh {unit} sudo -i 'charmed-kafka.keytool -list -keystore /var/snap/charmed-kafka/current/etc/kafka/client-truststore.jks -storepass {truststore_password}'",
+            f"JUJU_MODEL={ops_test.model_full_name} juju ssh {unit} sudo -i 'charmed-kafka.keytool -list -keystore /var/snap/charmed-kafka/current/etc/kafka/{scope}-truststore.jks -storepass {truststore_password}'",
             stderr=PIPE,
             shell=True,
             universal_newlines=True,

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -5,6 +5,7 @@
 import asyncio
 import logging
 import os
+from itertools import product
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -34,7 +35,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.kraft
 
 CONTROLLER_APP = "controller"
-PRODUCER_APP = "producer"
 TLS_NAME = "self-signed-certificates"
 
 
@@ -92,7 +92,7 @@ class TestKRaft:
 
     @pytest.mark.abort_on_fail
     @pytest.mark.skip_if_deployed
-    async def test_build_and_deploy(self, ops_test: OpsTest, kafka_charm, kraft_mode):
+    async def test_build_and_deploy(self, ops_test: OpsTest, kafka_charm, app_charm, kraft_mode):
 
         await asyncio.gather(
             ops_test.model.deploy(
@@ -107,18 +107,10 @@ class TestKRaft:
                 trust=True,
             ),
             ops_test.model.deploy(
-                "kafka-test-app",
-                application_name=PRODUCER_APP,
-                channel="edge",
+                app_charm,
+                application_name=DUMMY_NAME,
+                series=SERIES,
                 num_units=1,
-                series="jammy",
-                config={
-                    "topic_name": "HOT-TOPIC",
-                    "num_messages": 100000,
-                    "role": "producer",
-                    "partitions": 20,
-                    "replication_factor": "1",
-                },
                 trust=True,
             ),
         )
@@ -146,22 +138,29 @@ class TestKRaft:
         )
 
     @pytest.mark.abort_on_fail
-    async def test_integrate(self, ops_test: OpsTest):
+    async def test_integrate(self, ops_test: OpsTest, kafka_apps):
         if self.controller_app != APP_NAME:
             await ops_test.model.add_relation(
                 f"{APP_NAME}:{PEER_CLUSTER_ORCHESTRATOR_RELATION}",
                 f"{CONTROLLER_APP}:{PEER_CLUSTER_RELATION}",
             )
 
-        await ops_test.model.wait_for_idle(
-            apps=list({APP_NAME, self.controller_app}), idle_period=30
-        )
-
-        async with ops_test.fast_forward(fast_interval="20s"):
-            await asyncio.sleep(240)
+        async with ops_test.fast_forward(fast_interval="60s"):
+            await ops_test.model.wait_for_idle(
+                apps={self.controller_app, APP_NAME},
+                idle_period=40,
+                timeout=1800,
+                status="active",
+            )
 
         assert ops_test.model.applications[APP_NAME].status == "active"
         assert ops_test.model.applications[self.controller_app].status == "active"
+
+        # Relate app with broker.
+        await ops_test.model.add_relation(APP_NAME, f"{DUMMY_NAME}:{REL_NAME_ADMIN}")
+        await ops_test.model.wait_for_idle(
+            apps=[*kafka_apps, DUMMY_NAME], idle_period=60, status="active"
+        )
 
     @pytest.mark.abort_on_fail
     async def test_listeners(self, ops_test: OpsTest):
@@ -301,6 +300,9 @@ class TestKRaft:
     @pytest.mark.skipif(not tls_enabled, reason="only required when TLS is on.")
     @pytest.mark.abort_on_fail
     async def test_relate_peer_tls(self, ops_test: OpsTest):
+        c_writes = ContinuousWrites(ops_test=ops_test, app=DUMMY_NAME)
+        c_writes.start()
+
         await ops_test.model.deploy(TLS_NAME, application_name=TLS_NAME, channel="1/stable")
         await ops_test.model.wait_for_idle(
             apps=[TLS_NAME], idle_period=30, timeout=600, status="active"
@@ -339,9 +341,16 @@ class TestKRaft:
         # ensure we're not using internal CA
         assert internal_ca != controller_ca
 
+        results = c_writes.stop()
+        assert_continuous_writes_consistency(results)
+
     @pytest.mark.skipif(not tls_enabled, reason="only required when TLS is on.")
     @pytest.mark.abort_on_fail
     async def test_remove_peer_tls_relation(self, ops_test: OpsTest):
+        c_writes = ContinuousWrites(ops_test=ops_test, app=DUMMY_NAME)
+        c_writes.start()
+        await asyncio.sleep(60)
+
         await ops_test.juju("remove-relation", self.controller_app, TLS_NAME)
 
         async with ops_test.fast_forward(fast_interval="90s"):
@@ -369,3 +378,16 @@ class TestKRaft:
         assert controller_ca
         # Now we should be using internal CA
         assert internal_ca == controller_ca
+
+        results = c_writes.stop()
+        assert_continuous_writes_consistency(results)
+
+        async with ops_test.fast_forward(fast_interval="60s"):
+            # Wait for a couple of update-statues
+            await asyncio.sleep(300)
+
+        # We should have no temporary alias in the truststore
+        for i, app in product(range(3), {APP_NAME, self.controller_app}):
+            aliases = await list_truststore_aliases(ops_test, f"{app}/{i}", scope="peer")
+            logger.info(f"Trust aliases in {app}/{i}: {aliases}")
+            assert not ([alias for alias in aliases if "old-" in alias or "new-" in alias])

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -255,12 +255,12 @@ class TestKRaft:
         await ops_test.model.applications[self.controller_app].add_units(count=1)
 
         # ensure unit is added to dynamic quorum
-        async with ops_test.fast_forward(fast_interval="60s"):
+        async with ops_test.fast_forward(fast_interval="120s"):
             await ops_test.model.wait_for_idle(
                 apps=list({APP_NAME, self.controller_app}),
                 status="active",
                 timeout=1200,
-                idle_period=40,
+                idle_period=30,
             )
 
         unit_status = kraft_quorum_status(

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -311,15 +311,12 @@ class TestKRaft:
         await ops_test.model.add_relation(
             f"{self.controller_app}:{INTERNAL_TLS_RELATION}", TLS_NAME
         )
-        await ops_test.model.wait_for_idle(
-            apps=[self.controller_app, TLS_NAME], idle_period=60, timeout=1200
-        )
 
         async with ops_test.fast_forward(fast_interval="90s"):
             await ops_test.model.wait_for_idle(
                 apps={self.controller_app, APP_NAME, TLS_NAME},
                 idle_period=45,
-                timeout=1200,
+                timeout=2400,
                 status="active",
             )
 
@@ -357,7 +354,7 @@ class TestKRaft:
             await ops_test.model.wait_for_idle(
                 apps={self.controller_app, APP_NAME, TLS_NAME},
                 idle_period=60,
-                timeout=1800,
+                timeout=2400,
                 status="active",
             )
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -13,6 +13,7 @@ import pytest
 from charms.tls_certificates_interface.v4.tls_certificates import generate_private_key
 from pytest_operator.plugin import OpsTest
 
+from integration.helpers import sign_manual_certs
 from integration.helpers.pytest_operator import (
     APP_NAME,
     REL_NAME_PRODUCER,
@@ -26,7 +27,6 @@ from integration.helpers.pytest_operator import (
     list_truststore_aliases,
     search_secrets,
     set_tls_private_key,
-    sign_manual_certs,
 )
 from literals import (
     CERTIFICATE_TRANSFER_RELATION,
@@ -348,7 +348,7 @@ async def test_manual_tls_chain(ops_test: OpsTest, kafka_apps):
             raise_on_error=False,
         )
 
-    sign_manual_certs(ops_test)
+    sign_manual_certs(ops_test.model_full_name)
 
     # verifying brokers + servers can communicate with one-another
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_tls_complex.py
+++ b/tests/integration/test_tls_complex.py
@@ -113,7 +113,7 @@ def test_integrate_internal_tls(
     juju.wait(
         lambda status: all_active_idle(status, *kafka_apps, *tls_apps),
         delay=3,
-        successes=10,
+        successes=20,
         timeout=3600,
     )
 

--- a/tests/integration/test_tls_complex.py
+++ b/tests/integration/test_tls_complex.py
@@ -1,0 +1,125 @@
+import logging
+
+import jubilant
+import pytest
+
+from integration.ha.continuous_writes import ContinuousWrites
+from integration.helpers import (
+    APP_NAME,
+    CONTROLLER_NAME,
+    DUMMY_NAME,
+    REL_NAME_ADMIN,
+    sign_manual_certs,
+)
+from integration.helpers.ha import (
+    assert_all_brokers_up,
+    assert_all_controllers_up,
+    assert_continuous_writes_consistency,
+    assert_quorum_healthy,
+)
+from integration.helpers.jubilant import (
+    BASE,
+    all_active_idle,
+    deploy_cluster,
+)
+from literals import INTERNAL_TLS_RELATION, SECURITY_PROTOCOL_PORTS, TLS_RELATION
+
+logger = logging.getLogger(__name__)
+
+
+TLS_NAME = "self-signed-certificates"
+MANUAL_TLS_NAME = "manual-tls-certificates"
+
+TLS_APP_CLIENT = "ca"
+TLS_APP_BROKER = "ca-two"
+TLS_APP_CONTROLLER = "ca-three"
+
+
+@pytest.fixture
+def tls_apps(kraft_mode):
+    apps = [TLS_APP_CLIENT, TLS_APP_BROKER]
+    return apps if kraft_mode == "single" else apps + [TLS_APP_CONTROLLER]
+
+
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+def test_build_and_deploy(
+    juju: jubilant.Juju, kafka_charm, app_charm, kraft_mode, kafka_apps, tls_apps
+):
+    deploy_cluster(
+        juju=juju,
+        charm=kafka_charm,
+        kraft_mode=kraft_mode,
+        num_broker=3,
+        num_controller=3,
+    )
+    juju.deploy(app_charm, app=DUMMY_NAME, num_units=1, base=BASE)
+    juju.deploy(TLS_NAME, app=TLS_APP_CLIENT, to="0")
+    juju.deploy(MANUAL_TLS_NAME, app=TLS_APP_BROKER, to="1", channel="1/stable")
+    juju.deploy(TLS_NAME, app=TLS_APP_CONTROLLER, to="2")
+
+    juju.wait(
+        lambda status: all_active_idle(status, *kafka_apps, *tls_apps, DUMMY_NAME),
+        delay=3,
+        successes=10,
+        timeout=3600,
+    )
+
+    juju.integrate(APP_NAME, f"{DUMMY_NAME}:{REL_NAME_ADMIN}")
+
+    juju.wait(
+        lambda status: all_active_idle(status, *kafka_apps, DUMMY_NAME),
+        delay=3,
+        successes=20,
+        timeout=1200,
+    )
+
+    status = juju.status()
+    assert status.apps[APP_NAME].app_status.current == "active"
+    assert status.apps[DUMMY_NAME].app_status.current == "active"
+
+
+def test_integrate_client_tls(juju: jubilant.Juju, kafka_apps, tls_apps):
+    juju.integrate(f"{APP_NAME}:{TLS_RELATION}", TLS_APP_CLIENT)
+
+    juju.wait(
+        lambda status: all_active_idle(status, *kafka_apps, *tls_apps),
+        delay=3,
+        successes=10,
+        timeout=3600,
+    )
+
+    assert_all_brokers_up(juju, port=SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].client)
+
+
+def test_integrate_internal_tls(
+    juju: jubilant.Juju, controller_app, kafka_apps, tls_apps, kraft_mode
+):
+    assert juju.model  # this is to silent the linter
+    c_writes = ContinuousWrites(model=juju.model, app=DUMMY_NAME, produce_rate=5)
+    c_writes.start()
+
+    juju.integrate(f"{APP_NAME}:{INTERNAL_TLS_RELATION}", TLS_APP_BROKER)
+    if kraft_mode == "multi":
+        juju.integrate(f"{CONTROLLER_NAME}:{INTERNAL_TLS_RELATION}", TLS_APP_CONTROLLER)
+
+    juju.wait(
+        lambda status: "3 outstanding requests" in status.apps[TLS_APP_BROKER].app_status.message,
+        timeout=900,
+    )
+
+    sign_manual_certs(juju.model, manual_app=TLS_APP_BROKER)
+
+    juju.wait(
+        lambda status: all_active_idle(status, *kafka_apps, *tls_apps),
+        delay=3,
+        successes=10,
+        timeout=3600,
+    )
+
+    result = c_writes.stop()
+
+    assert_all_brokers_up(juju, port=SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].client)
+    assert_all_controllers_up(juju, controller_app=controller_app)
+    assert_continuous_writes_consistency(result)
+    assert_quorum_healthy(juju, kraft_mode=kraft_mode)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -75,6 +75,7 @@ def patched_workload(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("workload.Workload.get_service_pid", lambda _: 1314231)
     monkeypatch.setattr("workload.Workload.last_restart", time.time() - 100.0)
     monkeypatch.setattr("workload.Workload.modify_time", lambda _, file: time.time() - 1000.0)
+    monkeypatch.setattr("workload.Workload.ping", lambda _, nodes: True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 import json
+import time
 from collections import defaultdict
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -67,10 +68,13 @@ def patched_etc_environment():
 @pytest.fixture(autouse=True)
 def patched_workload(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("time.sleep", lambda _: None)
+    monkeypatch.setattr("charmlibs.pathops.LocalPath.exists", lambda _: True)
     monkeypatch.setattr("workload.Workload.active", lambda _: True)
     monkeypatch.setattr("workload.Workload.write", lambda _, content, path: None)
     monkeypatch.setattr("workload.Workload.read", lambda _, path: [])
     monkeypatch.setattr("workload.Workload.get_service_pid", lambda _: 1314231)
+    monkeypatch.setattr("workload.Workload.last_restart", time.time() - 100.0)
+    monkeypatch.setattr("workload.Workload.modify_time", lambda _, file: time.time() - 1000.0)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_tls_manager.py
+++ b/tests/unit/test_tls_manager.py
@@ -234,6 +234,7 @@ def test_tls_manager_truststore_functionality(
         sans_dns=[UNIT_NAME],
         with_intermediate=with_intermediate,
     )
+    caplog.set_level(logging.DEBUG)
     _set_manager_state(tls_manager, tls_artifacts=tls_artifacts)
     _tls_manager_set_everything(tls_manager)
 
@@ -373,7 +374,8 @@ def test_peer_cluster_trust(tls_manager: TLSManager):
 
     tls_manager.update_peer_cluster_trust()
     trusted_certs = tls_manager.peer_trusted_certificates
+    # we should have both certificates
     assert f"{tls_manager.PEER_CLUSTER_ALIAS}0" in trusted_certs
-    assert len(trusted_certs) == 1
-    new_fingerprint = next(iter(trusted_certs.values()))
-    assert new_fingerprint != fingerprint
+    assert f"{tls_manager.NEW_PREFIX}{tls_manager.PEER_CLUSTER_ALIAS}0" in trusted_certs
+    assert len(trusted_certs) == 2
+    assert fingerprint in tls_manager.peer_trusted_certificates.values()

--- a/tests/unit/test_tls_manager.py
+++ b/tests/unit/test_tls_manager.py
@@ -10,7 +10,7 @@ import os
 import ssl
 import subprocess
 from multiprocessing import Process
-from typing import Mapping
+from typing import Any, Mapping
 from unittest.mock import MagicMock
 
 import pytest
@@ -36,7 +36,7 @@ def _exec(
     command: list[str] | str,
     env: Mapping[str, str] | None = None,
     working_dir: str | None = None,
-    _: bool = False,
+    **kwargs: Any,
 ) -> str:
     _command = " ".join(command) if isinstance(command, list) else command
 

--- a/tests/unit/test_workload.py
+++ b/tests/unit/test_workload.py
@@ -2,10 +2,14 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import datetime
+import inspect
+import time
 from unittest.mock import mock_open, patch
 
 import pytest
 
+from core.workload import WorkloadBase
 from literals import SUBSTRATE
 from workload import KafkaWorkload
 
@@ -16,6 +20,52 @@ pytestmark = [
     pytest.mark.broker,
     pytest.mark.skipif(SUBSTRATE == "k8s", reason="workload tests not needed for K8s"),
 ]
+
+
+@pytest.fixture()
+def fake_workload(tmp_path_factory, monkeypatch) -> WorkloadBase:
+    monkeypatch.undo()
+    workload = KafkaWorkload()
+    workload.paths.conf_path = tmp_path_factory.mktemp("workload")
+    return workload
+
+
+@pytest.mark.skip
+def test_modify_time_functionality(fake_workload: WorkloadBase):
+    test_path = fake_workload.paths.server_properties
+    start = time.time()
+
+    with open(test_path, "w") as f:
+        f.write("test\n")
+
+    first_modified = fake_workload.modify_time(test_path)
+    assert first_modified > start
+
+    with open(test_path, "a") as f:
+        f.write("append to test\n")
+        f.flush()
+
+    assert fake_workload.modify_time(test_path) > first_modified
+
+
+def test_last_restart_parses_snap_changes_correctly(patched_exec, monkeypatch):
+    monkeypatch.undo()
+    patched_exec.return_value = inspect.cleandoc(
+        """
+    ID   Status  Spawn                 Ready                 Summary
+    4    Done    2025-07-14T16:15:32Z  2025-07-14T16:18:34Z  Install "charmed-kafka" snap
+    6    Done    2025-07-14T16:18:34Z  2025-07-14T16:18:34Z  Connect charmed-kafka:removable-media to snapd:removable-media
+    7    Done    2025-07-14T16:18:34Z  2025-07-14T16:18:34Z  Hold general refreshes for "charmed-kafka"
+    8    Done    2025-07-14T16:20:04Z  2025-07-14T16:20:04Z  Running service command
+    9    Done    2025-07-14T16:24:06Z  2025-07-14T16:24:07Z  Running service command
+    10   Done    2025-07-14T16:26:11Z  2025-07-14T16:26:12Z  Running service command
+    """
+    )
+
+    assert (
+        KafkaWorkload().last_restart
+        == datetime.datetime(2025, 7, 14, 16, 26, 12, tzinfo=datetime.timezone.utc).timestamp()
+    )
 
 
 def test_run_bin_command_args(patched_exec):

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ set_env =
     password-rotation: TEST_FILE=test_password_rotation.py
     refresh: TEST_FILE=test_refresh.py
     tls: TEST_FILE=test_tls.py
+    tls-complex: TEST_FILE=test_tls_complex.py
     ha: TEST_FILE=ha/test_ha.py
     ha-controller: TEST_FILE=ha/test_ha_controller.py
     kraft: TEST_FILE=test_kraft.py
@@ -91,7 +92,7 @@ commands =
     poetry install --with integration
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/
 
-[testenv:integration-{charm,provider,scaling,password-rotation,tls,refresh,ha,ha-controller,kraft,kraft-tls}]
+[testenv:integration-{charm,ha,ha-controller,kraft,kraft-tls,password-rotation,provider,refresh,scaling,tls,tls-complex}]
 description = Run integration tests
 pass_env =
     {[testenv]pass_env}


### PR DESCRIPTION
Fixes https://github.com/canonical/kafka-operator/issues/343

The process is as follows:

- Each unit reports its trusted certificates in its own unit databag, which is updated after restart
- Leader units report the intersection of trusted certificates of all units via app databag in the `peer-cluster` relation
- When a CA rotation is happening in either side, the app first waits for the other side (remote app) to report new cert being added to their truststores (which means a complete rolling restart in the remote app). In case both apps are in the middle of a rotation, the BROKER side attempts to restart first.
- After the remote side finishes rolling restart and reports the new cert in their truststore, the local app will start its rolling restart.
- Both apps will keep both old and new CA during the first round of rolling restarts.
- On `update-status`, if both sides report the new CA is added, they will remove the old CA and do another rolling restart.

## Enhancements:
- Adds `log_on_error` kwarg to `Workload.exec`, defaulting to `True`, to be able to silent the logs on acceptable failures (like when a cert is already added to truststore).
- Moves heavier tests to self-hosted runners.