### PR TITLE
ci: temporarily pin jammy LXD image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,8 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
+          lxc image copy ubuntu:568f69ff1166 local:
+          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
           if [ "${{ github.event_name }}" == "schedule" ]
           then
             echo Running unstable and stable tests
@@ -156,6 +158,8 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
+          lxc image copy ubuntu:568f69ff1166 local:
+          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
           if [ "${{ github.event_name }}" == "schedule" ]
           then
             echo Running unstable and stable tests


### PR DESCRIPTION
This is a temp fix, which pins the LXD jammy image, in order to unblock CI issues due to the recent problematic LXD image with serial `20251017`. Apparently, a fix from the upstream takes longer than expected to ship and all our CI tests which deploy jammy charms will fail until then...