### PR TITLE
Make sync manual

### DIFF
--- a/.github/workflows/sync-to-k8s.yml
+++ b/.github/workflows/sync-to-k8s.yml
@@ -3,8 +3,9 @@
 name: Sync feature PRs to kafka-k8s-operator
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   sync-pr:


### PR DESCRIPTION
If we don't have a synced baseline for both repos this workflow will keep failing, so make manual instead for the time being to stop failures on the PRs