### PR TITLE
ci: remove lib-check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,24 +45,6 @@ jobs:
       - name: Run tests
         run: tox run -e unit
 
-  lib-check:
-    if: ${{ github.event_name == 'schedule' }}
-    name: Check libraries
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.7.0
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      pull-requests: write
-
   build:
     strategy:
       matrix:


### PR DESCRIPTION
This PR removes `lib-check` from the CI.

Rationale:
- `lib-check` always fails on this repo given the fact that we have an unpublished charmlib, producing no meaningful results
- Leads to lots of failure noise on scheduled tests.