### PR TITLE
[DPE-8311] refactor: remove deployment mode logic from the TF module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,7 @@
 resource "juju_application" "kafka" {
   model = var.model
   name  = var.app_name
-  
+
   charm {
     name     = "kafka"
     channel  = var.channel

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,5 @@
 # Single mode: Combined broker+controller
-resource "juju_application" "kafka_single" {
-  count = var.deployment_mode == "single" ? 1 : 0
+resource "juju_application" "kafka" {
   model = var.model
   name  = var.app_name
   
@@ -11,85 +10,17 @@ resource "juju_application" "kafka_single" {
     base     = var.base
   }
 
-  units       = var.broker_units != null ? var.broker_units : var.units
+  units       = var.units
   constraints = var.constraints
-  config      = merge(var.config, {
-    roles = "broker,controller"
-  })
+  config      = var.config
+
   storage_directives = var.storage
 
-}
-
-# Split mode: Separate controller
-resource "juju_application" "kafka_controller" {
-  count = var.deployment_mode == "split" ? 1 : 0
-  model = var.model
-  name  = var.controller_app_name != null ? var.controller_app_name : "${var.app_name}-controller"
-  
-  charm {
-    name     = "kafka"
-    channel  = var.channel
-    revision = var.revision
-    base     = var.base
-  }
-  
-  units       = var.controller_units
-  constraints = var.constraints
-  config      = merge(var.config, {
-    roles = "controller"
-  })
-}
-
-# Split mode: Separate broker
-resource "juju_application" "kafka_broker" {
-  count = var.deployment_mode == "split" ? 1 : 0
-  model = var.model
-  name  = var.broker_app_name != null ? var.broker_app_name : "${var.app_name}-broker"
-  
-  charm {
-    name     = "kafka"
-    channel  = var.channel
-    revision = var.revision
-    base     = var.base
-  }
-  
-  units       = var.broker_units != null ? var.broker_units : var.units
-  constraints = var.constraints
-  config      = merge(var.config, {
-    roles = "broker"
-  })
-  storage_directives = var.storage
-
-}
-
-# Split mode: Integration between broker and controller
-resource "juju_integration" "broker_controller" {
-  count = var.deployment_mode == "split" ? 1 : 0
-  model = var.model
-  
-  application {
-    name     = juju_application.kafka_broker[0].name
-    endpoint = "peer-cluster-orchestrator"
-  }
-  
-  application {
-    name     = juju_application.kafka_controller[0].name
-    endpoint = "peer-cluster"
-  }
 }
 
 # Kafka client offer - Single mode
-resource "juju_offer" "kafka_client_single" {
-  count            = var.deployment_mode == "single" ? 1 : 0
+resource "juju_offer" "kafka_client" {
   model            = var.model
-  application_name = juju_application.kafka_single[0].name
-  endpoints        = ["kafka-client"]
-}
-
-# Kafka client offer - Split mode (broker provides client access)
-resource "juju_offer" "kafka_client_split" {
-  count            = var.deployment_mode == "split" ? 1 : 0
-  model            = var.model
-  application_name = juju_application.kafka_broker[0].name
+  application_name = juju_application.kafka.name
   endpoints        = ["kafka-client"]
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,7 +1,7 @@
 # CC006 mandatory outputs
 output "app_name" {
   description = "Name of the main Kafka application"
-  value = juju_application.kafka.name
+  value       = juju_application.kafka.name
 }
 
 output "provides_endpoints" {
@@ -21,5 +21,5 @@ output "offers" {
 
 output "kafka_client_offer" {
   description = "Kafka client offer URL for external applications"
-  value = juju_offer.kafka_client.url
+  value       = juju_offer.kafka_client.url
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,11 +1,7 @@
 # CC006 mandatory outputs
 output "app_name" {
   description = "Name of the main Kafka application"
-  value = var.deployment_mode == "single" ? (
-    length(juju_application.kafka_single) > 0 ? juju_application.kafka_single[0].name : null
-  ) : (
-    length(juju_application.kafka_broker) > 0 ? juju_application.kafka_broker[0].name : null
-  )
+  value = juju_application.kafka.name
 }
 
 output "provides_endpoints" {
@@ -19,39 +15,11 @@ output "provides_endpoints" {
 output "offers" {
   description = "offers created by this charm"
   value = {
-    kafka-client = var.deployment_mode == "single" ? (
-      length(juju_offer.kafka_client_single) > 0 ? juju_offer.kafka_client_single[0].url : null
-    ) : (
-      length(juju_offer.kafka_client_split) > 0 ? juju_offer.kafka_client_split[0].url : null
-    )
+    kafka-client = juju_offer.kafka_client.url
   }
-}
-
-# Additional outputs for reference
-output "deployment_mode" {
-  description = "Kafka deployment mode used"
-  value       = var.deployment_mode
-}
-
-output "controller_app_name" {
-  description = "Name of the controller application (split mode only)"
-  value = var.deployment_mode == "split" ? (
-    length(juju_application.kafka_controller) > 0 ? juju_application.kafka_controller[0].name : null
-  ) : null
-}
-
-output "broker_app_name" {
-  description = "Name of the broker application (split mode only)"
-  value = var.deployment_mode == "split" ? (
-    length(juju_application.kafka_broker) > 0 ? juju_application.kafka_broker[0].name : null
-  ) : null
 }
 
 output "kafka_client_offer" {
   description = "Kafka client offer URL for external applications"
-  value = var.deployment_mode == "single" ? (
-    length(juju_offer.kafka_client_single) > 0 ? juju_offer.kafka_client_single[0].url : null
-  ) : (
-    length(juju_offer.kafka_client_split) > 0 ? juju_offer.kafka_client_split[0].url : null
-  )
+  value = juju_offer.kafka_client.url
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,37 +52,3 @@ variable "base" {
   default     = "ubuntu@24.04"
 }
 
-variable "deployment_mode" {
-  description = "Kafka deployment mode: 'single' (combined broker+controller) or 'split' (separate broker and controller)"
-  type        = string
-  default     = "split"
-  
-  validation {
-    condition     = contains(["single", "split"], var.deployment_mode)
-    error_message = "Deployment mode must be either 'single' or 'split'."
-  }
-}
-
-variable "broker_units" {
-  description = "Number of broker units (used in split mode or overrides units in single mode)"
-  type        = number
-  default     = null
-}
-
-variable "controller_units" {
-  description = "Number of controller units (only used in split mode)"
-  type        = number
-  default     = 3
-}
-
-variable "broker_app_name" {
-  description = "Name for the broker application in split mode (defaults to app_name-broker)"
-  type        = string
-  default     = null
-}
-
-variable "controller_app_name" {
-  description = "Name for the controller application in split mode (defaults to app_name-controller)"
-  type        = string
-  default     = null
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel to deploy from"
   type        = string
-  default = "4/edge"
+  default     = "4/edge"
 }
 
 variable "config" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 0.14.0"
-  
+
   required_providers {
     juju = {
       source  = "juju/juju"


### PR DESCRIPTION
This PR accompanies another PR on the bundle repo, in which I moved all the deployment logic from the charm module to the product module, based on our joint discussion and decision.