### PR TITLE
[DPE-7987] fix: race condition in internal TLS setup

### DIFF
--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -474,7 +474,7 @@ class ClusterState(Object):
         if self.runs_broker_only and not self.peer_cluster_orchestrator_relation:
             return Status.MISSING_MODE
 
-        if not self.unit_broker.peer_certs.ready and not self.internal_ca:
+        if not self.unit_broker.peer_certs.ready:
             return Status.NO_INTERNAL_TLS
 
         for status in [self._broker_status, self._controller_status]:
@@ -495,7 +495,7 @@ class ClusterState(Object):
         if not self.peer_cluster_relation and not self.runs_broker:
             return Status.NO_PEER_CLUSTER_RELATION
 
-        if not self.unit_broker.peer_certs.ready and not self.internal_ca:
+        if not self.unit_broker.peer_certs.ready:
             return Status.NO_INTERNAL_TLS
 
         if not self.peer_cluster.broker_connected:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -199,7 +199,7 @@ class PeerCluster(RelationState):
             f"{PROV_SECRET_PREFIX}{group}"
         ):
             if secret := self.data_interface._model.get_secret(id=secrets_uri):
-                return secret.get_content().get(field, "")
+                return secret.get_content(refresh=True).get(field, "")
 
         return ""
 

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -171,8 +171,9 @@ class BrokerOperator(Object):
             generated_ca = self.tls_manager.generate_internal_ca()
             self.charm.state.internal_ca = generated_ca.ca
             self.charm.state.internal_ca_key = generated_ca.ca_key
-            # Now generate unit's self-signed certs
-            self.setup_internal_tls()
+
+        # Now generate unit's self-signed certs
+        self.setup_internal_tls()
 
         current_status = self.charm.state.ready_to_start
         if current_status is not Status.ACTIVE:
@@ -182,7 +183,6 @@ class BrokerOperator(Object):
 
         self.kraft.format_storages()
         self.update_external_services()
-        self.setup_internal_tls()
 
         self.config_manager.set_server_properties()
         self.config_manager.set_client_properties()

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -95,6 +95,11 @@ class KafkaProvider(Object):
             event.defer()
             return
 
+        if not self.charm.workload.ping(self.charm.state.bootstrap_server_internal):
+            logging.debug("Broker/Controller not up yet...")
+            event.defer()
+            return
+
         password = client.password or self.charm.workload.generate_password()
 
         # catching error here in case listeners not established for bootstrap-server auth
@@ -156,6 +161,11 @@ class KafkaProvider(Object):
             # Create a "mtls" flag so a new listener (CLIENT_SSL) is created
             self.charm.state.cluster.update({"mtls": "enabled"})
             self.charm.on.config_changed.emit()
+
+        if not self.charm.workload.ping(self.charm.state.bootstrap_server_internal):
+            logging.debug("Broker/Controller not up yet...")
+            event.defer()
+            return
 
         distinguished_name = self.dependent.tls_manager.certificate_distinguished_name(
             event.mtls_cert

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -60,6 +60,11 @@ class KafkaProvider(Object):
             event.defer()
             return
 
+        if not self.charm.workload.ping(self.charm.state.bootstrap_server_internal):
+            logging.debug("Broker/Controller not up yet...")
+            event.defer()
+            return
+
         # on all unit update the server properties to enable client listener if needed
         self.dependent._on_config_changed(event)
 
@@ -92,11 +97,6 @@ class KafkaProvider(Object):
             requesting_client.alias, requesting_client.mtls_cert
         ):
             logging.debug("Waiting for MTLS setup.")
-            event.defer()
-            return
-
-        if not self.charm.workload.ping(self.charm.state.bootstrap_server_internal):
-            logging.debug("Broker/Controller not up yet...")
             event.defer()
             return
 

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -318,7 +318,7 @@ class TLSHandler(Object):
         """Updates the truststore based on current state of MTLS client relations and certificates available on the `certificate_transfer` interface."""
         if not all(
             [
-                self.charm.workload.installed,
+                self.charm.broker.healthy,
                 self.charm.state.cluster.tls_enabled,
                 self.charm.state.unit_broker.client_certs.certificate,
                 self.charm.state.unit_broker.client_certs.ca,

--- a/src/events/user_secrets.py
+++ b/src/events/user_secrets.py
@@ -71,6 +71,11 @@ class SecretsHandler(Object):
 
         logger.info(f"Credentials change detected for {changed}")
 
+        if not self.charm.workload.ping(self.charm.state.bootstrap_server_internal):
+            logging.debug("Broker/Controller not up yet...")
+            event.defer()
+            return
+
         # Store the password on application databag
         for username in changed:
             new_password = credentials[username]

--- a/src/health.py
+++ b/src/health.py
@@ -67,6 +67,10 @@ class KafkaHealth(Object):
 
     def _get_partitions_size(self) -> tuple[int, int]:
         """Gets the number of partitions and their average size from the log dirs."""
+        if not self.dependent.workload.ping(self.charm.state.bootstrap_server_internal):
+            logging.debug("get_partitions_size failed: broker/controller not up yet.")
+            return (0, 0)
+
         log_dirs_command = [
             "--describe",
             f"--bootstrap-server {self.charm.state.bootstrap_server_internal}",

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -486,6 +486,7 @@ class TLSManager:
                 [
                     (self.workload.root / self.workload.paths.truststore).exists(),
                     (self.workload.root / self.workload.paths.client_properties).exists(),
+                    self.workload.ping(self.state.bootstrap_server_internal),
                 ]
             )
         ):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -45,6 +45,16 @@ def kraft_data() -> dict[str, str]:
 
 
 @pytest.fixture(scope="module")
+def unit_peer_tls_data() -> dict[str, str]:
+    tls_data = generate_tls_artifacts()
+    return {
+        "peer-ca-cert": tls_data.ca,
+        "peer-certificate": tls_data.certificate,
+        "peer-private-key": tls_data.private_key,
+    }
+
+
+@pytest.fixture(scope="module")
 def peer_cluster_rel() -> Relation:
     return Relation(PEER_CLUSTER_RELATION, "peer_cluster")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -338,10 +338,16 @@ def test_start_does_not_start_if_leader_has_not_set_creds(ctx: Context, base_sta
 
 
 def test_update_status_blocks_if_broker_not_active(
-    ctx: Context, base_state: State, kraft_data: dict[str, str], passwords_data: dict[str, str]
+    ctx: Context,
+    base_state: State,
+    kraft_data: dict[str, str],
+    passwords_data: dict[str, str],
+    unit_peer_tls_data: dict[str, str],
 ):
     # Given
-    cluster_peer = PeerRelation(PEER, PEER, local_app_data=kraft_data | passwords_data)
+    cluster_peer = PeerRelation(
+        PEER, PEER, local_unit_data=unit_peer_tls_data, local_app_data=kraft_data | passwords_data
+    )
     state_in = dataclasses.replace(base_state, relations=[cluster_peer])
 
     # When
@@ -380,10 +386,16 @@ def test_update_status_blocks_if_machine_not_configured(
 
 @pytest.mark.skipif(SUBSTRATE == "k8s", reason="sysctl config not used on K8s")
 def test_update_status_sets_sysconf_warning(
-    ctx: Context, base_state: State, passwords_data: dict[str, str], kraft_data: dict[str, str]
+    ctx: Context,
+    base_state: State,
+    passwords_data: dict[str, str],
+    kraft_data: dict[str, str],
+    unit_peer_tls_data: dict[str, str],
 ) -> None:
     # Given
-    cluster_peer = PeerRelation(PEER, PEER, local_app_data=passwords_data | kraft_data)
+    cluster_peer = PeerRelation(
+        PEER, PEER, local_unit_data=unit_peer_tls_data, local_app_data=passwords_data | kraft_data
+    )
     state_in = dataclasses.replace(base_state, relations=[cluster_peer])
 
     # When
@@ -402,10 +414,13 @@ def test_update_status_sets_active(
     base_state: State,
     passwords_data: dict[str, str],
     kraft_data: dict[str, str],
+    unit_peer_tls_data: dict[str, str],
     patched_health_machine_configured,
 ) -> None:
     # Given
-    cluster_peer = PeerRelation(PEER, PEER, local_app_data=passwords_data | kraft_data)
+    cluster_peer = PeerRelation(
+        PEER, PEER, local_unit_data=unit_peer_tls_data, local_app_data=passwords_data | kraft_data
+    )
     state_in = dataclasses.replace(base_state, relations=[cluster_peer])
 
     # When

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -241,6 +241,7 @@ def test_mtls_setup(
     tls_artifacts: TLSArtifacts,
     kraft_data: dict[str, str],
     passwords_data: dict[str, str],
+    unit_peer_tls_data: dict[str, str],
 ) -> None:
     # Given
     restart_relation = PeerRelation("restart", "rolling_op")
@@ -266,7 +267,8 @@ def test_mtls_setup(
         local_app_data={f"relation-{client_relation.id}": "password", "tls": "enabled"}
         | kraft_data
         | passwords_data,
-        local_unit_data={"client-certificate": "cert", "client-ca-cert": "ca"},
+        local_unit_data={"client-certificate": "cert", "client-ca-cert": "ca"}
+        | unit_peer_tls_data,
     )
     state_in = dataclasses.replace(
         base_state,


### PR DESCRIPTION
- Fixes https://github.com/canonical/kafka-operator/issues/397
- [Fixes](https://github.com/canonical/kafka-operator/pull/399/commits/d3d0bd407c160714a87dd645aa7c9fdd0a5ba2f4) the issue of `AuthManager` and `KafkaHealth` failing too slowly if broker/controller are not up, leading to deferral back pressure...
- Fixes the issue of `config-changed` calls linearly increasing with the number of clients, which makes cluster convergence to `active|idle` really slow