### PR TITLE
fix(k8s): advertise fully-qualified client addresses

### DIFF
--- a/common/single_kernel_kafka/core/models.py
+++ b/common/single_kernel_kafka/core/models.py
@@ -1112,7 +1112,7 @@ class KafkaBroker(RelationState):
         resolve neither the bootstrap servers nor the advertised listeners
         returned to it in cluster metadata.
         """
-        if self.substrate != "k8s":
+        if not self.substrate == "k8s":
             return self.internal_address
 
         return self.k8s.build_fqdn(self.internal_address, cluster_domain=self.cluster_domain)
@@ -1123,8 +1123,11 @@ class KafkaBroker(RelationState):
         return self.relation_data.get("cluster-domain", "")
 
     def update_cluster_domain(self) -> None:
-        """Caches the K8s cluster domain on the unit databag."""
-        if self.substrate != "k8s":
+        """Caches the K8s cluster domain on the unit databag.
+
+        Only runs once on assumption cluster-domain is static.
+        """
+        if not self.substrate == "k8s":
             return
 
         self.update({"cluster-domain": self.k8s.cluster_domain})

--- a/common/single_kernel_kafka/core/models.py
+++ b/common/single_kernel_kafka/core/models.py
@@ -1115,9 +1115,19 @@ class KafkaBroker(RelationState):
         if self.substrate != "k8s":
             return self.internal_address
 
-        # Taken from this pod's own FQDN since the domain is configurable.
-        domain = socket.getfqdn().partition(".svc.")[2] or "cluster.local"
-        return f"{self.internal_address}.{self.k8s.namespace}.svc.{domain}"
+        return self.k8s.build_fqdn(self.internal_address, cluster_domain=self.cluster_domain)
+
+    @property
+    def cluster_domain(self) -> str:
+        """The DNS domain of the K8s cluster the unit runs on."""
+        return self.relation_data.get("cluster-domain", "")
+
+    def update_cluster_domain(self) -> None:
+        """Caches the K8s cluster domain on the unit databag."""
+        if self.substrate != "k8s":
+            return
+
+        self.update({"cluster-domain": self.k8s.cluster_domain})
 
     @property
     def peer_ip_address(self) -> str:

--- a/common/single_kernel_kafka/core/models.py
+++ b/common/single_kernel_kafka/core/models.py
@@ -1103,6 +1103,23 @@ class KafkaBroker(RelationState):
         return addr
 
     @property
+    def client_address(self) -> str:
+        """The address that client applications should connect to.
+
+        Unlike `internal_address`, this is fully qualified. The short
+        `<unit>.<app>-endpoints` form only resolves through the DNS search path
+        of pods in the same namespace, so a client in any other namespace can
+        resolve neither the bootstrap servers nor the advertised listeners
+        returned to it in cluster metadata.
+        """
+        if self.substrate != "k8s":
+            return self.internal_address
+
+        # Taken from this pod's own FQDN since the domain is configurable.
+        domain = socket.getfqdn().partition(".svc.")[2] or "cluster.local"
+        return f"{self.internal_address}.{self.k8s.namespace}.svc.{domain}"
+
+    @property
     def peer_ip_address(self) -> str:
         """The IP address of the unit on the peer relation."""
         return self.relation_data.get("ip", "")
@@ -1121,7 +1138,7 @@ class KafkaBroker(RelationState):
             return ""
 
         if self.substrate == "k8s":
-            return self.internal_address
+            return self.client_address
 
         return self.relation_data.get(f"ip-{relation.id}", "")
 

--- a/common/single_kernel_kafka/events/broker.py
+++ b/common/single_kernel_kafka/events/broker.py
@@ -162,6 +162,7 @@ class BrokerOperator(Object):
             self.charm.state.unit_broker.update(
                 {"cores": str(self.balancer_manager.cores), "rack": self.config_manager.rack}
             )
+            self.charm.state.unit_broker.update_cluster_domain()
 
         # don't want to run default start/pebble-ready events during upgrades
         if self.charm.refresh.in_progress:

--- a/common/single_kernel_kafka/managers/config.py
+++ b/common/single_kernel_kafka/managers/config.py
@@ -596,9 +596,7 @@ class ConfigManager(CommonConfigManager):
     def client_listeners(self) -> list[Listener]:
         """Return a list of client listeners."""
         return [
-            Listener(
-                host=self.state.unit_broker.internal_address, auth_map=auth_map, scope="CLIENT"
-            )
+            Listener(host=self.state.unit_broker.client_address, auth_map=auth_map, scope="CLIENT")
             for auth_map in self.state.enabled_auth
         ]
 

--- a/common/single_kernel_kafka/managers/k8s.py
+++ b/common/single_kernel_kafka/managers/k8s.py
@@ -7,6 +7,7 @@
 import json
 import logging
 import math
+import socket
 import time
 from functools import cache
 
@@ -24,6 +25,8 @@ logging.getLogger("httpx").setLevel(logging.CRITICAL)
 logging.getLogger("httpcore").setLevel(logging.CRITICAL)
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_CLUSTER_DOMAIN = "cluster.local"
 
 
 class K8sManager:
@@ -66,6 +69,24 @@ class K8sManager:
             field_manager=self.pod_name,
             namespace=self.namespace,
         )
+
+    @property
+    def cluster_domain(self) -> str:
+        """The DNS domain of the K8s cluster, e.g `cluster.local`.
+
+        Taken from this Pod's own FQDN, as the domain is cluster-configurable.
+        """
+        return socket.getfqdn().partition(".svc.")[2] or DEFAULT_CLUSTER_DOMAIN
+
+    def build_fqdn(self, hostname: str, cluster_domain: str = "") -> str:
+        """Builds the fully-qualified DNS name of a Service-backed hostname.
+
+        Args:
+            hostname: the namespace-relative name, e.g `kafka-k8s-0.kafka-k8s-endpoints`
+            cluster_domain: the cluster domain to use, if already known.
+                Defaults to resolving it, which costs a DNS lookup.
+        """
+        return f"{hostname}.{self.namespace}.svc.{cluster_domain or self.cluster_domain}"
 
     @staticmethod
     def get_ttl_hash(seconds=60 * 2) -> int:

--- a/common/single_kernel_kafka/managers/k8s.py
+++ b/common/single_kernel_kafka/managers/k8s.py
@@ -26,8 +26,6 @@ logging.getLogger("httpcore").setLevel(logging.CRITICAL)
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CLUSTER_DOMAIN = "cluster.local"
-
 
 class K8sManager:
     """Manager for handling Kafka Kubernetes resources for a single Kafka pod."""
@@ -76,7 +74,22 @@ class K8sManager:
 
         Taken from this Pod's own FQDN, as the domain is cluster-configurable.
         """
-        return socket.getfqdn().partition(".svc.")[2] or DEFAULT_CLUSTER_DOMAIN
+        try:
+            addrinfo_domain = socket.getaddrinfo(
+                    self.pod_name,
+                    None,
+                    family=socket.AF_UNSPEC,
+                    flags=socket.AI_CANONNAME,
+                    type=socket.SOCK_STREAM,
+                )
+            addrinfo_domain = addrinfo_domain[0][3].split(".svc.")[1]
+        except socket.gaierror:
+            logger.exception("Unable to getaddrinfo, possibly coredns not up")
+            addrinfo_domain = ""  # fallback to getfqdn
+
+        getfqdn_domain = socket.getfqdn().split(".svc.")[1]
+
+        return addrinfo_domain or getfqdn_domain
 
     def build_fqdn(self, hostname: str, cluster_domain: str = "") -> str:
         """Builds the fully-qualified DNS name of a Service-backed hostname.

--- a/common/single_kernel_kafka/managers/tls.py
+++ b/common/single_kernel_kafka/managers/tls.py
@@ -100,7 +100,7 @@ class KafkaSansBuilder(SansBuilderBase):
                     [
                         self.state.unit_broker.internal_address.split(".")[0],
                         self.state.unit_broker.internal_address,
-                        socket.getfqdn(),
+                        self.state.unit_broker.client_address,
                     ]
                     + self._build_extra_sans()
                 ),

--- a/k8s/metadata.yaml
+++ b/k8s/metadata.yaml
@@ -10,13 +10,13 @@ description: |
   Users can find out more at the [Apache Kafka project page](https://kafka.apache.org/).
 summary: Charmed Apache Kafka K8s Operator
 docs: https://discourse.charmhub.io/t/charmed-apache-kafka-k8s-v-4-x/19022
-source: https://github.com/canonical/kafka-k8s-operator
-issues: https://github.com/canonical/kafka-k8s-operator/issues
+source: https://github.com/canonical/kafka-operator
+issues: https://github.com/canonical/kafka-operator/issues
 website:
   - https://ubuntu.com/data/kafka
   - https://canonical.com/data/docs/kafka/k8s
   - https://charmhub.io/kafka-k8s
-  - https://github.com/canonical/kafka-k8s-operator
+  - https://github.com/canonical/kafka-operator
   - https://matrix.to/#/%23charmhub-data-platform%3Aubuntu.com
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 import json
+import socket
 import time
 from collections import defaultdict
 from unittest.mock import Mock, PropertyMock, patch
@@ -17,7 +18,13 @@ from common.single_kernel_kafka.core.literals import (
 from common.single_kernel_kafka.managers.balancer import CruiseControlClient
 from ops import JujuVersion
 from ops.testing import Relation
-from tests.unit.helpers import SUBSTRATE_CLS, TLSArtifacts, generate_tls_artifacts
+from tests.unit.helpers import (
+    CLUSTER_DOMAIN,
+    MODEL_NAME,
+    SUBSTRATE_CLS,
+    TLSArtifacts,
+    generate_tls_artifacts,
+)
 
 
 @pytest.fixture(scope="module")
@@ -288,4 +295,33 @@ def mock_refresh():
         ),
         patch("charm_refresh._main._RefreshVersions", Mock(return_value=versions_mock)),
     ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patched_addrinfo():
+    with patch(
+        "socket.getaddrinfo",
+        return_value=[
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                6,
+                f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.{CLUSTER_DOMAIN}",
+                ("10.1.90.155", 0),
+            )
+        ],
+    ) as addrinfo:
+        yield addrinfo
+
+
+@pytest.fixture(autouse=True)
+def patched_getfqdn():
+    if SUBSTRATE == "k8s":
+        with patch(
+            "socket.getfqdn",
+            return_value=f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.{CLUSTER_DOMAIN}",
+        ) as getfqdn:
+            yield getfqdn
+    else:
         yield

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -20,7 +20,8 @@ SUBSTRATE_CLS = "Machine" if SUBSTRATE == "vm" else "K8s"
 CONFIG = yaml.safe_load(Path(f"./{SUBSTRATE_CLS.lower()}/config.yaml").read_text())
 ACTIONS = yaml.safe_load(Path(f"./{SUBSTRATE_CLS.lower()}/actions.yaml").read_text())
 METADATA = yaml.safe_load(Path(f"./{SUBSTRATE_CLS.lower()}/metadata.yaml").read_text())
-MODEL_NAME = "kafka-model"
+MODEL_NAME = "middlearth"
+CLUSTER_DOMAIN = "eriador.shire"
 
 if SUBSTRATE == "vm":
     from machine.src.charm import KafkaCharm

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -20,6 +20,7 @@ SUBSTRATE_CLS = "Machine" if SUBSTRATE == "vm" else "K8s"
 CONFIG = yaml.safe_load(Path(f"./{SUBSTRATE_CLS.lower()}/config.yaml").read_text())
 ACTIONS = yaml.safe_load(Path(f"./{SUBSTRATE_CLS.lower()}/actions.yaml").read_text())
 METADATA = yaml.safe_load(Path(f"./{SUBSTRATE_CLS.lower()}/metadata.yaml").read_text())
+MODEL_NAME = "kafka-model"
 
 if SUBSTRATE == "vm":
     from machine.src.charm import KafkaCharm

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -18,7 +18,15 @@ from common.single_kernel_kafka.core.literals import (
     Status,
 )
 from ops.testing import Container, Context, PeerRelation, Relation, State, Storage
-from tests.unit.helpers import ACTIONS, CONFIG, METADATA, SUBSTRATE, SUBSTRATE_CLS, KafkaCharm
+from tests.unit.helpers import (
+    ACTIONS,
+    CLUSTER_DOMAIN,
+    CONFIG,
+    METADATA,
+    SUBSTRATE,
+    SUBSTRATE_CLS,
+    KafkaCharm,
+)
 
 if SUBSTRATE == "vm":
     from charms.operator_libs_linux.v0.sysctl import ApplyError
@@ -254,6 +262,31 @@ def test_start_sets_necessary_config(
     # Then
     patched_server_properties.assert_called()
     patched_client_properties.assert_called()
+
+
+@pytest.mark.skipif(SUBSTRATE == "vm", reason="cluster-domain only set on Kubernetes")
+def test_start_sets_cluster_domain(
+    ctx: Context, base_state: State, passwords_data: dict[str, str]
+) -> None:
+    """Checks the K8s cluster-domain is cached to the unit databag on start."""
+    # Given
+    cluster_peer = PeerRelation(PEER, PEER, local_app_data=passwords_data)
+    state_in = dataclasses.replace(base_state, relations=[cluster_peer])
+
+    # When
+    with (
+        patch(
+            f"single_kernel_kafka.workload.KafkaWorkload{SUBSTRATE_CLS}.active", return_value=False
+        ),
+        patch(f"single_kernel_kafka.workload.KafkaWorkload{SUBSTRATE_CLS}.start"),
+    ):
+        state_out = ctx.run(ctx.on.start(), state_in)
+
+    # Then
+    assert (
+        state_out.get_relation(cluster_peer.id).local_unit_data.get("cluster-domain")
+        == CLUSTER_DOMAIN
+    )
 
 
 @pytest.mark.skipif(SUBSTRATE == "vm", reason="pebble layer not used on vm")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -24,6 +24,7 @@ from common.single_kernel_kafka.core.literals import (
     REL_NAME,
     TLS_RELATION,
 )
+from common.single_kernel_kafka.managers.k8s import DEFAULT_CLUSTER_DOMAIN
 from ops import CharmMeta
 from ops.testing import Container, Context, Model, PeerRelation, Relation, Secret, State, Storage
 from tests.unit.helpers import ACTIONS, CONFIG, METADATA, MODEL_NAME, SUBSTRATE, KafkaCharm
@@ -552,7 +553,7 @@ def test_client_addresses_are_fully_qualified(ctx: Context, base_state: State) -
     """Client-facing addresses must resolve from outside the charm's namespace."""
     # Given
     client_rel = Relation(REL_NAME)
-    cluster_peer = PeerRelation(PEER, PEER)
+    cluster_peer = PeerRelation(PEER, PEER, local_unit_data={"cluster-domain": "k8s.example"})
     state_in = dataclasses.replace(base_state, relations=[cluster_peer, client_rel])
 
     # When
@@ -562,11 +563,17 @@ def test_client_addresses_are_fully_qualified(ctx: Context, base_state: State) -
         # Then
         assert (
             charm.state.bootstrap_server_client(client_rel)
-            == f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.cluster.local:9092"
-        )
+            == f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.k8s.example:9092"
+        ), "the cached cluster domain is used, rather than being resolved on every hook"
         assert (
             charm.state.unit_broker.internal_address == "kafka-k8s-0.kafka-k8s-endpoints"
         ), "inter-broker traffic never leaves the namespace, so it keeps the short name"
+
+        # When
+        charm.state.unit_broker.update_cluster_domain()
+
+        # Then
+        assert charm.state.unit_broker.cluster_domain == DEFAULT_CLUSTER_DOMAIN
 
 
 def test_default_replication_properties_less_than_three(ctx: Context, base_state: State) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,6 +5,7 @@
 import dataclasses
 import json
 import logging
+import socket
 from typing import cast
 from unittest.mock import PropertyMock, mock_open, patch
 
@@ -24,10 +25,17 @@ from common.single_kernel_kafka.core.literals import (
     REL_NAME,
     TLS_RELATION,
 )
-from common.single_kernel_kafka.managers.k8s import DEFAULT_CLUSTER_DOMAIN
 from ops import CharmMeta
 from ops.testing import Container, Context, Model, PeerRelation, Relation, Secret, State, Storage
-from tests.unit.helpers import ACTIONS, CONFIG, METADATA, MODEL_NAME, SUBSTRATE, KafkaCharm
+from tests.unit.helpers import (
+    ACTIONS,
+    CLUSTER_DOMAIN,
+    CONFIG,
+    METADATA,
+    MODEL_NAME,
+    SUBSTRATE,
+    KafkaCharm,
+)
 
 pytestmark = pytest.mark.broker
 
@@ -54,14 +62,6 @@ def base_state():
         state = State(leader=True, model=Model(name=MODEL_NAME))
 
     return state
-
-
-def client_host(host: str) -> str:
-    """Return the address a client is advertised, given the internal one."""
-    if SUBSTRATE == "vm":
-        return host
-
-    return f"{host}.{MODEL_NAME}.svc.cluster.local"
 
 
 @pytest.fixture()
@@ -151,7 +151,7 @@ def test_listeners_in_server_properties(charm_configuration: dict, base_state: S
     """Checks that listeners are split into INTERNAL, CLIENT and EXTERNAL."""
     # Given
     charm_configuration["options"]["expose-external"]["default"] = "nodeport"
-    cluster_peer = PeerRelation(PEER, PEER, local_unit_data={"private-address": "treebeard"})
+    cluster_peer = PeerRelation(PEER, PEER, local_unit_data={"private-address": "treebeard", "cluster-domain": CLUSTER_DOMAIN})
     client_relation = Relation(REL_NAME, "app")
     state_in = dataclasses.replace(base_state, relations=[cluster_peer, client_relation])
     ctx = Context(
@@ -159,6 +159,7 @@ def test_listeners_in_server_properties(charm_configuration: dict, base_state: S
     )
 
     host = "treebeard" if SUBSTRATE == "vm" else "kafka-k8s-0.kafka-k8s-endpoints"
+    client_host = host if SUBSTRATE == "vm" else f"{host}.{MODEL_NAME}.svc.{CLUSTER_DOMAIN}"
     sasl_pm = "SASL_PLAINTEXT_SCRAM_SHA_512"
     ssl_pm = "SASL_SSL_SCRAM_SHA_512"
 
@@ -168,7 +169,7 @@ def test_listeners_in_server_properties(charm_configuration: dict, base_state: S
     ]
     expected_advertised_listeners = [
         f"INTERNAL_{ssl_pm}://{host}:19093",
-        f"CLIENT_{sasl_pm}://{client_host(host)}:9092",
+        f"CLIENT_{sasl_pm}://{client_host}:9092",
     ]
     if SUBSTRATE == "k8s":
         expected_listeners += [f"EXTERNAL_{sasl_pm}://0.0.0.0:29092"]
@@ -317,7 +318,7 @@ def test_extra_listeners_in_server_properties(charm_configuration: dict, base_st
 def test_oauth_client_listeners_in_server_properties(ctx: Context, base_state: State) -> None:
     """Checks that oauth client listeners are properly set when a relating through oauth."""
     # Given
-    cluster_peer = PeerRelation(PEER, PEER, local_unit_data={"private-address": "treebeard"})
+    cluster_peer = PeerRelation(PEER, PEER, local_unit_data={"private-address": "treebeard", "cluster-domain": CLUSTER_DOMAIN})
     oauth_relation = Relation(
         OAUTH_REL_NAME,
         "hydra",
@@ -340,6 +341,7 @@ def test_oauth_client_listeners_in_server_properties(ctx: Context, base_state: S
     )
 
     host = "treebeard" if SUBSTRATE == "vm" else "kafka-k8s-0.kafka-k8s-endpoints"
+    client_host = host if SUBSTRATE == "vm" else f"{host}.{MODEL_NAME}.svc.{CLUSTER_DOMAIN}"
     internal_protocol, internal_port = "INTERNAL_SASL_SSL_SCRAM_SHA_512", "19093"
     scram_client_protocol, scram_client_port = "CLIENT_SASL_PLAINTEXT_SCRAM_SHA_512", "9092"
     oauth_client_protocol, oauth_client_port = "CLIENT_SASL_PLAINTEXT_OAUTHBEARER", "9095"
@@ -351,8 +353,8 @@ def test_oauth_client_listeners_in_server_properties(ctx: Context, base_state: S
     )
     expected_advertised_listeners = (
         f"advertised.listeners={internal_protocol}://{host}:{internal_port},"
-        f"{scram_client_protocol}://{client_host(host)}:{scram_client_port},"
-        f"{oauth_client_protocol}://{client_host(host)}:{oauth_client_port}"
+        f"{scram_client_protocol}://{client_host}:{scram_client_port},"
+        f"{oauth_client_protocol}://{client_host}:{oauth_client_port}"
     )
 
     # When
@@ -371,7 +373,11 @@ def test_ssl_listeners_in_server_properties(ctx: Context, base_state: State, pat
     cluster_peer = PeerRelation(
         PEER,
         PEER,
-        local_unit_data={"private-address": "treebeard", "client-certificate": "keepitsecret"},
+        local_unit_data={
+            "private-address": "treebeard",
+            "client-certificate": "keepitsecret",
+            "cluster-domain": CLUSTER_DOMAIN,
+        },
     )
     # Simulate data-integrator relation
     client_relation = Relation(
@@ -388,13 +394,14 @@ def test_ssl_listeners_in_server_properties(ctx: Context, base_state: State, pat
     )
 
     host = "treebeard" if SUBSTRATE == "vm" else "kafka-k8s-0.kafka-k8s-endpoints"
+    client_host = host if SUBSTRATE == "vm" else f"{host}.{MODEL_NAME}.svc.{CLUSTER_DOMAIN}"
     sasl_pm = "SASL_SSL_SCRAM_SHA_512"
     ssl_pm = "SSL_SSL"
     expected_listeners = f"listeners=INTERNAL_{sasl_pm}://0.0.0.0:19093,CLIENT_{sasl_pm}://0.0.0.0:9093,CLIENT_{ssl_pm}://0.0.0.0:9094"
     expected_advertised_listeners = (
         f"advertised.listeners=INTERNAL_{sasl_pm}://{host}:19093,"
-        f"CLIENT_{sasl_pm}://{client_host(host)}:9093,"
-        f"CLIENT_{ssl_pm}://{client_host(host)}:9094"
+        f"CLIENT_{sasl_pm}://{client_host}:9093,"
+        f"CLIENT_{ssl_pm}://{client_host}:9094"
     )
 
     # When
@@ -518,8 +525,18 @@ def test_bootstrap_server(ctx: Context, base_state: State) -> None:
     cluster_peer = PeerRelation(
         PEER,
         PEER,
-        local_unit_data={"private-address": "treebeard", f"ip-{client_rel.id}": "draebeert"},
-        peers_data={1: {"private-address": "shelob", f"ip-{client_rel.id}": "bolehs"}},
+        local_unit_data={
+            "private-address": "treebeard",
+            f"ip-{client_rel.id}": "draebeert",
+            "cluster-domain": CLUSTER_DOMAIN,
+        },
+        peers_data={
+            1: {
+                "private-address": "shelob",
+                f"ip-{client_rel.id}": "bolehs",
+                "cluster-domain": CLUSTER_DOMAIN,
+            }
+        },
     )
     state_in = dataclasses.replace(base_state, relations=[cluster_peer, client_rel])
 
@@ -539,8 +556,8 @@ def test_bootstrap_server(ctx: Context, base_state: State) -> None:
             }
         else:
             assert set(bootstrap_servers_client.split(",")) == {
-                f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.cluster.local:9092",
-                f"kafka-k8s-1.kafka-k8s-endpoints.{MODEL_NAME}.svc.cluster.local:9092",
+                f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.{CLUSTER_DOMAIN}:9092",
+                f"kafka-k8s-1.kafka-k8s-endpoints.{MODEL_NAME}.svc.{CLUSTER_DOMAIN}:9092",
             }
             assert set(bootstrap_servers_internal.split(",")) == {
                 "kafka-k8s-0.kafka-k8s-endpoints:19093",
@@ -553,7 +570,7 @@ def test_client_addresses_are_fully_qualified(ctx: Context, base_state: State) -
     """Client-facing addresses must resolve from outside the charm's namespace."""
     # Given
     client_rel = Relation(REL_NAME)
-    cluster_peer = PeerRelation(PEER, PEER, local_unit_data={"cluster-domain": "k8s.example"})
+    cluster_peer = PeerRelation(PEER, PEER, local_unit_data={"cluster-domain": CLUSTER_DOMAIN})
     state_in = dataclasses.replace(base_state, relations=[cluster_peer, client_rel])
 
     # When
@@ -563,17 +580,59 @@ def test_client_addresses_are_fully_qualified(ctx: Context, base_state: State) -
         # Then
         assert (
             charm.state.bootstrap_server_client(client_rel)
-            == f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.k8s.example:9092"
+            == f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.{CLUSTER_DOMAIN}:9092"
         ), "the cached cluster domain is used, rather than being resolved on every hook"
         assert (
             charm.state.unit_broker.internal_address == "kafka-k8s-0.kafka-k8s-endpoints"
         ), "inter-broker traffic never leaves the namespace, so it keeps the short name"
 
-        # When
+
+@pytest.mark.skipif(SUBSTRATE == "vm", reason="Kubernetes DNS resolution only")
+def test_cluster_domain_prefers_addrinfo_then_falls_back_to_getfqdn(
+    ctx: Context, base_state: State
+) -> None:
+    """The cached cluster-domain is resolved via `getaddrinfo`, falling back to `getfqdn`."""
+    # Given
+    addrinfo_domain = "addrinfo.shire"
+    getfqdn_domain = "getfqdn.shire"
+    addrinfo_result = [
+        (
+            socket.AF_INET6,
+            socket.SOCK_STREAM,
+            6,
+            f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.{addrinfo_domain}",
+            ("10.1.90.155", 0),
+        )
+    ]
+    getfqdn_return = f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.{getfqdn_domain}"
+
+    # When
+    cluster_peer = PeerRelation(PEER, PEER)
+    state_in = dataclasses.replace(base_state, relations=[cluster_peer])
+    with (
+        patch("socket.getaddrinfo", return_value=addrinfo_result),
+        patch("socket.getfqdn", return_value=getfqdn_return),
+        ctx(ctx.on.config_changed(), state_in) as manager,
+    ):
+        charm = cast(KafkaCharm, manager.charm)
         charm.state.unit_broker.update_cluster_domain()
 
         # Then
-        assert charm.state.unit_broker.cluster_domain == DEFAULT_CLUSTER_DOMAIN
+        assert charm.state.unit_broker.cluster_domain == addrinfo_domain
+
+    # When
+    cluster_peer = PeerRelation(PEER, PEER)
+    state_in = dataclasses.replace(base_state, relations=[cluster_peer])
+    with (
+        patch("socket.getaddrinfo", side_effect=socket.gaierror),
+        patch("socket.getfqdn", return_value=getfqdn_return),
+        ctx(ctx.on.config_changed(), state_in) as manager,
+    ):
+        charm = cast(KafkaCharm, manager.charm)
+        charm.state.unit_broker.update_cluster_domain()
+
+        # Then
+        assert charm.state.unit_broker.cluster_domain == getfqdn_domain
 
 
 def test_default_replication_properties_less_than_three(ctx: Context, base_state: State) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,8 +25,8 @@ from common.single_kernel_kafka.core.literals import (
     TLS_RELATION,
 )
 from ops import CharmMeta
-from ops.testing import Container, Context, PeerRelation, Relation, Secret, State, Storage
-from tests.unit.helpers import ACTIONS, CONFIG, METADATA, SUBSTRATE, KafkaCharm
+from ops.testing import Container, Context, Model, PeerRelation, Relation, Secret, State, Storage
+from tests.unit.helpers import ACTIONS, CONFIG, METADATA, MODEL_NAME, SUBSTRATE, KafkaCharm
 
 pytestmark = pytest.mark.broker
 
@@ -43,12 +43,24 @@ def charm_configuration():
 @pytest.fixture()
 def base_state():
     if SUBSTRATE == "k8s":
-        state = State(leader=True, containers=[Container(name=CONTAINER, can_connect=True)])
+        state = State(
+            leader=True,
+            containers=[Container(name=CONTAINER, can_connect=True)],
+            model=Model(name=MODEL_NAME),
+        )
 
     else:
-        state = State(leader=True)
+        state = State(leader=True, model=Model(name=MODEL_NAME))
 
     return state
+
+
+def client_host(host: str) -> str:
+    """Return the address a client is advertised, given the internal one."""
+    if SUBSTRATE == "vm":
+        return host
+
+    return f"{host}.{MODEL_NAME}.svc.cluster.local"
 
 
 @pytest.fixture()
@@ -155,7 +167,7 @@ def test_listeners_in_server_properties(charm_configuration: dict, base_state: S
     ]
     expected_advertised_listeners = [
         f"INTERNAL_{ssl_pm}://{host}:19093",
-        f"CLIENT_{sasl_pm}://{host}:9092",
+        f"CLIENT_{sasl_pm}://{client_host(host)}:9092",
     ]
     if SUBSTRATE == "k8s":
         expected_listeners += [f"EXTERNAL_{sasl_pm}://0.0.0.0:29092"]
@@ -338,8 +350,8 @@ def test_oauth_client_listeners_in_server_properties(ctx: Context, base_state: S
     )
     expected_advertised_listeners = (
         f"advertised.listeners={internal_protocol}://{host}:{internal_port},"
-        f"{scram_client_protocol}://{host}:{scram_client_port},"
-        f"{oauth_client_protocol}://{host}:{oauth_client_port}"
+        f"{scram_client_protocol}://{client_host(host)}:{scram_client_port},"
+        f"{oauth_client_protocol}://{client_host(host)}:{oauth_client_port}"
     )
 
     # When
@@ -378,7 +390,11 @@ def test_ssl_listeners_in_server_properties(ctx: Context, base_state: State, pat
     sasl_pm = "SASL_SSL_SCRAM_SHA_512"
     ssl_pm = "SSL_SSL"
     expected_listeners = f"listeners=INTERNAL_{sasl_pm}://0.0.0.0:19093,CLIENT_{sasl_pm}://0.0.0.0:9093,CLIENT_{ssl_pm}://0.0.0.0:9094"
-    expected_advertised_listeners = f"advertised.listeners=INTERNAL_{sasl_pm}://{host}:19093,CLIENT_{sasl_pm}://{host}:9093,CLIENT_{ssl_pm}://{host}:9094"
+    expected_advertised_listeners = (
+        f"advertised.listeners=INTERNAL_{sasl_pm}://{host}:19093,"
+        f"CLIENT_{sasl_pm}://{client_host(host)}:9093,"
+        f"CLIENT_{ssl_pm}://{client_host(host)}:9094"
+    )
 
     # When
     with (
@@ -522,13 +538,35 @@ def test_bootstrap_server(ctx: Context, base_state: State) -> None:
             }
         else:
             assert set(bootstrap_servers_client.split(",")) == {
-                "kafka-k8s-0.kafka-k8s-endpoints:9092",
-                "kafka-k8s-1.kafka-k8s-endpoints:9092",
+                f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.cluster.local:9092",
+                f"kafka-k8s-1.kafka-k8s-endpoints.{MODEL_NAME}.svc.cluster.local:9092",
             }
             assert set(bootstrap_servers_internal.split(",")) == {
                 "kafka-k8s-0.kafka-k8s-endpoints:19093",
                 "kafka-k8s-1.kafka-k8s-endpoints:19093",
             }
+
+
+@pytest.mark.skipif(SUBSTRATE == "vm", reason="Kubernetes DNS resolution only")
+def test_client_addresses_are_fully_qualified(ctx: Context, base_state: State) -> None:
+    """Client-facing addresses must resolve from outside the charm's namespace."""
+    # Given
+    client_rel = Relation(REL_NAME)
+    cluster_peer = PeerRelation(PEER, PEER)
+    state_in = dataclasses.replace(base_state, relations=[cluster_peer, client_rel])
+
+    # When
+    with ctx(ctx.on.config_changed(), state_in) as manager:
+        charm = cast(KafkaCharm, manager.charm)
+
+        # Then
+        assert (
+            charm.state.bootstrap_server_client(client_rel)
+            == f"kafka-k8s-0.kafka-k8s-endpoints.{MODEL_NAME}.svc.cluster.local:9092"
+        )
+        assert (
+            charm.state.unit_broker.internal_address == "kafka-k8s-0.kafka-k8s-endpoints"
+        ), "inter-broker traffic never leaves the namespace, so it keeps the short name"
 
 
 def test_default_replication_properties_less_than_three(ctx: Context, base_state: State) -> None:

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -17,11 +17,13 @@ from common.single_kernel_kafka.core.literals import (
     PEER,
 )
 from ops import BoundEvent
-from ops.testing import Container, Context, PeerRelation, Secret, State
+from ops.testing import Container, Context, Model, PeerRelation, Secret, State
 from tests.unit.helpers import (
     ACTIONS,
+    CLUSTER_DOMAIN,
     CONFIG,
     METADATA,
+    MODEL_NAME,
     SUBSTRATE,
     KafkaCharm,
     generate_tls_artifacts,
@@ -43,7 +45,11 @@ def ca() -> CA:
 @pytest.fixture()
 def base_state():
     if SUBSTRATE == "k8s":
-        state = State(leader=True, containers=[Container(name=CONTAINER, can_connect=True)])
+        state = State(
+            leader=True,
+            containers=[Container(name=CONTAINER, can_connect=True)],
+            model=Model(name=MODEL_NAME),
+        )
 
     else:
         state = State(leader=True)
@@ -207,7 +213,7 @@ def test_sans(charm_configuration: dict, base_state: State, patched_node_ip, mon
     cluster_peer = PeerRelation(
         PEER,
         PEER,
-        local_unit_data={"private-address": "treebeard"},
+        local_unit_data={"private-address": "treebeard", "cluster-domain": CLUSTER_DOMAIN},
     )
     monkeypatch.setattr("single_kernel_kafka.workload.WorkloadMachine.ips", ["treebeard"])
     state_in = dataclasses.replace(base_state, relations=[cluster_peer])


### PR DESCRIPTION
Fixes https://github.com/canonical/kafka-operator/issues/560

On K8s the charm hands clients namespace-relative addresses (`<unit>.<app>-endpoints`). Those only resolve through the DNS search path of pods in the same namespace, so a client in any other namespace (e.g., one in a cross-model relation) fails at two separate points:

1. Bootstrap: Every entry in `bootstrap.servers` is unresolvable, so the client never connects at all:
```
org.apache.kafka.common.config.ConfigException:
 No resolvable bootstrap urls given in bootstrap.servers
```
2. After bootstrap:  Even the cluster metadata returns `advertised.listeners` in the short form:
```
Discovered group coordinator kafka-broker-1.kafka-broker-endpoints:9092
java.net.UnknownHostException: kafka-broker-1.kafka-broker-endpoints
```

The fix adds `KafkaBroker.client_address`, which produces the format `<unit>.<app>-endpoints.<namespace>.svc.<cluster-domain>` and uses it in the two client-facing places:
- `relation_ip_address()`: the `endpoints` field published on `kafka-client` relations
- `ConfigManager.client_listeners`: the CLIENT entries in `advertised.listeners`
