### PR TITLE
docs: Replace charmhub links

### DIFF
--- a/docs/how-to/deploy/deploy-anywhere.md
+++ b/docs/how-to/deploy/deploy-anywhere.md
@@ -6,7 +6,7 @@ For specific guides, see: [AWS](how-to-deploy-deploy-on-aws), [Azure](how-to-dep
 (how-to-deploy-deploy-anywhere)=
 
 ```{caution}
-For K8s Charmed Apache Kafka, see the [Charmed Apache Kafka K8s documentation](https://charmhub.io/kafka-k8s) instead.
+For K8s Charmed Apache Kafka, see the [Charmed Apache Kafka K8s documentation](https://documentation.ubuntu.com/charmed-kafka-k8s/3/) instead.
 ```
 
 To deploy a Charmed Apache Kafka cluster on a bare environment, it is necessary to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 (index)=
 
 ```{note}
-This is an **IAAS/VM** charmed operator. To deploy on Kubernetes, see [Charmed Apache Kafka K8s operator](https://charmhub.io/kafka-k8s).
+This is an **IAAS/VM** charmed operator. To deploy on Kubernetes, see [Charmed Apache Kafka K8s operator](https://documentation.ubuntu.com/charmed-kafka-k8s/3/).
 ```
 
 # Charmed Apache Kafka documentation


### PR DESCRIPTION
Replaced Charmhub links in the Kafka-K8s substrate warnings with Kafka K8s RTD docs links.