### PR TITLE
[MISC] ci: use Canonical K8s & improve test stability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,36 +304,11 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
-          # calico has issues with strict confinements, so remove -strict
-          sudo snap install microk8s --channel ${MICROK8S_CHANNEL//"-strict"/} --classic
-          sudo snap install juju --channel $JUJU_CHANNEL
-
-          sudo usermod -a -G microk8s $USER
-          mkdir -p ~/.kube
-          chmod 0700 ~/.kube
-
-          sudo tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
-          server = "$DOCKERHUB_MIRROR"
-          [host."${DOCKERHUB_MIRROR#'https://'}"]
-          capabilities = ["pull", "resolve"]
-          EOF
-
-          sudo microk8s stop
-          sudo microk8s start
-
-          # make juju work with microk8s --classic
-          sudo mkdir -p /var/snap/juju/current/microk8s/credentials
-          sudo microk8s config | sudo tee /var/snap/juju/current/microk8s/credentials/client.config
-          sudo chown -R $USER:$USER /var/snap/juju/current/microk8s/credentials
-
-          sudo concierge prepare \
-            -p microk8s \
-            --microk8s-channel ${MICROK8S_CHANNEL//"-strict"/} \
-            --juju-channel $JUJU_CHANNEL \
-            --extra-debs pipx
-
-          pipx ensurepath
+          sudo concierge prepare --trace --extra-debs pipx
+      - name: Install dependencies
+        run: |
           pipx install tox poetry
+          pipx ensurepath
       # FIXME: remove this step when the previously installed charmcraft snap supports monorepos.
       - name: Install charmcraft with monorepo feature
         run: |
@@ -406,36 +381,11 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
-          # calico has issues with strict confinements, so remove -strict
-          sudo snap install microk8s --channel ${MICROK8S_CHANNEL//"-strict"/} --classic
-          sudo snap install juju --channel $JUJU_CHANNEL
-
-          sudo usermod -a -G microk8s $USER
-          mkdir -p ~/.kube
-          chmod 0700 ~/.kube
-
-          sudo tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
-          server = "$DOCKERHUB_MIRROR"
-          [host."${DOCKERHUB_MIRROR#'https://'}"]
-          capabilities = ["pull", "resolve"]
-          EOF
-
-          sudo microk8s stop
-          sudo microk8s start
-
-          # make juju work with microk8s --classic
-          sudo mkdir -p /var/snap/juju/current/microk8s/credentials
-          sudo microk8s config | sudo tee /var/snap/juju/current/microk8s/credentials/client.config
-          sudo chown -R $USER:$USER /var/snap/juju/current/microk8s/credentials
-
-          sudo concierge prepare \
-            -p microk8s \
-            --microk8s-channel ${MICROK8S_CHANNEL//"-strict"/} \
-            --juju-channel $JUJU_CHANNEL \
-            --extra-debs pipx
-          
-          pipx ensurepath
+          sudo concierge prepare --trace --extra-debs pipx
+      - name: Install dependencies
+        run: |
           pipx install tox poetry
+          pipx ensurepath
       # FIXME: remove this step when the previously installed charmcraft snap supports monorepos.
       - name: Install charmcraft with monorepo feature
         run: |

--- a/common/single_kernel_kafka/core/literals.py
+++ b/common/single_kernel_kafka/core/literals.py
@@ -426,7 +426,7 @@ CONNECT_DEPENDENCIES = {
     "connect_service": {
         "dependencies": {},  # do not need to check Kafka, backwards compatible since 0.10
         "name": "connect",
-        "upgrade_supported": "^4.0",
+        "upgrade_supported": ">=3.9",
         "version": "4.2.0",
     },
 }

--- a/tests/integration/k8s/ha/scripts/deploy_chaos_mesh.sh
+++ b/tests/integration/k8s/ha/scripts/deploy_chaos_mesh.sh
@@ -10,15 +10,24 @@ if [ -z "${chaos_mesh_ns}" ]; then
 	exit 1
 fi
 
+# Check if microk8s is available
+if command -v microk8s.helm3 >/dev/null 2>&1; then
+  helm_cmd="microk8s.helm3"
+  socket_path=/var/snap/microk8s/common/run/containerd.sock
+else
+  helm_cmd="k8s helm"
+  socket_path=/run/containerd/containerd.sock
+fi
+
 deploy_chaos_mesh() {
 	echo "adding chaos-mesh helm repo"
-	microk8s.helm3 repo add chaos-mesh https://charts.chaos-mesh.org
+	$helm_cmd repo add chaos-mesh https://charts.chaos-mesh.org
 
 	echo "installing chaos-mesh"
-        microk8s.helm3 install chaos-mesh chaos-mesh/chaos-mesh \
+        $helm_cmd install chaos-mesh chaos-mesh/chaos-mesh \
           --namespace="${chaos_mesh_ns}" \
           --set chaosDaemon.runtime=containerd \
-          --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock \
+          --set chaosDaemon.socketPath="$socket_path" \
           --set dashboard.create=false \
           --version "${chaos_mesh_version}" \
           --set clusterScoped=false \

--- a/tests/integration/k8s/ha/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/k8s/ha/scripts/destroy_chaos_mesh.sh
@@ -9,6 +9,13 @@ if [ -z "${chaos_mesh_ns}" ]; then
 	exit 1
 fi
 
+# Check if microk8s is available
+if command -v microk8s.helm3 >/dev/null 2>&1; then
+  helm_cmd="microk8s.helm3"
+else
+  helm_cmd="k8s helm"
+fi
+
 destroy_chaos_mesh() {
 	echo "deleting api-resources"
 	for i in $(kubectl api-resources | awk '/chaos-mesh/ {print $1}'); do
@@ -45,9 +52,9 @@ destroy_chaos_mesh() {
 		timeout 30 kubectl delete crd "${args[@]}" || true
 	fi
 
-	if [ -n "${chaos_mesh_ns}" ] && microk8s.helm3 repo list --namespace="${chaos_mesh_ns}" | grep -q 'chaos-mesh'; then
+	if [ -n "${chaos_mesh_ns}" ] && $helm_cmd repo list --namespace="${chaos_mesh_ns}" | grep -q 'chaos-mesh'; then
 		echo "uninstalling chaos-mesh helm repo"
-		microk8s.helm3 uninstall chaos-mesh --namespace="${chaos_mesh_ns}" || true
+		$helm_cmd uninstall chaos-mesh --namespace="${chaos_mesh_ns}" || true
 	fi
 }
 

--- a/tests/integration/k8s/test_refresh.py
+++ b/tests/integration/k8s/test_refresh.py
@@ -2,16 +2,15 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import glob
 import logging
 import os
-import shutil
 import subprocess
-from typing import Literal
+import zipfile
+from pathlib import Path
 
 import jubilant
 import pytest
-import yaml
+import tomlkit
 from single_kernel_kafka.core.literals import TLS_RELATION
 
 from integration.k8s.helpers import (
@@ -27,77 +26,75 @@ from integration.k8s.helpers.jubilant import all_active_idle, check_logs, deploy
 
 logger = logging.getLogger(__name__)
 
-CHANNEL = "3/stable"
+CHANNEL = "4/stable"
 CHARMCRAFT = os.environ.get("CHARMCRAFT_BIN", "charmcraft")
 
 
-def _build_pinned_refresh_charm(
-    juju: jubilant.Juju,
+def test_repack_charm(
     tmp_path_factory: pytest.TempPathFactory,
-    version: Literal["pre", "post"] = "post",
+    kafka_charm,
 ):
-    """Build charms used for refresh tests."""
+    """Unpack the built charm and repack using a refresh-able version."""
+    base = tmp_path_factory.mktemp("refresh-charm-")
+    os.system(f"unzip -q {kafka_charm} -d {base}")
 
-    def ignore_hidden(path, names):
-        return [name for name in names if name.startswith(".")]
-
-    # create a charmcraft.yaml without the write-charm-version override
-    with open("k8s/charmcraft.yaml") as f:
-        cc = yaml.safe_load(f)
-        cc["parts"]["files"].pop("override-build")
-
-    tmp_dir = tmp_path_factory.mktemp(f"refresh-charm-{version}")
-    os.makedirs(tmp_dir, exist_ok=True)
-    # Copy repo files to the tmp_dir
-    os.system(f"rsync -avq --exclude .tox --exclude venv . {tmp_dir}/")
-    shutil.copyfile(
-        f"tests/integration/k8s/refresh-charm/refresh_versions.{version}.toml",
-        f"{tmp_dir}/k8s/refresh_versions.toml",
-    )
-    with open(f"{tmp_dir}/k8s/charmcraft.yaml", "w") as f:
-        f.write(yaml.safe_dump(cc))
-
-    logger.info(f"Building {version} refresh charm, using {tmp_dir}. might take a while...")
-    subprocess.check_output(
-        f"{CHARMCRAFT} pack",
+    # get the latest refresh git tag, i.e. v4/1.##.#
+    current_tag_cmd_pipeline = [
+        "git ls-remote --tags https://github.com/canonical/kafka-operator",
+        "grep v4",  # filter v4 tags
+        r"sed -n 's_^.*/\([^/}]*\)$_\1_p'",  # only return tag names, e.g. 1.22.0
+        r"sed 's/1\.//g'",  # strip the "1." part
+        "sort -n",  # numeric sort
+        "tail -n 1",  # return the last one
+    ]
+    current_tag = subprocess.check_output(
+        " | ".join(current_tag_cmd_pipeline),
         shell=True,
         stderr=subprocess.PIPE,
-        cwd=f"{tmp_dir}/k8s",
-        env=os.environ | {"CHARMCRAFT_EXPERIMENTAL_MONOREPO": "true"},
     )
-    if not (paths := glob.glob(f"{tmp_dir}/k8s/*.charm")):
-        raise RuntimeError("Can not find built charm path!")
 
-    return paths[0]
+    # compute the next refresh version, which will be released to edge.
+    # same logic as .github/workflows/release.yaml
+    next_ver = int(float(current_tag) + 1)
+    refresh_version = f"4/1.{next_ver}.0"
 
+    # rewrite the refresh_versions.toml file using the new computed version.
+    with open(f"{base}/refresh_versions.toml") as file:
+        versions = tomlkit.load(file)
+    versions["charm"] = refresh_version
+    with open(f"{base}/refresh_versions.toml", "w") as file:
+        tomlkit.dump(versions, file)
 
-@pytest.fixture(scope="module")
-def pre_refresh_charm(juju: jubilant.Juju, tmp_path_factory):
-    return _build_pinned_refresh_charm(juju, tmp_path_factory=tmp_path_factory, version="pre")
+    # this is equivalent to charmcraft pack, which uses the updated refresh_versions.toml file.
+    # basically, we're using the `base` folder as the prime dir.
+    # see: https://github.com/canonical/charmcraft/blob/a2503a34fad32de497b95c19ae355121a54327a8/charmcraft/utils/file.py#L59-L72
+    output_file = f"kafka_refresh_{refresh_version.replace('/', '_')}.charm"
+    with zipfile.ZipFile(output_file, mode="w", compression=zipfile.ZIP_DEFLATED) as charm_zip:
+        for root, _, files in os.walk(base, followlinks=True):
+            for file in files:
+                file_path = Path(root) / file
+                archive_name = file_path.relative_to(base)
+                charm_zip.write(file_path, arcname=archive_name)
 
-
-@pytest.fixture(scope="module")
-def post_refresh_charm(juju: jubilant.Juju, tmp_path_factory):
-    return _build_pinned_refresh_charm(juju, tmp_path_factory=tmp_path_factory, version="post")
+    os.environ.update({"REFRESH_CHARM": f"./{output_file}"})
 
 
 @pytest.mark.abort_on_fail
-def test_in_place_refresh(
-    juju: jubilant.Juju, kraft_mode: KRaftMode, pre_refresh_charm, post_refresh_charm
-):
+def test_in_place_refresh(juju: jubilant.Juju, kraft_mode: KRaftMode):
     """Tests happy path refresh with TLS in KRaft mode."""
     kafka_apps = [APP_NAME] if kraft_mode == "single" else [APP_NAME, CONTROLLER_NAME]
     tls_config = {"ca-common-name": "kafka"}
 
     deploy_cluster(
         juju=juju,
-        charm=pre_refresh_charm,
+        charm="kafka-k8s",
         kraft_mode=kraft_mode,
         num_broker=1,
         num_controller=1,
+        channel=CHANNEL,
     )
 
-    juju.deploy(TLS_NAME, channel="edge", config=tls_config, revision=163, trust=True)
+    juju.deploy(TLS_NAME, channel="1/stable", config=tls_config, trust=True)
 
     juju.wait(
         lambda status: all_active_idle(status, *kafka_apps, TLS_NAME),
@@ -142,9 +139,10 @@ def test_in_place_refresh(
     )
 
     logger.info("Upgrading Kafka...")
+    refresh_charm = os.environ.get("REFRESH_CHARM")
     juju.refresh(
         APP_NAME,
-        path=post_refresh_charm,
+        path=refresh_charm,
         resources={"kafka-image": KAFKA_CONTAINER},
     )
 

--- a/tests/integration/k8s/test_tls.py
+++ b/tests/integration/k8s/test_tls.py
@@ -260,6 +260,16 @@ def test_certificate_transfer(juju: jubilant.Juju, kafka_apps):
     # We don't expect a broker restart here because of truststore live reload
     juju.integrate(f"{APP_NAME}:{CERTIFICATE_TRANSFER_RELATION}", "other-ca:send-ca-cert")
 
+    with fast_forward(juju, fast_interval="60s"):
+        time.sleep(120)
+
+    juju.wait(
+        lambda status: all_active_idle(status, *kafka_apps),
+        delay=3,
+        successes=10,
+        timeout=900,
+    )
+
     address = get_address(juju, app_name=APP_NAME, unit_num=0)
     sasl_port = SECURITY_PROTOCOL_PORTS["SASL_SSL", "SCRAM-SHA-512"].internal
     sasl_bootstrap_server = f"{address}:{sasl_port}"
@@ -340,6 +350,11 @@ def test_kafka_tls_scaling(juju: jubilant.Juju, kafka_apps):
 def test_mtls_broken(juju: jubilant.Juju, kafka_apps):
     # remove relation and check connection again
     juju.remove_relation(APP_NAME, DUMMY_NAME)
+
+    # ensuring enough update-status
+    with fast_forward(juju, fast_interval="60s"):
+        time.sleep(120)
+
     juju.wait(
         lambda status: all_active_idle(status, *kafka_apps, DUMMY_NAME),
         delay=3,

--- a/tests/integration/machine/helpers/pytest_operator.py
+++ b/tests/integration/machine/helpers/pytest_operator.py
@@ -339,6 +339,7 @@ def produce_and_check_logs(
     create_topic: bool = True,
     replication_factor: int = 1,
     num_partitions: int = 5,
+    credentials: tuple[str, str] | None = None,
 ) -> None:
     """Produces 15 messages from HN to chosen Kafka topic.
 
@@ -350,6 +351,8 @@ def produce_and_check_logs(
         create_topic: if the topic needs to be created
         replication_factor: replication factor of the created topic
         num_partitions: number of partitions for the topic
+        credentials: client (username, password) tuple to be used, if not provided,
+          it will be read from relation data.
 
     Raises:
         KeyError: if missing relation data
@@ -360,10 +363,17 @@ def produce_and_check_logs(
         unit_name=provider_unit_name,
         owner=APP_NAME,
     )
+
+    if credentials:
+        username, password = credentials
+    else:
+        username = relation_data["username"]
+        password = relation_data["password"]
+
     client = KafkaClient(
         servers=relation_data["endpoints"].split(","),
-        username=relation_data["username"],
-        password=relation_data["password"],
+        username=username,
+        password=password,
         security_protocol="SASL_PLAINTEXT",
     )
 
@@ -525,17 +535,23 @@ def show_unit(ops_test: OpsTest, unit_name: str) -> Any:
     return yaml.safe_load(result)
 
 
-def get_client_usernames(ops_test: OpsTest, owner: str = APP_NAME) -> set[str]:
+def get_client_credentials(ops_test: OpsTest, owner: str = APP_NAME) -> dict[str, str]:
     app_secret = get_secret_by_label(ops_test, label=f"cluster.{owner}.app", owner=owner)
 
-    usernames = set()
+    credentials = {}
     for key in app_secret.keys():
         if "password" in key:
-            usernames.add(key.split("-")[0])
+            username = key.split("-")[0]
+            credentials[username] = app_secret[key]
         if "relation" in key:
-            usernames.add(key)
+            username = key
+            credentials[username] = app_secret[key]
 
-    return usernames
+    return credentials
+
+
+def get_client_usernames(ops_test: OpsTest, owner: str = APP_NAME) -> set[str]:
+    return set(get_client_credentials(ops_test, owner=owner))
 
 
 def get_provider_data(

--- a/tests/integration/machine/test_charm.py
+++ b/tests/integration/machine/test_charm.py
@@ -22,6 +22,7 @@ from single_kernel_kafka.core.literals import (
     REL_NAME,
     SECURITY_PROTOCOL_PORTS,
 )
+from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from integration.machine.helpers import APP_NAME, DUMMY_NAME, REL_NAME_ADMIN, SERIES
 from integration.machine.helpers.pytest_operator import (
@@ -120,8 +121,18 @@ async def test_listeners(ops_test: OpsTest, app_charm, kafka_apps):
         apps=[*kafka_apps, DUMMY_NAME], idle_period=60, status="active"
     )
 
-    # check that client listener is active
-    assert check_socket(address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client)
+    # Opening the client listener is applied via a rolling restart that the
+    # rollingops library processes in a background worker, which Juju idle
+    # detection does not gate on. Retry briefly until the listener settles.
+    for attempt in Retrying(stop=stop_after_attempt(6), wait=wait_fixed(15), reraise=True):
+        with attempt:
+            await ops_test.model.wait_for_idle(
+                apps=[*kafka_apps, DUMMY_NAME], idle_period=30, status="active"
+            )
+            # check that client listener is active
+            assert check_socket(
+                address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
+            )
 
     # remove relation and check that client listener is not active
     await ops_test.model.applications[APP_NAME].remove_relation(
@@ -129,9 +140,14 @@ async def test_listeners(ops_test: OpsTest, app_charm, kafka_apps):
     )
     await ops_test.model.wait_for_idle(apps=kafka_apps, idle_period=60)
 
-    assert not check_socket(
-        address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
-    )
+    # Likewise, tearing down the listener is applied via a background rolling
+    # restart, so retry until it is actually closed.
+    for attempt in Retrying(stop=stop_after_attempt(6), wait=wait_fixed(15), reraise=True):
+        with attempt:
+            await ops_test.model.wait_for_idle(apps=kafka_apps, idle_period=30)
+            assert not check_socket(
+                address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
+            )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/machine/test_charm.py
+++ b/tests/integration/machine/test_charm.py
@@ -156,9 +156,17 @@ async def test_client_properties_makes_admin_connection(ops_test: OpsTest, kafka
     await ops_test.model.add_relation(APP_NAME, f"{DUMMY_NAME}:{REL_NAME_ADMIN}")
     assert ops_test.model.applications[APP_NAME].status == "active"
     assert ops_test.model.applications[DUMMY_NAME].status == "active"
-    await ops_test.model.wait_for_idle(
-        apps=[*kafka_apps, DUMMY_NAME], idle_period=60, status="active"
-    )
+
+    address = await get_address(ops_test=ops_test)
+    for attempt in Retrying(stop=stop_after_attempt(6), wait=wait_fixed(15), reraise=True):
+        with attempt:
+            await ops_test.model.wait_for_idle(
+                apps=[*kafka_apps, DUMMY_NAME], idle_period=30, status="active"
+            )
+            assert check_socket(
+                address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
+            )
+
     result = await run_client_properties(ops_test=ops_test)
     assert result
     logger.debug(f"{result=}")
@@ -168,6 +176,10 @@ async def test_client_properties_makes_admin_connection(ops_test: OpsTest, kafka
     # we explicitly test that:
     credentials = get_client_credentials(ops_test=ops_test)
     for username, password in credentials.items():
+        if username == "controller":
+            # controller user is defined on separate listener (9098)
+            continue
+        logger.info(f"Testing {username} has admin privileges:")
         produce_and_check_logs(
             ops_test=ops_test,
             kafka_unit_name=f"{APP_NAME}/0",

--- a/tests/integration/machine/test_charm.py
+++ b/tests/integration/machine/test_charm.py
@@ -30,6 +30,7 @@ from integration.machine.helpers.pytest_operator import (
     count_lines_with,
     deploy_cluster,
     get_address,
+    get_client_credentials,
     get_machine,
     produce_and_check_logs,
     run_client_properties,
@@ -162,14 +163,19 @@ async def test_client_properties_makes_admin_connection(ops_test: OpsTest, kafka
     assert result
     logger.debug(f"{result=}")
 
-    acls = 0
-    for line in result.strip().split("\n"):
-        if "SCRAM credential configs for user-principal" in line:
-            acls += 1
-
-    # single mode: operator, replication, relation-# => 3
-    # multi mode: operator, relation-# => 2
-    assert acls == 2 + int(kraft_mode == "single")
+    # At this stage, all internal and client users should have admin privileges,
+    # i.e. they should be able to create topics, produce, and consume.
+    # we explicitly test that:
+    credentials = get_client_credentials(ops_test=ops_test)
+    for username, password in credentials.items():
+        produce_and_check_logs(
+            ops_test=ops_test,
+            kafka_unit_name=f"{APP_NAME}/0",
+            provider_unit_name=f"{DUMMY_NAME}/0",
+            topic=f"test-admin-{username}",
+            create_topic=True,
+            credentials=(username, password),
+        )
 
     await ops_test.model.applications[APP_NAME].remove_relation(
         f"{APP_NAME}:{REL_NAME}", f"{DUMMY_NAME}:{REL_NAME_ADMIN}"

--- a/tests/integration/machine/test_refresh.py
+++ b/tests/integration/machine/test_refresh.py
@@ -3,10 +3,15 @@
 # See LICENSE file for licensing details.
 
 import logging
+import os
+import subprocess
 import time
+import zipfile
+from pathlib import Path
 
 import jubilant
 import pytest
+import tomlkit
 
 from integration.machine.helpers import (
     APP_NAME,
@@ -24,11 +29,62 @@ from integration.machine.helpers.jubilant import (
 logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.broker
+CHANNEL = "4/stable"
+
+
+def test_repack_charm(
+    tmp_path_factory: pytest.TempPathFactory,
+    kafka_charm,
+):
+    """Unpack the built charm and repack using a refresh-able version."""
+    base = tmp_path_factory.mktemp("refresh-charm-")
+    os.system(f"unzip -q {kafka_charm} -d {base}")
+
+    # get the latest refresh git tag, i.e. v4/1.##.#
+    current_tag_cmd_pipeline = [
+        "git ls-remote --tags https://github.com/canonical/kafka-operator",
+        "grep v4",  # filter v4 tags
+        r"sed -n 's_^.*/\([^/}]*\)$_\1_p'",  # only return tag names, e.g. 1.22.0
+        r"sed 's/1\.//g'",  # strip the "1." part
+        "sort -n",  # numeric sort
+        "tail -n 1",  # return the last one
+    ]
+    current_tag = subprocess.check_output(
+        " | ".join(current_tag_cmd_pipeline),
+        shell=True,
+        stderr=subprocess.PIPE,
+    )
+
+    # compute the next refresh version, which will be released to edge.
+    # same logic as .github/workflows/release.yaml
+    next_ver = int(float(current_tag) + 1)
+    refresh_version = f"4/1.{next_ver}.0"
+
+    # rewrite the refresh_versions.toml file using the new computed version.
+    with open(f"{base}/refresh_versions.toml") as file:
+        versions = tomlkit.load(file)
+    versions["charm"] = refresh_version
+    with open(f"{base}/refresh_versions.toml", "w") as file:
+        tomlkit.dump(versions, file)
+
+    # this is equivalent to charmcraft pack,
+    # and uses the updated refresh_versions.toml file.
+    # basically, we're using the `base` folder as the prime dir.
+    # see: https://github.com/canonical/charmcraft/blob/a2503a34fad32de497b95c19ae355121a54327a8/charmcraft/utils/file.py#L59-L72
+    output_file = f"kafka_refresh_{refresh_version.replace('/', '_')}.charm"
+    with zipfile.ZipFile(output_file, mode="w", compression=zipfile.ZIP_DEFLATED) as charm_zip:
+        for root, _, files in os.walk(base, followlinks=True):
+            for file in files:
+                file_path = Path(root) / file
+                archive_name = file_path.relative_to(base)
+                charm_zip.write(file_path, arcname=archive_name)
+
+    os.environ.update({"REFRESH_CHARM": f"./{output_file}"})
 
 
 @pytest.mark.abort_on_fail
-def test_in_place_upgrade(juju: jubilant.Juju, kafka_charm, app_charm, kraft_mode, controller_app):
-    deploy_cluster(juju=juju, charm=kafka_charm, kraft_mode=kraft_mode, num_broker=3)
+def test_in_place_upgrade(juju: jubilant.Juju, app_charm, kraft_mode, controller_app):
+    deploy_cluster(juju=juju, charm="kafka", kraft_mode=kraft_mode, num_broker=3, channel=CHANNEL)
     juju.deploy(app_charm, app=DUMMY_NAME, num_units=1, base=BASE)
 
     # Get kafka apps list for waiting
@@ -79,7 +135,8 @@ def test_in_place_upgrade(juju: jubilant.Juju, kafka_charm, app_charm, kraft_mod
     time.sleep(10)
 
     logger.info("Upgrading Kafka...")
-    juju.refresh(APP_NAME, path=str(kafka_charm))
+    refresh_charm = os.environ.get("REFRESH_CHARM")
+    juju.refresh(APP_NAME, path=str(refresh_charm))
     juju.wait(
         lambda status: all_active_idle(status, *kafka_apps),
         delay=3,
@@ -96,9 +153,7 @@ def test_in_place_upgrade(juju: jubilant.Juju, kafka_charm, app_charm, kraft_mod
 
 
 @pytest.mark.abort_on_fail
-def test_controller_upgrade_multinode(
-    juju: jubilant.Juju, kafka_charm, kraft_mode, controller_app
-):
+def test_controller_upgrade_multinode(juju: jubilant.Juju, kraft_mode, controller_app):
     """Test upgrading the controller separately in multi-node mode."""
     if kraft_mode != "multi":
         logger.info(f"Skipping controller upgrade test because we're using {kraft_mode} mode.")
@@ -130,7 +185,8 @@ def test_controller_upgrade_multinode(
     time.sleep(10)
 
     logger.info("Upgrading Controller...")
-    juju.refresh(controller_app, path=str(kafka_charm))
+    refresh_charm = os.environ.get("REFRESH_CHARM")
+    juju.refresh(controller_app, path=str(refresh_charm))
     juju.wait(
         lambda status: all_active_idle(status, controller_app, APP_NAME),
         delay=3,

--- a/tests/integration/machine/test_tls.py
+++ b/tests/integration/machine/test_tls.py
@@ -267,6 +267,9 @@ async def test_certificate_transfer(ops_test: OpsTest, kafka_apps):
         f"{APP_NAME}:{CERTIFICATE_TRANSFER_RELATION}", "other-ca:send-ca-cert"
     )
 
+    async with ops_test.fast_forward(fast_interval="60s"):
+        await asyncio.sleep(120)
+
     await ops_test.model.wait_for_idle(
         apps=kafka_apps, idle_period=60, timeout=2000, status="active"
     )
@@ -345,6 +348,11 @@ async def test_mtls_broken(ops_test: OpsTest, kafka_apps):
     await ops_test.model.applications[APP_NAME].remove_relation(
         f"{APP_NAME}:{REL_NAME}", f"{DUMMY_NAME}:{REL_NAME_PRODUCER}"
     )
+
+    # ensuring enough update-status
+    async with ops_test.fast_forward(fast_interval="60s"):
+        await asyncio.sleep(120)
+
     await ops_test.model.wait_for_idle(apps=kafka_apps, idle_period=60, status="active")
     for unit_num in range(len(ops_test.model.applications[APP_NAME].units)):
         kafka_address = await get_address(ops_test=ops_test, app_name=APP_NAME, unit_num=unit_num)


### PR DESCRIPTION
## Description

- Switches to Canonical K8s everywhere, adapted the chaos mesh scripts accordingly
- improves stability of 3 tests in `test_charm.py` without changing test logic
- improves refresh v3 tests to do an actual `4/stable` to `4/edge` refresh: this is done by simulating the refresh tagging process, and fixating the next `4/edge` tag in the built charm.
- improves stability of `test_tls.py` tests by adding some waits.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
