### PR TITLE
Implement page-to-page Discourse redirects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -214,8 +214,9 @@ html_static_path = ["_static"]
 # NOTE: If undefined, set to None, or empty,
 #       the sphinx_reredirects extension will be disabled.
 
-redirects = {}
+# redirects = {}
 
+rediraffe_redirects = "redirects.txt"
 
 ###########################
 # Link checker exceptions #
@@ -288,6 +289,7 @@ extensions = [
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
+    "sphinxext.rediraffe",
 ]
 
 # Excludes files or directories from processing

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -22,7 +22,7 @@ Charmed Apache Kafka can be deployed on top of several clouds and virtualisation
 
 ### Juju
 
-Juju is the component responsible for orchestrating the entire lifecycle, from deployment to Day 2 operations. For more information on Juju security hardening, see the [Juju security](https://documentation.ubuntu.com/juju/3.6/explanation/juju-security/) page and the [How to harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#harden-your-deployment) guide.
+Juju is the component responsible for orchestrating the entire lifecycle, from deployment to Day 2 operations. For more information on Juju security hardening, see the [Juju security](https://documentation.ubuntu.com/juju/3.6/explanation/juju-security/) page and the [How to harden your deployment](https://documentation.ubuntu.com/juju/latest/howto/manage-your-juju-deployment/harden-your-juju-deployment/) guide.
 
 #### Cloud credentials
 

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -15,14 +15,14 @@
 # Tutorial
 
 t-overview/ tutorial/
-t-setup-environment/ environment/
-t-deploy/ deploy/
-t-relate-kafka/ integrate-with-client-applications/
-t-manage-passwords/ manage-passwords/
-t-enable-encryption/ enable-encryption/
-t-kafka-connect/ use-kafka-connect/
-t-reassign-partitions/ rebalance-partitions/
-t-cleanup-environment/ cleanup/
+t-setup-environment/ tutorial/environment/
+t-deploy/ tutorial/deploy/
+t-relate-kafka/ tutorial/integrate-with-client-applications/
+t-manage-passwords/ tutorial/manage-passwords/
+t-enable-encryption/ tutorial/enable-encryption/
+t-kafka-connect/ tutorial/use-kafka-connect/
+t-reassign-partitions/ tutorial/rebalance-partitions/
+t-cleanup-environment/ tutorial/cleanup/
 
 # How-to guides
 
@@ -30,8 +30,8 @@ h-deploy/ how-to/deploy/
 h-deploy-anywhere/ how-to/deploy/
 h-deploy-aws/ how-to/deploy/deploy-aws/
 h-deploy-azure/ how-to/deploy/deploy-azure/
+h-kraft-mode/ how-to/deploy/kraft-mode/
 
-h-kraft-mode/ how-to/kraft-mode/
 h-manage-units/ how-to/manage-units/
 h-manage-app/ how-to/manage-applications/
 h-enable-encryption/ how-to/enable-encryption/
@@ -39,7 +39,7 @@ h-upgrade/ how-to/upgrade/
 
 h-monitoring/ how-to/monitoring/
 h-enable-monitoring/ how-to/monitoring/
-h-integrate-alerts-dashboards/ how-to/monitoring/#alerts-and-dashboards
+h-integrate-alerts-dashboards/ how-to/monitoring/
 
 h-cluster/ how-to/cluster/
 h-cluster-migration/ how-to/cluster/migrate/
@@ -60,9 +60,9 @@ r-rev156_136/ reference/release-notes/revision-156-136/
 r-rev195_149/ reference/release-notes/revision-195-149/
 r-rev205/ reference/release-notes/revision-205/
 
-r-actions/ https://charmhub.io/kafka/actions?channel=3/edge
-r-configurations/ https://charmhub.io/kafka/configure?channel=3/edge
-r-libraries/ https://charmhub.io/kafka/libraries/kafka_libs?channel=3/edge
+# r-actions/ https://charmhub.io/kafka/actions?channel=3/edge
+# r-configurations/ https://charmhub.io/kafka/configure?channel=3/edge
+# r-libraries/ https://charmhub.io/kafka/libraries/kafka_libs?channel=3/edge
 r-file-system-paths/ reference/file-system-paths/
 r-snap-entrypoints/ reference/snap-entrypoints/
 r-listeners/ reference/listeners/

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,0 +1,80 @@
+# The redirects.txt file stores all the redirects for the published docs
+# If you change a filename, move or delete a file, you need a redirect here.
+# - Comment lines start with a hash (#) and are ignored
+# - Each redirect should appear on its own line
+
+# We are using the dirhtml builder, so files are treated as directories:
+# - A file is built like `filename/index.html`, not `filename.html`
+# - *Do* include a trailing slash at the end of the path
+# - *Do not* include a file extension or you'll get errors
+# - Paths don't need a slash in front of them
+
+# Example:
+# redirect/from/file/ redirect/to/file/
+
+# Tutorial
+
+t-overview/ tutorial/
+t-setup-environment/ environment/
+t-deploy/ deploy/
+t-relate-kafka/ integrate-with-client-applications/
+t-manage-passwords/ manage-passwords/
+t-enable-encryption/ enable-encryption/
+t-kafka-connect/ use-kafka-connect/
+t-reassign-partitions/ rebalance-partitions/
+t-cleanup-environment/ cleanup/
+
+# How-to guides
+
+h-deploy/ how-to/deploy/
+h-deploy-anywhere/ how-to/deploy/
+h-deploy-aws/ how-to/deploy/deploy-aws/
+h-deploy-azure/ how-to/deploy/deploy-azure/
+
+h-kraft-mode/ how-to/kraft-mode/
+h-manage-units/ how-to/manage-units/
+h-manage-app/ how-to/manage-applications/
+h-enable-encryption/ how-to/enable-encryption/
+h-upgrade/ how-to/upgrade/
+
+h-monitoring/ how-to/monitoring/
+h-enable-monitoring/ how-to/monitoring/
+h-integrate-alerts-dashboards/ how-to/monitoring/#alerts-and-dashboards
+
+h-cluster/ how-to/cluster/
+h-cluster-migration/ how-to/cluster/migrate/
+h-cluster-replication/ how-to/cluster/replication/
+
+h-create-mtls-client-credentials/ how-to/create-mtls-client-credentials/
+h-enable-oauth/ how-to/oauth/
+h-backup/ how-to/back-up-and-restore/
+h-manage-message-schemas/ how-to/schemas/
+h-kafka-connect/ how-to/kafka-connect/
+
+# Reference
+
+
+r-releases/ reference/release-notes/
+r-rev156_126/ reference/release-notes/revision-156-126/
+r-rev156_136/ reference/release-notes/revision-156-136/
+r-rev195_149/ reference/release-notes/revision-195-149/
+r-rev205/ reference/release-notes/revision-205/
+
+r-actions/ https://charmhub.io/kafka/actions?channel=3/edge
+r-configurations/ https://charmhub.io/kafka/configure?channel=3/edge
+r-libraries/ https://charmhub.io/kafka/libraries/kafka_libs?channel=3/edge
+r-file-system-paths/ reference/file-system-paths/
+r-snap-entrypoints/ reference/snap-entrypoints/
+r-listeners/ reference/listeners/
+r-statuses/ reference/statuses/
+r-requirements/ reference/requirements/
+r-performance-tuning/ reference/performance-tuning/
+r-contacts/ reference/contact/
+
+# Explanation
+
+e-security/ explanation/security/
+e-cryptography/ explanation/cryptography/
+e-cluster-configuration/ explanation/cluster-configuration/
+e-trademarks/ explanation/trademarks/
+e-mirrormaker/ explanation/mirrormaker2-0/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ packaging
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
 sphinx-sitemap
+sphinxext-rediraffe


### PR DESCRIPTION
Implementing page-to-page matching to apply after wildcard redirects.
You can check them by navigating to the preview build URLs:

Test 1:
https://canonical-ubuntu-documentation-library--405.com.readthedocs.build/charmed-kafka/405/t-relate-kafka/ 
should redirect to 
https://canonical-ubuntu-documentation-library--405.com.readthedocs.build/charmed-kafka/405/tutorial/integrate-with-client-applications/index.html

Test 2:
https://canonical-ubuntu-documentation-library--405.com.readthedocs.build/charmed-kafka/405/h-deploy-azure/
should redirect to
https://canonical-ubuntu-documentation-library--405.com.readthedocs.build/charmed-kafka/405/how-to/deploy/deploy-azure/index.html