### PR TITLE
Update Charmhub description

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,7 +9,7 @@ description: |
   Apache Kafka is a free, open source software project by the Apache Software Foundation. 
   Users can find out more at the [Apache Kafka project page](https://kafka.apache.org/).
 summary: Charmed Apache Kafka Operator
-docs: https://discourse.charmhub.io/t/charmed-kafka-documentation/10288
+docs: https://discourse.charmhub.io/t/charmed-apache-kafka-v-4-x/18914
 source: https://github.com/canonical/kafka-operator
 issues: https://github.com/canonical/kafka-operator/issues
 website:


### PR DESCRIPTION
Updating the `metadata.yaml` file to show only description on Charmhub's Description tab, instead of full docs previously.