### PR TITLE
Docs: Fix docs badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CharmHub Badge](https://charmhub.io/kafka/badge.svg)](https://charmhub.io/kafka)
 [![Release](https://github.com/canonical/kafka-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/kafka-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/kafka-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/kafka-operator/actions/workflows/ci.yaml?query=branch%3Amain)
-[![Docs](https://readthedocs.com/projects/canonical-charmed-kafka/badge/?version=3&style=plastic)](https://app.readthedocs.com/projects/canonical-charmed-kafka/builds/?version__slug=3)
+[![Docs](https://readthedocs.com/projects/canonical-charmed-kafka/badge/?version=3)](https://app.readthedocs.com/projects/canonical-charmed-kafka/builds/?version__slug=3)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CharmHub Badge](https://charmhub.io/kafka/badge.svg)](https://charmhub.io/kafka)
 [![Release](https://github.com/canonical/kafka-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/kafka-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/kafka-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/kafka-operator/actions/workflows/ci.yaml?query=branch%3Amain)
-[![Docs](https://readthedocs.com/projects/canonical-charmed-kafka/badge/?version=main&style=plastic)](https://app.readthedocs.com/projects/canonical-charmed-kafka/builds/?version__slug=main)
+[![Docs](https://readthedocs.com/projects/canonical-charmed-kafka/badge/?version=3&style=plastic)](https://app.readthedocs.com/projects/canonical-charmed-kafka/builds/?version__slug=3)
 
 ## Overview
 


### PR DESCRIPTION
Fixed the docs badge in our README file to show correct results by replacing the version slug with the correct one for the track `3`.
I've switched to the default (flat) style, as it seems to be looking closer to other badges. To see a preview, open the rendered README file. For example: https://github.com/canonical/kafka-operator/blob/32293af7cf373f82d4ebc33706da24470f8556f9/README.md