### PR TITLE
docs: Fix spread install in GH workflow

### DIFF
--- a/.github/workflows/tutorial-tests.yaml
+++ b/.github/workflows/tutorial-tests.yaml
@@ -35,7 +35,7 @@ jobs:
           if ! command -v go &>/dev/null; then
             sudo snap install go --classic
           fi
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
 
       - name: Install tox

--- a/tests/tutorial/TESTING.md
+++ b/tests/tutorial/TESTING.md
@@ -37,7 +37,7 @@ be generated locally before running Spread.
 - [Go](https://go.dev/doc/install)
 - [Spread](https://github.com/canonical/spread) installed via Go (**not** as a snap):
   ```bash
-  go install github.com/snapcore/spread/cmd/spread@latest
+  go install github.com/canonical/spread/cmd/spread@latest
   ```
 - Python 3 and `make` (usually pre-installed on Ubuntu)
 


### PR DESCRIPTION
## Description

Since I started developing the tutorial tests automation the Spread tool [updated the way it gets installed](https://github.com/canonical/spread/pull/281). While the change is positive, we need to make sure we implement it everywhere. It was implemented in the `tox` for manual tests, but I forgot to update it also in GitHub workflow. Now I'm fixing it.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
