### PR TITLE
[MISC] Generate coverage XML report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 *.charm
 .tox/
 .coverage
+coverage.xml
 __pycache__/
 *.py[cod]
 .vscode

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,7 @@ commands =
     /bin/bash -c 'SUBSTRATE=k8s PYTHONPATH=k8s/src:k8s/lib:connect_k8s/lib poetry run coverage run --source=k8s/src --source=single_kernel_kafka \
         --append -m pytest -vv --tb native -s {posargs:{[vars]tests_path}/unit/}'
     poetry run coverage report
+    poetry run coverage xml
 
 [testenv:tutorial-extract]
 description = Generate tutorial test scripts from Markdown sources


### PR DESCRIPTION
TIOBE scan fails due to missing XML coverage report. Generate the report as part of the tox unit test job.
