### PR TITLE
docs: Home page improvements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ```{note}
 This is an **IAAS/VM** charmed operator.
-To deploy on Kubernetes, see [Charmed Apache Kafka K8s operator](https://charmhub.io/kafka-k8s).
+To deploy on Kubernetes, see [Charmed Apache Kafka K8s operator](https://documentation.ubuntu.com/charmed-kafka-k8s/4/).
 ```
 
 # Charmed Apache Kafka documentation


### PR DESCRIPTION
Cherry-picked home page improvements from edge.
Deleted references to pages that are no longer present: backups how-to guide and ZooKeeper cluster config explanation.
Updated a link to the Contacts page to use the internal RTD page, instead of the Discourse post.