### PR TITLE
[DPE-10073] feat: consumer lag metrics collection

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -73,7 +73,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.94.0  # renovate: charmcraft-rust-latest
+      rustup default 1.96.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,6 +32,7 @@ from literals import (
     LOGS_RULES_DIR,
     METRICS_RULES_DIR,
     OS_REQUIREMENTS,
+    PYTHON_EXPORTER_PORT,
     SUBSTRATE,
     DebugLevel,
     Status,
@@ -66,6 +67,7 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
                 # See https://github.com/canonical/charmed-kafka-snap for details
                 {"path": "/metrics", "port": JMX_EXPORTER_PORT},
                 {"path": "/metrics", "port": JMX_CC_PORT},
+                {"path": "/metrics", "port": PYTHON_EXPORTER_PORT},
             ],
             metrics_rules_dir=METRICS_RULES_DIR,
             logs_rules_dir=LOGS_RULES_DIR,

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -4,10 +4,12 @@
 
 """Supporting objects for Kafka charm state."""
 
+import os
 import re
 import secrets
 import string
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 
 from charmlibs import pathops
 from ops.pebble import Layer
@@ -203,6 +205,16 @@ class WorkloadBase(ABC):
             version = ""
         return version
 
+    def read_env(self, env_file: str = "/etc/environment") -> dict[str, str]:
+        """Read environment variables from the specified env_file and parse them as dict."""
+        if not os.path.exists(env_file):
+            return {}
+
+        with open(env_file) as f:
+            lines = [line.strip() for line in f.readlines() if not line.strip().startswith("#")]
+
+        return map_env(lines)
+
     @property
     @abstractmethod
     def installed(self) -> bool:
@@ -229,3 +241,15 @@ class WorkloadBase(ABC):
             String of 32 randomized letter+digit characters
         """
         return "".join([secrets.choice(string.ascii_letters + string.digits) for _ in range(32)])
+
+
+def map_env(env: Iterable[str]) -> dict[str, str]:
+    """Parse env var into a dict."""
+    map_env = {}
+    for var in env:
+        key = "".join(var.split("=", maxsplit=1)[0])
+        value = "".join(var.split("=", maxsplit=1)[1:])
+        if key:
+            # only check for keys, as we can have an empty value for a variable
+            map_env[key] = value
+    return map_env

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -38,6 +38,7 @@ from literals import (
     GROUP,
     PEER,
     PROFILE_TESTING,
+    PYTHON_EXPORTER_SERVICE,
     REL_NAME,
     USER_ID,
     Status,
@@ -327,6 +328,17 @@ class BrokerOperator(Object):
         self.charm.state.unit_broker.unit.set_ports(  # in case of listeners changes
             *[listener.port for listener in self.config_manager.all_listeners]
         )
+
+        # Reconcile python exporter service
+        current_env = self.workload.read_env()
+        env_changed = (
+            current_env.get("BOOTSTRAP_SERVER") != self.charm.state.bootstrap_server_internal
+        )
+        if (
+            not self.charm.workload.kafka.services.get(PYTHON_EXPORTER_SERVICE, {}).get("active")
+            or env_changed
+        ):
+            self.charm.workload.kafka.restart(services=[PYTHON_EXPORTER_SERVICE])
 
         # If Kafka is related to client charms, update their information.
         if self.model.relations.get(REL_NAME, None) and self.charm.unit.is_leader():

--- a/src/grafana_dashboards/kafka-metrics.json
+++ b/src/grafana_dashboards/kafka-metrics.json
@@ -1108,7 +1108,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 15
+        "y": 25
       },
       "id": 467,
       "links": [],
@@ -1147,7 +1147,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 30
       },
       "id": 680,
       "panels": [],
@@ -1204,7 +1204,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 21
+        "y": 31
       },
       "id": 681,
       "links": [],
@@ -1244,7 +1244,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 36
       },
       "id": 651,
       "panels": [],
@@ -1294,7 +1294,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 27
+        "y": 37
       },
       "id": 192,
       "links": [],
@@ -1369,7 +1369,7 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 27
+        "y": 37
       },
       "id": 677,
       "links": [],
@@ -1443,7 +1443,7 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 27
+        "y": 37
       },
       "id": 678,
       "links": [],
@@ -1498,7 +1498,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 32
+        "y": 42
       },
       "hiddenSeries": false,
       "id": 665,
@@ -1603,7 +1603,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 32
+        "y": 42
       },
       "hiddenSeries": false,
       "id": 666,
@@ -1708,7 +1708,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 32
+        "y": 42
       },
       "hiddenSeries": false,
       "id": 667,
@@ -1799,7 +1799,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 50
       },
       "id": 653,
       "panels": [],
@@ -1826,7 +1826,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 41
+        "y": 51
       },
       "hiddenSeries": false,
       "id": 152,
@@ -1931,7 +1931,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 41
+        "y": 51
       },
       "hiddenSeries": false,
       "id": 155,
@@ -2047,7 +2047,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 61
       },
       "hiddenSeries": false,
       "id": 50,
@@ -2153,7 +2153,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 61
       },
       "hiddenSeries": false,
       "id": 176,
@@ -2799,7 +2799,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 90
+        "y": 81
       },
       "hiddenSeries": false,
       "id": 150,
@@ -3553,7 +3553,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 124
+        "y": 116
       },
       "hiddenSeries": false,
       "id": 140,
@@ -4421,6 +4421,99 @@
       ],
       "title": "JVM",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Total Lag Across Partitions",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 689,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (group, topic) ( (sum by (group, topic, juju_unit) (kafka_consumer_offset_lag_total ) ) )",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Consumer Group Lags",
+      "type": "timeseries"
     }
   ],
   "refresh": "1m",

--- a/src/literals.py
+++ b/src/literals.py
@@ -12,7 +12,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase
 
 CHARM_KEY = "kafka"
 SNAP_NAME = "charmed-kafka"
-CHARMED_KAFKA_SNAP_REVISION = "60"
+CHARMED_KAFKA_SNAP_REVISION = "71"
 CONTAINER = "kafka"
 SUBSTRATE = "vm"
 STORAGE = "data"
@@ -67,6 +67,8 @@ SECRETS_UNIT = [
 
 JMX_EXPORTER_PORT = 9101
 JMX_CC_PORT = 9102
+PYTHON_EXPORTER_PORT = 9110
+PYTHON_EXPORTER_SERVICE = "python-exporter"
 METRICS_RULES_DIR = "./src/alert_rules/prometheus"
 LOGS_RULES_DIR = "./src/alert_rules/loki"
 
@@ -297,6 +299,6 @@ DEPENDENCIES = {
         "dependencies": {"zookeeper": ">3.6"},
         "name": "kafka",
         "upgrade_supported": "^3",  # zk support removed in 4.0
-        "version": "3.9.0",
+        "version": "3.9.2",
     },
 }

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -11,14 +11,14 @@ import os
 import re
 import textwrap
 from abc import abstractmethod
-from typing import Iterable, cast
+from typing import cast
 
 from lightkube.core.exceptions import ApiError
 from typing_extensions import override
 
 from core.cluster import ClusterState
 from core.structured_config import CharmConfig, LogLevel
-from core.workload import CharmedKafkaPaths, WorkloadBase
+from core.workload import CharmedKafkaPaths, WorkloadBase, map_env
 from literals import (
     ADMIN_USER,
     BALANCER,
@@ -832,6 +832,7 @@ class ConfigManager(CommonConfigManager):
             self.jvm_performance_opts,
             self.heap_opts,
             self.log_level,
+            f"BOOTSTRAP_SERVER={self.state.bootstrap_server_internal}",
         ]
 
         raw_current_env = self.workload.read("/etc/environment")
@@ -1050,15 +1051,3 @@ class BalancerConfigManager(CommonConfigManager):
             content=f"{self.state.cluster.balancer_username}: {self.state.cluster.balancer_password},ADMIN\n",
             path=self.workload.paths.cruise_control_auth,
         )
-
-
-def map_env(env: Iterable[str]) -> dict[str, str]:
-    """Parse env var into a dict."""
-    map_env = {}
-    for var in env:
-        key = "".join(var.split("=", maxsplit=1)[0])
-        value = "".join(var.split("=", maxsplit=1)[1:])
-        if key:
-            # only check for keys, as we can have an empty value for a variable
-            map_env[key] = value
-    return map_env


### PR DESCRIPTION
## Description

This PR adds collection and visualization of consumer lag metrics.

## Manual testing:

```bash
juju deploy ./kafka_ubuntu@22.04-amd64.charm -n 3
juju deploy zookeeper --channel 3/edge -n 3
juju deploy opentelemetry-collector otelcol --base ubuntu@22.04

# Consume COS offers, then:

juju integrate kafka zookeeper
juju integrate kafka otelcol
juju integrate otelcol grafana-dashboards
juju integrate otelcol loki-logging
juju integrate otelcol prometheus-receive-remote-write
```

## Grafana dashboard

<img width="1912" height="887" alt="image" src="https://github.com/user-attachments/assets/944ebcb8-91cb-4624-9141-5133d95ef719" />

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
