### PR TITLE
docs: Enable sequential nav buttons

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,13 +227,14 @@ linkcheck_ignore = [
     "https://kafka.apache.org/documentation/#connectconfigs",
     "https://kafka.apache.org/documentation/#kraft",
     "https://kafka.apache.org/documentation/#mirrormakerconfigs",
+    "https://kafka.apache.org/documentation/#security_authz_ssl",
     "https://matrix.to/#/#charmhub-data-platform:ubuntu.com",
     "https://us-east-1.console.aws.amazon.com/ec2/",
     "https://kafka.apache.org/39/documentation.html#georeplication-overview",
     "https://kafka.apache.org/39/documentation.html#georeplication-monitoring",
     "https://launchpad.net/soss",
     "https://cwiki.apache.org/*",
-    "https://archive.apache.org/*"
+    "https://archive.apache.org/*",
     ]
 
 


### PR DESCRIPTION
Enable Previous and Next buttons at the bottom of each documentation page for sequential navigation.

<img width="887" height="88" alt="Screenshot from 2025-10-10 21-16-09" src="https://github.com/user-attachments/assets/6df6cb3c-d53f-4755-8b2b-0edd46b34689" />

https://github.com/canonical/kafka-operator/pull/421 cherry-pick