### PR TITLE
chore: remove inter.broker.protocol.version config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
       path-to-charm-directory: ${{ matrix.path }}
       cache: false # TODO: fix after added to the charmcraftcache
 
-  integration-test:
+  integration-test-github:
     strategy:
       fail-fast: false
       matrix:
@@ -85,12 +85,10 @@ jobs:
           - integration-password-rotation
           - integration-tls
           #- integration-upgrade
-          - integration-balancer-single
-          - integration-balancer-multi
           - integration-kraft
+          - integration-ha
         kraft-mode:
           - single
-          - multi
         exclude:
           - tox-environments: integration-balancer-single
             kraft-mode: single
@@ -133,15 +131,22 @@ jobs:
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
 
-  integration-test-ha:
+  integration-test-self-hosted:
     strategy:
       fail-fast: false
       matrix:
         tox-environments:
+          - integration-charm
+          - integration-provider
+          - integration-password-rotation
+          - integration-tls
+          #- integration-upgrade
+          - integration-kraft
+          - integration-balancer-single
+          - integration-balancer-multi
           - integration-ha
           - integration-ha-controller
         kraft-mode:
-          - single
           - multi
         exclude:
           - tox-environments: integration-ha-controller

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -728,7 +728,6 @@ class ConfigManager(CommonConfigManager):
                 f"listeners={','.join(listeners_repr)}",
                 f"advertised.listeners={','.join(advertised_listeners)}",
                 f"inter.broker.listener.name={self.internal_listener.name}",
-                f"inter.broker.protocol.version={self.inter_broker_protocol_version}",
             ]
             + self.scram_properties
             + self.oauth_properties

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -600,10 +600,8 @@ def test_inter_broker_protocol_version(ctx: Context, base_state: State) -> None:
         # Then
         kafka_version: str = DEPENDENCIES.get("kafka_service", {}).get("version", "0.0.0")
         major_minor = ".".join(kafka_version.split(".")[:2])
-        assert (
-            f"inter.broker.protocol.version={major_minor}"
-            in charm.broker.config_manager.server_properties
-        )
+
+    assert charm.broker.config_manager.inter_broker_protocol_version == f"{major_minor}"
     assert len(DEPENDENCIES["kafka_service"]["version"].split(".")) == 3
 
 


### PR DESCRIPTION
This PR removes `inter.broker.protocol.version` as we don't need it in Kafka 4, and since it causes issues with Kafka UI. 

## Enhancements:
- Move all `multi` KRaft tests to self-hosted runners and keep `single` ones on GH runners.