### PR TITLE
[DPE-7843] refactor: rename broker to kafka

### DIFF
--- a/src/events/actions.py
+++ b/src/events/actions.py
@@ -12,7 +12,7 @@ from ops.framework import Object
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
-    from events.broker import BrokerOperator
+    from events.kafka import KafkaOperator
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class ActionEvents(Object):
     """Event handlers for Juju Actions."""
 
-    def __init__(self, dependent: "BrokerOperator") -> None:
+    def __init__(self, dependent: "KafkaOperator") -> None:
         super().__init__(dependent, "action_events")
         self.dependent = dependent
         self.charm: "KafkaCharm" = dependent.charm

--- a/src/events/controller.py
+++ b/src/events/controller.py
@@ -29,7 +29,7 @@ from workload import KafkaWorkload
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
-    from events.broker import BrokerOperator
+    from events.kafka import KafkaOperator
 
 logger = logging.getLogger(__name__)
 
@@ -37,10 +37,10 @@ logger = logging.getLogger(__name__)
 class KRaftHandler(Object):
     """Handler for KRaft specific events."""
 
-    def __init__(self, broker: "BrokerOperator") -> None:
-        super().__init__(broker, CONTROLLER.value)
-        self.charm: "KafkaCharm" = broker.charm
-        self.broker: "BrokerOperator" = broker
+    def __init__(self, kafka: "KafkaOperator") -> None:
+        super().__init__(kafka, CONTROLLER.value)
+        self.charm: "KafkaCharm" = kafka.charm
+        self.kafka: "KafkaOperator" = kafka
 
         self.workload = KafkaWorkload(
             container=(

--- a/src/events/kafka.py
+++ b/src/events/kafka.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class BrokerOperator(Object):
+class KafkaOperator(Object):
     """Charmed Operator for Kafka."""
 
     def __init__(self, charm) -> None:

--- a/src/events/oauth.py
+++ b/src/events/oauth.py
@@ -14,7 +14,7 @@ from literals import OAUTH_REL_NAME
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
-    from events.broker import BrokerOperator
+    from events.kafka import KafkaOperator
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class OAuthHandler(Object):
     """Handler for managing oauth relations."""
 
-    def __init__(self, dependent: "BrokerOperator") -> None:
+    def __init__(self, dependent: "KafkaOperator") -> None:
         super().__init__(dependent, "oauth")
         self.dependent = dependent
         self.charm: "KafkaCharm" = dependent.charm

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -23,7 +23,7 @@ from managers.ssl_principal_mapper import NoMatchingRuleError, SslPrincipalMappe
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
-    from events.broker import BrokerOperator
+    from events.kafka import KafkaOperator
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 class KafkaProvider(Object):
     """Implements the provider-side logic for client applications relating to Kafka."""
 
-    def __init__(self, dependent: "BrokerOperator") -> None:
+    def __init__(self, dependent: "KafkaOperator") -> None:
         super().__init__(dependent, "kafka_client")
         self.dependent = dependent
         self.charm: "KafkaCharm" = dependent.charm
@@ -130,7 +130,7 @@ class KafkaProvider(Object):
 
     def on_mtls_cert_updated(self, event: KafkaClientMtlsCertUpdatedEvent) -> None:
         """Handler for `kafka-client-mtls-cert-updated` event."""
-        if not self.charm.broker.healthy:
+        if not self.charm.kafka.healthy:
             event.defer()
             return
 

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -58,7 +58,7 @@ class TLSHandler(Object):
         super().__init__(charm, "tls")
         self.charm: "KafkaCharm" = charm
 
-        self.sans = self.charm.broker.tls_manager.build_sans()
+        self.sans = self.charm.kafka.tls_manager.build_sans()
         self.common_name = f"{self.charm.unit.name}-{self.charm.model.uuid}"
 
         peer_private_key = None
@@ -170,12 +170,12 @@ class TLSHandler(Object):
         state.ca = ""
 
         # remove all existing keystores from the unit so we don't preserve certs
-        self.charm.broker.tls_manager.remove_stores(scope=state.scope)
+        self.charm.kafka.tls_manager.remove_stores(scope=state.scope)
         self.charm.balancer.tls_manager.remove_stores(scope=state.scope)
 
         if state.scope == TLSScope.PEER:
             # switch back to internal TLS
-            self.charm.broker.setup_internal_tls()
+            self.charm.kafka.setup_internal_tls()
 
             # Keep the old bundle
             for dependent in ["broker", "balancer"]:
@@ -293,7 +293,7 @@ class TLSHandler(Object):
         """Updates the truststore based on current state of MTLS client relations and certificates available on the `certificate_transfer` interface."""
         if not all(
             [
-                self.charm.broker.healthy,
+                self.charm.kafka.healthy,
                 self.charm.state.cluster.tls_enabled,
                 self.charm.state.unit_broker.client_certs.certificate,
                 self.charm.state.unit_broker.client_certs.ca,
@@ -311,28 +311,28 @@ class TLSHandler(Object):
                 continue
 
             alias = client.alias
-            if not self.charm.broker.tls_manager.alias_needs_update(alias, client.mtls_cert):
+            if not self.charm.kafka.tls_manager.alias_needs_update(alias, client.mtls_cert):
                 continue
 
-            self.charm.broker.tls_manager.update_cert(alias=alias, cert=client.mtls_cert)
+            self.charm.kafka.tls_manager.update_cert(alias=alias, cert=client.mtls_cert)
             live_aliases.add(alias)
             should_reload = True
 
         # Transferred certs
         transferred_certs = self.certificate_transfer.get_all_certificates()
         for cert in transferred_certs:
-            alias = self.charm.broker.tls_manager.certificate_distinguished_name(cert)
+            alias = self.charm.kafka.tls_manager.certificate_distinguished_name(cert)
             live_aliases.add(alias)
 
-            if not self.charm.broker.tls_manager.alias_needs_update(alias, cert):
+            if not self.charm.kafka.tls_manager.alias_needs_update(alias, cert):
                 continue
 
-            self.charm.broker.tls_manager.update_cert(alias=alias, cert=cert)
+            self.charm.kafka.tls_manager.update_cert(alias=alias, cert=cert)
             should_reload = True
 
         logger.debug(f"Following aliases should be in the truststore: {live_aliases}")
         if should_reload:
-            self.charm.broker.tls_manager.reload_truststore()
+            self.charm.kafka.tls_manager.reload_truststore()
 
     @property
     def ready(self) -> bool:

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -178,7 +178,7 @@ class TLSHandler(Object):
             self.charm.kafka.setup_internal_tls()
 
             # Keep the old bundle
-            for dependent in ["broker", "balancer"]:
+            for dependent in ["kafka", "balancer"]:
                 getattr(self.charm, dependent).tls_manager.import_bundle(
                     bundle=old_bundle, scope=state.scope, alias_prefix=TLSManager.OLD_PREFIX
                 )
@@ -207,7 +207,7 @@ class TLSHandler(Object):
         state.ca = event.ca.raw
         state.chain = json.dumps([certificate.raw for certificate in event.chain])
 
-        for dependent in ["broker", "balancer"]:
+        for dependent in ["kafka", "balancer"]:
             getattr(self.charm, dependent).tls_manager.remove_stores(scope=state.scope)
             getattr(self.charm, dependent).tls_manager.configure()
 

--- a/src/events/user_secrets.py
+++ b/src/events/user_secrets.py
@@ -32,7 +32,7 @@ from literals import INTERNAL_USERS
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
-    from events.broker import BrokerOperator
+    from events.kafka import KafkaOperator
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 class SecretsHandler(Object):
     """Handler for events related to user-defined secrets."""
 
-    def __init__(self, dependent: "BrokerOperator") -> None:
+    def __init__(self, dependent: "KafkaOperator") -> None:
         super().__init__(dependent.charm, "connect-secrets")
         self.dependent = dependent
         self.charm: "KafkaCharm" = dependent.charm

--- a/src/health.py
+++ b/src/health.py
@@ -16,7 +16,7 @@ from literals import JVM_MEM_MAX_GB, JVM_MEM_MIN_GB
 
 if TYPE_CHECKING:
     from charm import KafkaCharm
-    from events.broker import BrokerOperator
+    from events.kafka import KafkaOperator
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class KafkaHealth(Object):
     """Manager for handling Kafka machine health."""
 
-    def __init__(self, dependent: "BrokerOperator") -> None:
+    def __init__(self, dependent: "KafkaOperator") -> None:
         super().__init__(dependent, "kafka_health")
         self.dependent = dependent
         self.charm: "KafkaCharm" = dependent.charm

--- a/src/managers/balancer.py
+++ b/src/managers/balancer.py
@@ -18,7 +18,7 @@ from literals import BALANCER, BALANCER_TOPICS, MODE_FULL, STORAGE
 if TYPE_CHECKING:
     from charm import KafkaCharm
     from events.balancer import BalancerOperator
-    from events.broker import BrokerOperator
+    from events.kafka import KafkaOperator
 
 
 logger = logging.getLogger(__name__)
@@ -129,7 +129,7 @@ class CruiseControlClient:
 class BalancerManager:
     """Manager for handling Balancer."""
 
-    def __init__(self, dependent: "BrokerOperator | BalancerOperator") -> None:
+    def __init__(self, dependent: "KafkaOperator | BalancerOperator") -> None:
         self.dependent = dependent
         self.charm: "KafkaCharm" = dependent.charm
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -118,7 +118,7 @@ def test_log_dirs_in_server_properties(ctx: Context, base_state: State) -> None:
     # When
     with (ctx(ctx.on.config_changed(), state_in) as manager,):
         charm = cast(KafkaCharm, manager.charm)
-        for prop in charm.broker.config_manager.server_properties:
+        for prop in charm.kafka.config_manager.server_properties:
             if "log.dirs" in prop:
                 found_log_dirs = True
 
@@ -174,12 +174,12 @@ def test_listeners_in_server_properties(charm_configuration: dict, base_state: S
 
         listeners = [
             prop
-            for prop in charm.broker.config_manager.server_properties
+            for prop in charm.kafka.config_manager.server_properties
             if prop.startswith("listeners=")
         ][0]
         advertised_listeners = [
             prop
-            for prop in charm.broker.config_manager.server_properties
+            for prop in charm.kafka.config_manager.server_properties
             if prop.startswith("advertised.listeners=")
         ][0]
 
@@ -221,7 +221,7 @@ def test_extra_listeners_in_server_properties(charm_configuration: dict, base_st
 
         # Then
         # 3 extra, 1 internal, 1 client
-        assert len(charm.broker.config_manager.all_listeners) == 5
+        assert len(charm.kafka.config_manager.all_listeners) == 5
 
     # Adding SSL
     tls_relation = Relation(TLS_RELATION)
@@ -235,7 +235,7 @@ def test_extra_listeners_in_server_properties(charm_configuration: dict, base_st
 
         # Then
         # 3 extra, 1 internal, 1 client
-        assert len(charm.broker.config_manager.all_listeners) == 5
+        assert len(charm.kafka.config_manager.all_listeners) == 5
 
     # Adding SSL
     client_relation = dataclasses.replace(
@@ -249,10 +249,10 @@ def test_extra_listeners_in_server_properties(charm_configuration: dict, base_st
 
         # Then
         # 3 extra sasl_ssl, 3 extra ssl, 1 internal, 2 client
-        assert len(charm.broker.config_manager.all_listeners) == 9
+        assert len(charm.kafka.config_manager.all_listeners) == 9
 
         advertised_listeners_prop = ""
-        for prop in charm.broker.config_manager.server_properties:
+        for prop in charm.kafka.config_manager.server_properties:
             if "advertised.listener" in prop:
                 advertised_listeners_prop = prop
 
@@ -332,8 +332,8 @@ def test_oauth_client_listeners_in_server_properties(ctx: Context, base_state: S
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert expected_listeners in charm.broker.config_manager.server_properties
-        assert expected_advertised_listeners in charm.broker.config_manager.server_properties
+        assert expected_listeners in charm.kafka.config_manager.server_properties
+        assert expected_advertised_listeners in charm.kafka.config_manager.server_properties
 
 
 def test_ssl_listeners_in_server_properties(ctx: Context, base_state: State, patched_exec) -> None:
@@ -377,8 +377,8 @@ def test_ssl_listeners_in_server_properties(ctx: Context, base_state: State, pat
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert expected_listeners in charm.broker.config_manager.server_properties
-        assert expected_advertised_listeners in charm.broker.config_manager.server_properties
+        assert expected_listeners in charm.kafka.config_manager.server_properties
+        assert expected_advertised_listeners in charm.kafka.config_manager.server_properties
 
 
 def test_kafka_opts(ctx: Context, base_state: State) -> None:
@@ -391,7 +391,7 @@ def test_kafka_opts(ctx: Context, base_state: State) -> None:
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        args = charm.broker.config_manager.kafka_opts
+        args = charm.kafka.config_manager.kafka_opts
         assert "KAFKA_OPTS" in args
 
 
@@ -414,7 +414,7 @@ def test_heap_opts(
     with ctx(ctx.on.config_changed(), state_in) as manager:
         charm = cast(KafkaCharm, manager.charm)
 
-        args = charm.broker.config_manager.heap_opts
+        args = charm.kafka.config_manager.heap_opts
 
     # Then
     assert f"Xms{expected}G" in args
@@ -430,7 +430,7 @@ def test_kafka_jmx_opts(ctx: Context, base_state: State) -> None:
     # When
     with ctx(ctx.on.config_changed(), state_in) as manager:
         charm = cast(KafkaCharm, manager.charm)
-        args = charm.broker.config_manager.kafka_jmx_opts
+        args = charm.kafka.config_manager.kafka_jmx_opts
 
     # Then
     assert "-javaagent:" in args
@@ -446,7 +446,7 @@ def test_cc_jmx_opts(ctx: Context, base_state: State) -> None:
     # When
     with ctx(ctx.on.config_changed(), state_in) as manager:
         charm = cast(KafkaCharm, manager.charm)
-        args = charm.broker.config_manager.cc_jmx_opts
+        args = charm.kafka.config_manager.cc_jmx_opts
 
     # Then
     assert "-javaagent:" in args
@@ -467,7 +467,7 @@ def test_set_environment(ctx: Context, base_state: State) -> None:
         ctx(ctx.on.config_changed(), state_in) as manager,
     ):
         charm = cast(KafkaCharm, manager.charm)
-        charm.broker.config_manager.set_environment()
+        charm.kafka.config_manager.set_environment()
 
     # Then
     for call in patched_write.call_args_list:
@@ -510,14 +510,12 @@ def test_default_replication_properties_less_than_three(ctx: Context, base_state
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert "num.partitions=1" in charm.broker.config_manager.default_replication_properties
+        assert "num.partitions=1" in charm.kafka.config_manager.default_replication_properties
         assert (
             "default.replication.factor=1"
-            in charm.broker.config_manager.default_replication_properties
+            in charm.kafka.config_manager.default_replication_properties
         )
-        assert (
-            "min.insync.replicas=1" in charm.broker.config_manager.default_replication_properties
-        )
+        assert "min.insync.replicas=1" in charm.kafka.config_manager.default_replication_properties
 
 
 def test_default_replication_properties_more_than_three(ctx: Context, base_state: State) -> None:
@@ -531,14 +529,12 @@ def test_default_replication_properties_more_than_three(ctx: Context, base_state
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert "num.partitions=3" in charm.broker.config_manager.default_replication_properties
+        assert "num.partitions=3" in charm.kafka.config_manager.default_replication_properties
         assert (
             "default.replication.factor=3"
-            in charm.broker.config_manager.default_replication_properties
+            in charm.kafka.config_manager.default_replication_properties
         )
-        assert (
-            "min.insync.replicas=2" in charm.broker.config_manager.default_replication_properties
-        )
+        assert "min.insync.replicas=2" in charm.kafka.config_manager.default_replication_properties
 
 
 def test_ssl_principal_mapping_rules(charm_configuration: dict, base_state: State) -> None:
@@ -567,7 +563,7 @@ def test_ssl_principal_mapping_rules(charm_configuration: dict, base_state: Stat
         # Then
         assert (
             "ssl.principal.mapping.rules=RULE:^(erebor)$/$1/,DEFAULT"
-            in charm.broker.config_manager.server_properties
+            in charm.kafka.config_manager.server_properties
         )
 
 
@@ -589,7 +585,7 @@ def test_rack_properties(ctx: Context, base_state: State) -> None:
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert "broker.rack=gondor-west" in charm.broker.config_manager.server_properties
+        assert "broker.rack=gondor-west" in charm.kafka.config_manager.server_properties
 
 
 def test_super_users(ctx: Context, base_state: State) -> None:
@@ -671,7 +667,7 @@ def test_cruise_control_reporter_only_with_balancer(ctx: Context, base_state: St
 
         # Then
         # Default roles value does not include balancer
-        assert reporters_config_value not in charm.broker.config_manager.server_properties
+        assert reporters_config_value not in charm.kafka.config_manager.server_properties
 
     # Given
 
@@ -686,4 +682,4 @@ def test_cruise_control_reporter_only_with_balancer(ctx: Context, base_state: St
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert reporters_config_value in charm.broker.config_manager.server_properties
+        assert reporters_config_value in charm.kafka.config_manager.server_properties

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -74,7 +74,7 @@ def test_service_pid(ctx: Context, base_state: State) -> None:
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert charm.broker.health._service_pid == 1314231
+        assert charm.kafka.health._service_pid == 1314231
 
 
 def test_check_vm_swappiness(ctx: Context, base_state: State) -> None:
@@ -92,8 +92,8 @@ def test_check_vm_swappiness(ctx: Context, base_state: State) -> None:
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert not charm.broker.health._check_vm_swappiness()
-        assert not charm.broker.health.machine_configured()
+        assert not charm.kafka.health._check_vm_swappiness()
+        assert not charm.kafka.health.machine_configured()
 
 
 @pytest.mark.parametrize("total_mem_kb", [5741156, 65741156])
@@ -119,9 +119,9 @@ def test_check_total_memory_testing_profile(
 
         # Then
         if total_mem_kb / 1000000 <= limit:
-            assert not charm.broker.health._check_total_memory()
+            assert not charm.kafka.health._check_total_memory()
         else:
-            assert charm.broker.health._check_total_memory()
+            assert charm.kafka.health._check_total_memory()
 
 
 def test_get_partitions_size(ctx: Context, base_state: State) -> None:
@@ -137,7 +137,7 @@ def test_get_partitions_size(ctx: Context, base_state: State) -> None:
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert charm.broker.health._get_partitions_size() == (5, 393)
+        assert charm.kafka.health._get_partitions_size() == (5, 393)
 
 
 def test_check_file_descriptors_no_listeners(ctx: Context, base_state: State) -> None:
@@ -152,7 +152,7 @@ def test_check_file_descriptors_no_listeners(ctx: Context, base_state: State) ->
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert charm.broker.health._check_file_descriptors()
+        assert charm.kafka.health._check_file_descriptors()
         assert patched_run_bin.call_count == 0
 
 
@@ -178,6 +178,6 @@ def test_machine_configured_succeeds_and_fails(
 
         # Then
         if all([mmap, fd, swap, mem]):
-            assert charm.broker.health.machine_configured()
+            assert charm.kafka.health.machine_configured()
         else:
-            assert not charm.broker.health.machine_configured()
+            assert not charm.kafka.health.machine_configured()

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -68,9 +68,7 @@ def test_client_relation_created_defers_if_not_ready(ctx: Context, base_state: S
 
     # When
     with (
-        patch(
-            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=False
-        ),
+        patch("events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=False),
         patch("managers.auth.AuthManager.add_user") as patched_add_user,
         patch("ops.framework.EventBase.defer") as patched_defer,
     ):
@@ -93,9 +91,7 @@ def test_client_relation_created_adds_user(ctx: Context, base_state: State) -> N
 
     # When
     with (
-        patch(
-            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
-        ),
+        patch("events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True),
         patch("managers.auth.AuthManager.add_user") as patched_add_user,
         patch("workload.KafkaWorkload.run_bin_command"),
     ):
@@ -128,9 +124,7 @@ def test_client_relation_broken_removes_user(ctx: Context, base_state: State) ->
 
     # When
     with (
-        patch(
-            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
-        ),
+        patch("events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True),
         patch("managers.auth.AuthManager.add_user"),
         patch("managers.auth.AuthManager.delete_user") as patched_delete_user,
         patch("managers.auth.AuthManager.remove_all_user_acls") as patched_remove_acls,
@@ -166,9 +160,7 @@ def test_client_relation_joined_sets_necessary_relation_data(
 
     # When
     with (
-        patch(
-            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
-        ),
+        patch("events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True),
         patch("managers.auth.AuthManager.add_user"),
         patch("workload.KafkaWorkload.run_bin_command"),
     ):
@@ -223,9 +215,7 @@ def test_mtls_without_tls_relation(
 
     with (
         patch("workload.KafkaWorkload.read", return_value=["key=value"]),
-        patch(
-            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
-        ),
+        patch("events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True),
         # Model props
         patch("core.models.KafkaCluster.internal_user_credentials"),
     ):
@@ -279,9 +269,7 @@ def test_mtls_setup(
 
     with (
         patch("workload.KafkaWorkload.read", return_value=["key=value"]),
-        patch(
-            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
-        ),
+        patch("events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True),
         # Model props
         patch("core.models.KafkaCluster.internal_user_credentials"),
         # TLSManager methods

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -69,7 +69,7 @@ def test_client_relation_created_defers_if_not_ready(ctx: Context, base_state: S
     # When
     with (
         patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock, return_value=False
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=False
         ),
         patch("managers.auth.AuthManager.add_user") as patched_add_user,
         patch("ops.framework.EventBase.defer") as patched_defer,
@@ -94,7 +94,7 @@ def test_client_relation_created_adds_user(ctx: Context, base_state: State) -> N
     # When
     with (
         patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock, return_value=True
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
         ),
         patch("managers.auth.AuthManager.add_user") as patched_add_user,
         patch("workload.KafkaWorkload.run_bin_command"),
@@ -129,7 +129,7 @@ def test_client_relation_broken_removes_user(ctx: Context, base_state: State) ->
     # When
     with (
         patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock, return_value=True
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
         ),
         patch("managers.auth.AuthManager.add_user"),
         patch("managers.auth.AuthManager.delete_user") as patched_delete_user,
@@ -167,7 +167,7 @@ def test_client_relation_joined_sets_necessary_relation_data(
     # When
     with (
         patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock, return_value=True
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
         ),
         patch("managers.auth.AuthManager.add_user"),
         patch("workload.KafkaWorkload.run_bin_command"),
@@ -224,7 +224,7 @@ def test_mtls_without_tls_relation(
     with (
         patch("workload.KafkaWorkload.read", return_value=["key=value"]),
         patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock, return_value=True
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
         ),
         # Model props
         patch("core.models.KafkaCluster.internal_user_credentials"),
@@ -280,7 +280,7 @@ def test_mtls_setup(
     with (
         patch("workload.KafkaWorkload.read", return_value=["key=value"]),
         patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock, return_value=True
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
         ),
         # Model props
         patch("core.models.KafkaCluster.internal_user_credentials"),
@@ -296,7 +296,7 @@ def test_mtls_setup(
     ):
         mock_auth_manager = MagicMock(spec=AuthManager)
         charm = cast(KafkaCharm, mgr.charm)
-        charm.broker.auth_manager = mock_auth_manager
+        charm.kafka.auth_manager = mock_auth_manager
         state_out = mgr.run()
 
     # Then

--- a/tests/unit/test_refresh.py
+++ b/tests/unit/test_refresh.py
@@ -67,7 +67,7 @@ def test_post_snap_refresh_healthy_cluster(ctx: Context, base_state: State) -> N
         mock_refresh.next_unit_allowed_to_refresh = False
 
         with patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock, return_value=True
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=True
         ):
             charm.post_snap_refresh(mock_refresh)
 
@@ -87,7 +87,7 @@ def test_post_snap_refresh_unhealthy_cluster(ctx: Context, base_state: State) ->
         mock_refresh.next_unit_allowed_to_refresh = False
 
         with patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock, return_value=False
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock, return_value=False
         ):
             charm.post_snap_refresh(mock_refresh)
 

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -104,7 +104,7 @@ def test_extra_sans_config(
         charm = cast(KafkaCharm, manager.charm)
 
         # Then
-        assert charm.broker.tls_manager._build_extra_sans() == expected
+        assert charm.kafka.tls_manager._build_extra_sans() == expected
 
 
 def test_sans(charm_configuration: dict, base_state: State, patched_node_ip) -> None:
@@ -125,7 +125,7 @@ def test_sans(charm_configuration: dict, base_state: State, patched_node_ip) -> 
     if SUBSTRATE == "vm":
         with ctx(ctx.on.config_changed(), state_in) as manager:
             charm = cast(KafkaCharm, manager.charm)
-            built_sans = charm.broker.tls_manager.build_sans()
+            built_sans = charm.kafka.tls_manager.build_sans()
 
         # Then
         assert built_sans == {
@@ -145,7 +145,7 @@ def test_sans(charm_configuration: dict, base_state: State, patched_node_ip) -> 
             ctx(ctx.on.config_changed(), state_in) as manager,
         ):
             charm = cast(KafkaCharm, manager.charm)
-            built_sans = charm.broker.tls_manager.build_sans()
+            built_sans = charm.kafka.tls_manager.build_sans()
 
         # Then
         assert sorted(built_sans["sans_dns"]) == sorted(

--- a/tests/unit/test_user_secrets.py
+++ b/tests/unit/test_user_secrets.py
@@ -66,9 +66,7 @@ def test_set_credentials(
 
     with (
         ctx(ctx.on.secret_changed(auth_secret), state_in) as mgr,
-        patch(
-            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock(return_value=True)
-        ),
+        patch("events.kafka.KafkaOperator.healthy", new_callable=PropertyMock(return_value=True)),
     ):
         charm: KafkaCharm = cast(KafkaCharm, mgr.charm)
         previous_password = charm.state.cluster.internal_user_credentials.get(user)
@@ -107,9 +105,7 @@ def test_secret_removed_preserves_credentials(
 
     with (
         ctx(ctx.on.secret_changed(auth_secret), state_in) as mgr,
-        patch(
-            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock(return_value=True)
-        ),
+        patch("events.kafka.KafkaOperator.healthy", new_callable=PropertyMock(return_value=True)),
     ):
         charm: KafkaCharm = cast(KafkaCharm, mgr.charm)
         previous_password = charm.state.cluster.internal_user_credentials.get("admin")
@@ -122,9 +118,7 @@ def test_secret_removed_preserves_credentials(
 
     with (
         ctx(ctx.on.config_changed(), state_interim) as mgr,
-        patch(
-            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock(return_value=True)
-        ),
+        patch("events.kafka.KafkaOperator.healthy", new_callable=PropertyMock(return_value=True)),
     ):
         charm: KafkaCharm = cast(KafkaCharm, mgr.charm)
         new_password = charm.state.cluster.internal_user_credentials.get("admin")

--- a/tests/unit/test_user_secrets.py
+++ b/tests/unit/test_user_secrets.py
@@ -67,7 +67,7 @@ def test_set_credentials(
     with (
         ctx(ctx.on.secret_changed(auth_secret), state_in) as mgr,
         patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock(return_value=True)
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock(return_value=True)
         ),
     ):
         charm: KafkaCharm = cast(KafkaCharm, mgr.charm)
@@ -108,7 +108,7 @@ def test_secret_removed_preserves_credentials(
     with (
         ctx(ctx.on.secret_changed(auth_secret), state_in) as mgr,
         patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock(return_value=True)
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock(return_value=True)
         ),
     ):
         charm: KafkaCharm = cast(KafkaCharm, mgr.charm)
@@ -123,7 +123,7 @@ def test_secret_removed_preserves_credentials(
     with (
         ctx(ctx.on.config_changed(), state_interim) as mgr,
         patch(
-            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock(return_value=True)
+            "events.kafka.KafkaOperator.healthy", new_callable=PropertyMock(return_value=True)
         ),
     ):
         charm: KafkaCharm = cast(KafkaCharm, mgr.charm)


### PR DESCRIPTION
This PR renames `broker.py` module to `kafka.py`, and `BrokerOperator` handler to `KafkaOperator`.