### PR TITLE
docs: Fix tutorial test deployment - add pipx install

### DIFF
--- a/.github/workflows/tutorial-tests.yaml
+++ b/.github/workflows/tutorial-tests.yaml
@@ -38,6 +38,14 @@ jobs:
           go install github.com/canonical/spread/cmd/spread@latest
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
 
+      - name: Install pipx
+        run: |
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+
+      - name: Add pipx to PATH
+        run: echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
       - name: Install tox
         run: pipx install tox
 


### PR DESCRIPTION
## Description

Adding pipx installation to GH tutorial test workflow to fix a deployment error.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
