### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security policy
+
+## What qualifies as a security issue
+
+Credentials leakage, outdated dependencies with known vulnerabilities, and
+other issues that could lead to unauthorized access to the system or its data.
+
+## Reporting a vulnerability
+
+The easiest way to report a security issue is through
+[GitHub](https://github.com/canonical/spark-history-server-k8s-operator/security/advisories/new).
+See
+[Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions.
+
+The repository admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then handle figuring out a fix, getting a CVE
+assigned and coordinating the release of the fix.
+
+The
+[Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
+contains more  information about what you can expect when you contact us,
+and what we expect from you.


### PR DESCRIPTION
Add a SECURITY.md file to the repo as per SSDLC requirements.
The content of the file is based on the [Spark History Server](https://github.com/canonical/spark-history-server-k8s-operator/blob/3/edge/SECURITY.md) repository with minimal customisation for wording.