### PR TITLE
[DPE-7846] fix: secrets not set issue in RelationState.update

### DIFF
--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -12,13 +12,10 @@ from ipaddress import IPv4Address, IPv6Address
 from typing import TYPE_CHECKING, Any
 
 from charms.data_platform_libs.v0.data_interfaces import (
-    SECRET_GROUPS,
     DataPeerData,
     DataPeerOtherUnitData,
     DataPeerUnitData,
     KafkaProviderData,
-    ProviderData,
-    RequirerData,
 )
 from charms.tls_certificates_interface.v4.tls_certificates import Certificate, PrivateKey
 from lightkube.core.exceptions import ApiError as LightKubeApiError
@@ -33,6 +30,8 @@ from core.models import (
     KafkaCluster,
     OAuth,
     PeerCluster,
+    PeerClusterData,
+    PeerClusterOrchestratorData,
 )
 from literals import (
     ADMIN_USER,
@@ -61,45 +60,6 @@ if TYPE_CHECKING:
     from charm import KafkaCharm
 
 logger = logging.getLogger(__name__)
-
-custom_secret_groups = SECRET_GROUPS
-setattr(custom_secret_groups, "BROKER", "broker")
-setattr(custom_secret_groups, "BALANCER", "balancer")
-setattr(custom_secret_groups, "CONTROLLER", "controller")
-
-SECRET_LABEL_MAP = {
-    "broker-username": getattr(custom_secret_groups, "BROKER"),
-    "broker-password": getattr(custom_secret_groups, "BROKER"),
-    "controller-password": getattr(custom_secret_groups, "CONTROLLER"),
-    "broker-uris": getattr(custom_secret_groups, "BROKER"),
-    "balancer-username": getattr(custom_secret_groups, "BALANCER"),
-    "balancer-password": getattr(custom_secret_groups, "BALANCER"),
-    "balancer-uris": getattr(custom_secret_groups, "BALANCER"),
-}
-
-
-class PeerClusterOrchestratorData(ProviderData, RequirerData):
-    """Broker provider data model."""
-
-    SECRET_LABEL_MAP = SECRET_LABEL_MAP
-    SECRET_FIELDS = BROKER.requested_secrets
-
-    # This is to bypass the PrematureDataAccessError, which is irrelevant in this case.
-    def _update_relation_data(self, relation: Relation, data: dict[str, str]) -> None:
-        """Set values for fields not caring whether it's a secret or not."""
-        super(ProviderData, self)._update_relation_data(relation, data)
-
-
-class PeerClusterData(ProviderData, RequirerData):
-    """Broker provider data model."""
-
-    SECRET_LABEL_MAP = SECRET_LABEL_MAP
-    SECRET_FIELDS = list(set(BALANCER.requested_secrets) | set(CONTROLLER.requested_secrets))
-
-    # This is to bypass the PrematureDataAccessError, which is irrelevant in this case.
-    def _update_relation_data(self, relation: Relation, data: dict[str, str]) -> None:
-        """Set values for fields not caring whether it's a secret or not."""
-        super(ProviderData, self)._update_relation_data(relation, data)
 
 
 class ClusterState(Object):

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -13,9 +13,12 @@ from typing import MutableMapping, TypeAlias, TypedDict
 import requests
 from charms.data_platform_libs.v0.data_interfaces import (
     PROV_SECRET_PREFIX,
+    SECRET_GROUPS,
     Data,
     DataPeerData,
     DataPeerUnitData,
+    ProviderData,
+    RequirerData,
 )
 from lightkube.resources.core_v1 import Node, Pod
 from ops.model import Application, Relation, Unit
@@ -24,6 +27,7 @@ from typing_extensions import override
 from literals import (
     BALANCER,
     BROKER,
+    CONTROLLER,
     INTERNAL_USERS,
     KRAFT_NODE_ID_OFFSET,
     SECRETS_APP,
@@ -45,6 +49,21 @@ BrokerCapacity = TypedDict("BrokerCapacity", {"brokerId": str, "capacity": Capac
 BrokerCapacities = TypedDict(
     "BrokerCapacities", {"brokerCapacities": list[BrokerCapacity]}, total=False
 )
+
+custom_secret_groups = SECRET_GROUPS
+setattr(custom_secret_groups, "BROKER", "broker")
+setattr(custom_secret_groups, "BALANCER", "balancer")
+setattr(custom_secret_groups, "CONTROLLER", "controller")
+
+SECRET_LABEL_MAP = {
+    "broker-username": getattr(custom_secret_groups, "BROKER"),
+    "broker-password": getattr(custom_secret_groups, "BROKER"),
+    "controller-password": getattr(custom_secret_groups, "CONTROLLER"),
+    "broker-uris": getattr(custom_secret_groups, "BROKER"),
+    "balancer-username": getattr(custom_secret_groups, "BALANCER"),
+    "balancer-password": getattr(custom_secret_groups, "BALANCER"),
+    "balancer-uris": getattr(custom_secret_groups, "BALANCER"),
+}
 
 
 @dataclass
@@ -101,6 +120,39 @@ class RelationState:
 
         for field in delete_fields:
             del self.relation_data[field]
+
+        if not self.relation:
+            return
+
+        secret_keys = set(update_content) & set(SECRET_LABEL_MAP)
+        for key in secret_keys:
+            self.data_interface._add_or_update_relation_secrets(
+                self.relation, SECRET_LABEL_MAP[key], {key}, {key: update_content[key]}
+            )
+
+
+class PeerClusterOrchestratorData(ProviderData, RequirerData):
+    """Broker provider data model."""
+
+    SECRET_LABEL_MAP = SECRET_LABEL_MAP
+    SECRET_FIELDS = BROKER.requested_secrets
+
+    # This is to bypass the PrematureDataAccessError, which is irrelevant in this case.
+    def _update_relation_data(self, relation: Relation, data: dict[str, str]) -> None:
+        """Set values for fields not caring whether it's a secret or not."""
+        super(ProviderData, self)._update_relation_data(relation, data)
+
+
+class PeerClusterData(ProviderData, RequirerData):
+    """Broker provider data model."""
+
+    SECRET_LABEL_MAP = SECRET_LABEL_MAP
+    SECRET_FIELDS = list(set(BALANCER.requested_secrets) | set(CONTROLLER.requested_secrets))
+
+    # This is to bypass the PrematureDataAccessError, which is irrelevant in this case.
+    def _update_relation_data(self, relation: Relation, data: dict[str, str]) -> None:
+        """Set values for fields not caring whether it's a secret or not."""
+        super(ProviderData, self)._update_relation_data(relation, data)
 
 
 class PeerCluster(RelationState):

--- a/src/events/peer_cluster.py
+++ b/src/events/peer_cluster.py
@@ -26,7 +26,7 @@ from ops.charm import (
 )
 from ops.framework import Object
 
-from core.cluster import custom_secret_groups
+from core.models import custom_secret_groups
 from literals import (
     BALANCER,
     BROKER,

--- a/tests/unit/test_tls_manager.py
+++ b/tests/unit/test_tls_manager.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 import yaml
 from charmlibs import pathops
-from src.core.models import KafkaBroker
+from src.core.cluster import KafkaBroker
 from src.core.structured_config import CharmConfig
 from src.core.workload import CharmedKafkaPaths, WorkloadBase
 from src.literals import BROKER, SUBSTRATE, TLSScope


### PR DESCRIPTION
This PR fixes a [possibly] race condition issue in `RelationState.update` and the underlying `data_interfaces` logic, which in some cases leads to secrets not being set, for example **when a user immediately relates broker and controller after deployment**.

The only material change in this PR is [these lines](https://github.com/canonical/kafka-operator/pull/387/files#diff-e46c88bb687d77b94764a732b3e08a0a7bd544a64e606429c0b787c13e1c226aR124-R131) added to the `update` method of `RelationState`. The other changes were basically refactoring some of the code from `cluster` to the `models` module, which seemed more appropriate.

To test this PR, the following script was run before and after changes. 
- Before the changes, almost half of the deployments led to broker being stuck in `waiting for controller user credentials`, which was due the fact that the controller password was set in relation data instead of secrets. 
- After the changes, 100/100 deployments were successful.

```python
import os
import time

import jubilant

NO_ATTEMPTS = 100

DEPLOY = """juju add-model testing
juju deploy self-signed-certificates ss
juju deploy ./kafka_ubuntu@24.04-amd64.charm -n 1
juju deploy ./kafka_ubuntu@24.04-amd64.charm --config roles="controller" controller -n 1
juju integrate kafka:peer-cluster-orchestrator controller:peer-cluster"""

DESTROY = "juju destroy-model --destroy-storage --force --no-wait --no-prompt testing"

apps = ["kafka", "controller"]

for attempt in range(1, 1 + NO_ATTEMPTS):
    print(f"\033[31mATTEMPT {attempt}...\033[0m")
    juju = jubilant.Juju(model="testing")
    for cmd in DEPLOY.split("\n"):
        os.system(cmd)
    try:
        juju.wait(
            lambda status: jubilant.all_active(status, *apps) and jubilant.all_agents_idle(status, *apps),
            timeout=1800,
            successes=20,
            delay=3,
        )
    except:
        os.system("juju status")
        break

    os.system(DESTROY)
    time.sleep(30)
```