### PR TITLE
docs: Update docs README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CharmHub Badge](https://charmhub.io/kafka/badge.svg)](https://charmhub.io/kafka)
 [![Release](https://github.com/canonical/kafka-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/kafka-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/kafka-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/kafka-operator/actions/workflows/ci.yaml?query=branch%3Amain)
-[![Docs](https://readthedocs.com/projects/canonical-charmed-kafka/badge/?version=main&style=plastic)](https://app.readthedocs.com/projects/canonical-charmed-kafka/builds/?version__slug=main)
+[![Docs](https://readthedocs.com/projects/canonical-charmed-kafka/badge/?version=4&style=plastic)](https://app.readthedocs.com/projects/canonical-charmed-kafka/builds/?version__slug=4)
 
 ## Overview
 


### PR DESCRIPTION
Preparing the README docs badge for RTD docs version 4.
It will be working as soon as we make the docs public. For now, it shows unknown status. AFAIK, this is because the docs for version 4 are private.