### PR TITLE
ci: unpin juju & lxd image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,6 @@ jobs:
         with:
           provider: lxd
           juju-channel: 3.6/stable
-          bootstrap-options: "--agent-version 3.6.6"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v4
         with:
@@ -162,7 +161,6 @@ jobs:
         with:
           provider: lxd
           juju-channel: 3.6/stable
-          bootstrap-options: "--agent-version 3.6.6"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
       - lint
       - unit-test
       - build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,10 +105,6 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
-          lxc image copy ubuntu:ad33d28f277c local:
-          sudo lxc image alias delete "juju/ubuntu@24.04/amd64"
-          sudo lxc image alias create "juju/ubuntu@24.04/amd64" ad33d28f277c
-
           if [ "${{ github.event_name }}" == "schedule" ]
           then
             echo Running unstable and stable tests
@@ -121,6 +117,9 @@ jobs:
         run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --kraft-mode ${{ matrix.kraft-mode }}
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
 
   integration-test-multi:
     strategy:
@@ -203,10 +202,6 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
-          lxc image copy ubuntu:ad33d28f277c local:
-          sudo lxc image alias delete "juju/ubuntu@24.04/amd64"
-          sudo lxc image alias create "juju/ubuntu@24.04/amd64" ad33d28f277c
-
           if [ "${{ github.event_name }}" == "schedule" ]
           then
             echo Running unstable and stable tests
@@ -219,4 +214,7 @@ jobs:
         run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --keep-models --kraft-mode ${{ matrix.kraft-mode }}
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,11 +105,6 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
-          # TODO: remove after LXD image issue is fixed:
-          # https://bugs.launchpad.net/snapd/+bug/2127244
-          lxc image copy ubuntu:568f69ff1166 local:
-          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
-
           if [ "${{ github.event_name }}" == "schedule" ]
           then
             echo Running unstable and stable tests
@@ -204,11 +199,6 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
-          # TODO: remove after LXD image issue is fixed:
-          # https://bugs.launchpad.net/snapd/+bug/2127244
-          lxc image copy ubuntu:568f69ff1166 local:
-          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
-
           if [ "${{ github.event_name }}" == "schedule" ]
           then
             echo Running unstable and stable tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,9 +105,9 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
-          lxc image copy ubuntu:40cd8be9d79e local:
+          lxc image copy ubuntu:ad33d28f277c local:
           sudo lxc image alias delete "juju/ubuntu@24.04/amd64"
-          sudo lxc image alias create "juju/ubuntu@24.04/amd64" 40cd8be9d79e
+          sudo lxc image alias create "juju/ubuntu@24.04/amd64" ad33d28f277c
 
           if [ "${{ github.event_name }}" == "schedule" ]
           then
@@ -203,9 +203,9 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
-          lxc image copy ubuntu:40cd8be9d79e local:
+          lxc image copy ubuntu:ad33d28f277c local:
           sudo lxc image alias delete "juju/ubuntu@24.04/amd64"
-          sudo lxc image alias create "juju/ubuntu@24.04/amd64" 40cd8be9d79e
+          sudo lxc image alias create "juju/ubuntu@24.04/amd64" ad33d28f277c
 
           if [ "${{ github.event_name }}" == "schedule" ]
           then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,9 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
+          lxc image copy ubuntu:40cd8be9d79e local:
+          sudo lxc image alias create "juju/ubuntu@24.04/amd64" 40cd8be9d79e
+
           if [ "${{ github.event_name }}" == "schedule" ]
           then
             echo Running unstable and stable tests
@@ -199,6 +202,9 @@ jobs:
       - name: Select tests
         id: select-tests
         run: |
+          lxc image copy ubuntu:40cd8be9d79e local:
+          sudo lxc image alias create "juju/ubuntu@24.04/amd64" 40cd8be9d79e
+
           if [ "${{ github.event_name }}" == "schedule" ]
           then
             echo Running unstable and stable tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
       - lint
       - unit-test
       - build
-    runs-on: [self-hosted, linux, AMD64, X64, large, noble]
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -216,5 +216,4 @@ jobs:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
       - name: Setup tmate session
         if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-
+        uses: canonical/action-tmate@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,7 @@ jobs:
         id: select-tests
         run: |
           lxc image copy ubuntu:40cd8be9d79e local:
+          sudo lxc image alias delete "juju/ubuntu@24.04/amd64"
           sudo lxc image alias create "juju/ubuntu@24.04/amd64" 40cd8be9d79e
 
           if [ "${{ github.event_name }}" == "schedule" ]
@@ -203,6 +204,7 @@ jobs:
         id: select-tests
         run: |
           lxc image copy ubuntu:40cd8be9d79e local:
+          sudo lxc image alias delete "juju/ubuntu@24.04/amd64"
           sudo lxc image alias create "juju/ubuntu@24.04/amd64" 40cd8be9d79e
 
           if [ "${{ github.event_name }}" == "schedule" ]


### PR DESCRIPTION
## Description

There's no need to pin juju agent version in our CI tests as of `3.6.14` release of Juju. Moreover, the issue with lxd noble image is resolved.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
